### PR TITLE
Fit colormap in html body

### DIFF
--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -510,7 +510,7 @@ fuzzer. This should change in the future to be per-fuzzer-basis.</p>"""
     image_name = "%s_colormap.png"%(fuzzer_filename.replace(" ", "").split("/")[-1])
 
     create_horisontal_calltree_image(image_name, profile)
-    html_string += "<img src=\"%s\">"%(image_name)
+    html_string += "<img class=\"colormap\" src=\"%s\">"%(image_name)
 
     # Fuzz blocker table
     html_string += html_add_header_with_link(

--- a/post-processing/styling/styles.css
+++ b/post-processing/styling/styles.css
@@ -340,3 +340,6 @@ input[type="checkbox"] {
     background: #eaffd4;
     color: #3b7300;
 }
+.colormap {
+	width: 100%;
+}


### PR DESCRIPTION
The colormap would not fit inside the html body and would be wider than it. This fits it inside the body so that you don't have to scroll to view it.