### PR TITLE
oss-fuzz: make patch a bit more permanent

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -1,5 +1,5 @@
 diff --git a/infra/base-images/base-builder/Dockerfile b/infra/base-images/base-builder/Dockerfile
-index c76bd011..76acdfe3 100644
+index afaf860e..9cc474df 100644
 --- a/infra/base-images/base-builder/Dockerfile
 +++ b/infra/base-images/base-builder/Dockerfile
 @@ -162,5 +162,7 @@ COPY cargo compile compile_afl compile_dataflow compile_libfuzzer compile_honggf
@@ -24,23 +24,14 @@ index 372e89a8..be760cc3 100755
    cp -rf $SRC/inspector $OUT/inspector
  fi
 diff --git a/infra/base-images/base-clang/Dockerfile b/infra/base-images/base-clang/Dockerfile
-index d44166df..8b49ad04 100644
+index 46a9ac77..d7d6dd8c 100644
 --- a/infra/base-images/base-clang/Dockerfile
 +++ b/infra/base-images/base-clang/Dockerfile
-@@ -33,11 +33,13 @@ RUN apt-get update && apt-get install -y wget sudo && \
-     SUDO_FORCE_REMOVE=yes apt-get remove --purge -y wget sudo && \
-     rm -rf /usr/local/doc/cmake /usr/local/bin/cmake-gui
- 
--RUN apt-get update && apt-get install -y git && \
--    git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
--    cd fuzz-introspector && \
--    git checkout 00d5be0a8a0671be7dfbf06eb5e65ce90afffac0 && \
--    apt-get remove --purge -y git
-+#RUN apt-get update && apt-get install -y git && \
-+#    git clone https://github.com/ossf/fuzz-introspector.git fuzz-introspector && \
-+#    cd fuzz-introspector && \
-+#    git checkout 00d5be0a8a0671be7dfbf06eb5e65ce90afffac0 && \
-+#    apt-get remove --purge -y git
+@@ -38,6 +38,9 @@ RUN apt-get update && apt-get install -y git && \
+     cd fuzz-introspector && \
+     git checkout 9f02f35b0b104f4ceb4da2fe34e97e6cc646c4f7 && \
+     apt-get remove --purge -y git
++RUN rm -rf /fuzz-introspector
 +COPY fuzz-introspector fuzz-introspector
 +
  


### PR DESCRIPTION
Instead of changing the existing Dockerfile to not download
fuzz-introspector, simply remove the downloaded version. This enables us
to avoid updating the checkout commit each time oss-fuzz is bumped.