### PR TITLE
demangle the new fuzzer name before adding to list

### DIFF
--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -465,9 +465,7 @@ def add_func_to_reached_and_clone(merged_profile_old: MergedProjectProfile,
         f = merged_profile.all_functions[func_name]
         f.hitcount += 1
 
-        # This seems incorrect? reached_by_fuzzers is fuzzer names not function names?
-        # TODO: investigate further
-        f.reached_by_fuzzers.append(func_to_add.function_name)
+        f.reached_by_fuzzers.append(fuzz_utils.demangle_cpp_func(func_to_add.function_name))
 
     # Recompute all analysis that is based on hitcounts in all functions as hitcount has
     # changed for elements in the dictionary.


### PR DESCRIPTION
Needed this to have the name of the suggested fuzz target demangle.

P.S: I've seen your comment @DavidKorczynski, this is correct behavior as this function is only called by [analysis_synthesize_simple_targets](https://github.com/ossf/fuzz-introspector/blob/5bc9bc1d0e80d01a7675f2a99e96b2eb8da57bc8/post-processing/fuzz_analysis.py#L380) on each suggested fuzz target. So, it is  essentially collecting reached_by_fuzzers including the suggested fuzzers.