### PR TITLE
post-process: fix calltree issues

### DIFF
--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -71,6 +71,8 @@ def overlay_calltree_with_coverage(
         # Add to callstack
         callstack_set_curr_node(node, demangled_name, callstack)
 
+        logger.info(f"Checking callsite: { demangled_name}")
+
         # Get hitcount for this node
         node_hitcount: int = 0
         if is_first:
@@ -94,11 +96,14 @@ def overlay_calltree_with_coverage(
             is_first = False
         elif callstack_has_parent(node, callstack):
             # Find the parent function and check coverage of the node
+            logger.info("Extracting data")
             coverage_data = profile.get_function_coverage(
                 fuzz_utils.normalise_str(
                     callstack_get_parent(node, callstack)),
-                True)
+                    True
+                )
             for (n_line_number, hit_count_cov) in coverage_data:
+                logger.info(f"  - iterating {n_line_number} : {hit_count_cov}")
                 if n_line_number == node.src_linenumber and hit_count_cov > 0:
                     node_hitcount = hit_count_cov
             node.cov_parent = callstack_get_parent(node, callstack)

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -98,10 +98,9 @@ def overlay_calltree_with_coverage(
             # Find the parent function and check coverage of the node
             logger.info("Extracting data")
             coverage_data = profile.get_function_coverage(
-                fuzz_utils.normalise_str(
-                    callstack_get_parent(node, callstack)),
-                    True
-                )
+                fuzz_utils.normalise_str(callstack_get_parent(node, callstack)),
+                True
+            )
             for (n_line_number, hit_count_cov) in coverage_data:
                 logger.info(f"  - iterating {n_line_number} : {hit_count_cov}")
                 if n_line_number == node.src_linenumber and hit_count_cov > 0:

--- a/post-processing/fuzz_cfg_load.py
+++ b/post-processing/fuzz_cfg_load.py
@@ -159,4 +159,5 @@ def data_file_read_calltree(filename: str) -> Optional[CalltreeCallsite]:
         ctcs_root = ctcs_root.parent_calltree_callsite
         if ctcs_root is None:
             return None
+    print_ctcs_tree(ctcs_root)
     return ctcs_root

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -100,6 +100,7 @@ def llvm_cov_load(target_dir, target_name=None):
                     continue
 
                 line = line.replace("\n", "")
+                logger.info("cov-readline: %s"%(line))
 
                 # Parse lines that signal function names. These linse indicate that the
                 # lines following this line will be the specific source code lines of
@@ -148,6 +149,7 @@ def llvm_cov_load(target_dir, target_name=None):
                     except Exception:
                         hit_times = 0
                     # Add source code line and hitcount to coverage map of current function
+                    logger.info(f"reading coverage: {fname} -- {curr_func} -- {line_number} -- {hit_times}")
                     cp.covmap[curr_func].append((line_number, hit_times))
     return cp
 

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -100,7 +100,7 @@ def llvm_cov_load(target_dir, target_name=None):
                     continue
 
                 line = line.replace("\n", "")
-                logger.info("cov-readline: %s"%(line))
+                logger.info(f"cov-readline: { line }")
 
                 # Parse lines that signal function names. These linse indicate that the
                 # lines following this line will be the specific source code lines of
@@ -149,7 +149,8 @@ def llvm_cov_load(target_dir, target_name=None):
                     except Exception:
                         hit_times = 0
                     # Add source code line and hitcount to coverage map of current function
-                    logger.info(f"reading coverage: {fname} -- {curr_func} -- {line_number} -- {hit_times}")
+                    logger.info(f"reading coverage: {fname} -- {curr_func} "
+                                f"-- {line_number} -- {hit_times}")
                     cp.covmap[curr_func].append((line_number, hit_times))
     return cp
 

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -183,7 +183,7 @@ class FuzzerProfile:
         """
         Get the tuples reflecting coverage map of a given function
         """
-        logger.info("getting function coverage of %s"%(function_name))
+        logger.info(f"getting function coverage of { function_name }")
         if self.coverage is None:
             logger.info("Returning None")
             return []
@@ -196,7 +196,9 @@ class FuzzerProfile:
         # should_normalise
         logger.info("Should normalise")
         for funcname in self.coverage.covmap:
-            normalised_funcname = fuzz_utils.normalise_str(fuzz_utils.demangle_cpp_func(fuzz_utils.normalise_str(funcname)))
+            normalised_funcname = fuzz_utils.normalise_str(
+                fuzz_utils.demangle_cpp_func(fuzz_utils.normalise_str(funcname))
+            )
             if normalised_funcname == function_name:
                 logger.info(f"Found normalised: {normalised_funcname}")
                 return self.coverage.covmap[funcname]

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -183,16 +183,22 @@ class FuzzerProfile:
         """
         Get the tuples reflecting coverage map of a given function
         """
+        logger.info("getting function coverage of %s"%(function_name))
         if self.coverage is None:
+            logger.info("Returning None")
             return []
         if not should_normalise:
+            logger.info("Should not normalise")
             if function_name not in self.coverage.covmap:
                 return []
             return self.coverage.covmap[function_name]
+
         # should_normalise
+        logger.info("Should normalise")
         for funcname in self.coverage.covmap:
-            normalised_funcname = fuzz_utils.demangle_cpp_func(fuzz_utils.normalise_str(funcname))
+            normalised_funcname = fuzz_utils.normalise_str(fuzz_utils.demangle_cpp_func(fuzz_utils.normalise_str(funcname)))
             if normalised_funcname == function_name:
+                logger.info(f"Found normalised: {normalised_funcname}")
                 return self.coverage.covmap[funcname]
 
         # In case of errs return empty list


### PR DESCRIPTION
The function names extracted from the node destination and the coverage
profile were not the same. The problem was one was normalised and the
other was not, which resulted in one having whitespace and the other
not. This fixes it.

Ref: https://github.com/ossf/fuzz-introspector/issues/74