### PR TITLE
Prefix all profile log files

### DIFF
--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -336,8 +336,12 @@ std::string FuzzIntrospector::getNextLogFile() {
   std::string TargetLogName;
   std::string RandomStr = GenRandom(10);
   int Idx = 0;
+  std::string prefix = "";
+  if (getenv("SRC")) {
+    prefix = std::string(getenv("SRC")) + "/";
+  }
   do {
-    TargetLogName = formatv("fuzzerLogFile-{0}-{1}.data", std::to_string(Idx++), RandomStr);
+    TargetLogName = formatv("{0}fuzzerLogFile-{1}-{2}.data", prefix, std::to_string(Idx++), RandomStr);
   } while (llvm::sys::fs::exists(TargetLogName));
 
   // Add a UID to the logname. The reason we do this is when fuzzers are compiled in different

--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -337,8 +337,8 @@ std::string FuzzIntrospector::getNextLogFile() {
   std::string RandomStr = GenRandom(10);
   int Idx = 0;
   std::string prefix = "";
-  if (getenv("SRC")) {
-    prefix = std::string(getenv("SRC")) + "/";
+  if (getenv("FUZZINTRO_OUTDIR")) {
+    prefix = std::string(getenv("FUZZINTRO_OUTDIR")) + "/";
   }
   do {
     TargetLogName = formatv("{0}fuzzerLogFile-{1}-{2}.data", prefix, std::to_string(Idx++), RandomStr);


### PR DESCRIPTION
Fuzzer can be compiled in different directories. We have to make sure the profiles are created in a pre-determined location to let compile script be able to find and use them.

Fixes issues like [this](https://github.com/ossf/fuzz-introspector/issues/43#issuecomment-1051258838) 