### PR TITLE
make all.sh conditional to avoid it in cloud build

### DIFF
--- a/oss_fuzz_integration/build_patched_oss_fuzz.sh
+++ b/oss_fuzz_integration/build_patched_oss_fuzz.sh
@@ -35,5 +35,9 @@ rm -rf ./oss-fuzz/infra/base-images/base-builder/post-processing
 cp -rf ../llvm ./oss-fuzz/infra/base-images/base-clang/llvm
 cp -rf ../post-processing ./oss-fuzz/infra/base-images/base-builder/post-processing
 
-cd oss-fuzz
-./infra/base-images/all.sh
+# Skip all.sh if CLOUD_BUILD_ENV is set (it is in cloud build).
+if [[ -z ${CLOUD_BUILD_ENV:+dummy} ]]; then
+  echo 'running all.sh'
+  cd oss-fuzz
+  ./infra/base-images/all.sh
+fi


### PR DESCRIPTION
We need this to differentiate local vs cloud build. When making the cloud build, the local variable CLOUD_BUILD_ENV is set so all.sh is skipped.
As I tested this should work and not break the local build.

cc @oliverchang 