### PR TITLE
Use per-target coverage report in fuzzer details

### DIFF
--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -766,6 +766,14 @@ def create_calltree(
     write_wrapped_html_file(calltree_html_string, calltree_html_file, blocker_idxs)
     return calltree_html_file
 
+def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
+    """
+    This function changes overall coverage URL to per-target coverage URL. Like:
+        https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports/<report-date>/linux
+        to
+        https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports-by-target/<report-date>/<target-name>/linux
+    """
+    return coverage_url.replace("reports", "reports-by-target").replace("linux", f"{target_name}/linux")
 
 def create_fuzzer_detailed_section(
         profile: fuzz_data_loader.FuzzerProfile,
@@ -773,7 +781,7 @@ def create_fuzzer_detailed_section(
         tables: List[str],
         curr_tt_profile: int,
         project_profile: fuzz_data_loader.MergedProjectProfile,
-        coverage_url: str,
+        target_coverage_url: str,
         git_repo_url: str,
         basefolder: str,
         conclusions, extract_conclusion) -> str:
@@ -810,7 +818,7 @@ def create_fuzzer_detailed_section(
     calltree_file_name = create_calltree(
         profile,
         project_profile,
-        coverage_url,
+        target_coverage_url,
         git_repo_url,
         basefolder,
         image_name,
@@ -823,7 +831,7 @@ def create_fuzzer_detailed_section(
     # Fuzz blocker table
     html_fuzz_blocker_table = create_fuzz_blocker_table(profile,
                                                         project_profile,
-                                                        coverage_url,
+                                                        target_coverage_url,
                                                         git_repo_url,
                                                         basefolder,
                                                         image_name,
@@ -1250,13 +1258,15 @@ def create_html_report(
     html_report_core += "<div class=\"report-box\">"
     html_report_core += html_add_header_with_link("Fuzzer details", 1, toc_list)
     for profile_idx in range(len(profiles)):
+        target_name = profiles[profile_idx].fuzzer_source_file
+        target_coverage_url = get_target_coverage_url(coverage_url, target_name)
         html_report_core += create_fuzzer_detailed_section(
             profiles[profile_idx],
             toc_list,
             tables,
             profile_idx,
             project_profile,
-            coverage_url,
+            target_coverage_url,
             git_repo_url,
             basefolder,
             conclusions,

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -766,6 +766,7 @@ def create_calltree(
     write_wrapped_html_file(calltree_html_string, calltree_html_file, blocker_idxs)
     return calltree_html_file
 
+
 def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
     """
     This function changes overall coverage URL to per-target coverage URL. Like:
@@ -773,7 +774,9 @@ def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
         to
         https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports-by-target/<report-date>/<target-name>/linux
     """
-    return coverage_url.replace("reports", "reports-by-target").replace("linux", f"{target_name}/linux")
+    return coverage_url.replace("reports", "reports-by-target").replace("linux",
+                                                                        f"{target_name}/linux")
+
 
 def create_fuzzer_detailed_section(
         profile: fuzz_data_loader.FuzzerProfile,

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -1264,7 +1264,7 @@ def create_html_report(
         if os.environ.get('FUZZ_INTROSPECTOR'):
             target_name = profiles[profile_idx].fuzzer_source_file
             target_coverage_url = get_target_coverage_url(coverage_url, target_name)
-        else: # This is temporary for local runs.
+        else:  # This is temporary for local runs.
             target_coverage_url = coverage_url
         html_report_core += create_fuzzer_detailed_section(
             profiles[profile_idx],

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -1261,8 +1261,11 @@ def create_html_report(
     html_report_core += "<div class=\"report-box\">"
     html_report_core += html_add_header_with_link("Fuzzer details", 1, toc_list)
     for profile_idx in range(len(profiles)):
-        target_name = profiles[profile_idx].fuzzer_source_file
-        target_coverage_url = get_target_coverage_url(coverage_url, target_name)
+        if os.environ.get('FUZZ_INTROSPECTOR'):
+            target_name = profiles[profile_idx].fuzzer_source_file
+            target_coverage_url = get_target_coverage_url(coverage_url, target_name)
+        else: # This is temporary for local runs.
+            target_coverage_url = coverage_url
         html_report_core += create_fuzzer_detailed_section(
             profiles[profile_idx],
             toc_list,


### PR DESCRIPTION
With coverage reports by target produced on OSS-Fuzz side, we can use it in "Fuzzer details" section.
It makes sense for the project overview report to link to overall coverage, so I did not change it.