### PR TITLE
fix cases where reached functions are not logged in all_functions

### DIFF
--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -260,6 +260,8 @@ class MergedProjectProfile:
             incoming_references = list()
 
             for reached_func_name in fp_obj.functions_reached:
+                if reached_func_name not in self.all_functions:
+                    continue
                 reached_func_obj = self.all_functions[reached_func_name]
                 reached_func_obj.incoming_references.append(fp_obj.function_name)
                 total_cyclomatic_complexity += reached_func_obj.cyclomatic_complexity


### PR DESCRIPTION
There are cases that we get dict key error for all_functions. Like followings:
[log-36f90ef8-9855-4166-b357-d66b9f56defb.txt](https://github.com/ossf/fuzz-introspector/files/8028561/log-36f90ef8-9855-4166-b357-d66b9f56defb.txt)
[log-886dfa32-0367-4daf-bd5d-2b21cf69445d.txt](https://github.com/ossf/fuzz-introspector/files/8028563/log-886dfa32-0367-4daf-bd5d-2b21cf69445d.txt)

