### PR TITLE
Using per-target coverage url in calltree

### DIFF
--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -62,6 +62,11 @@ def overlay_calltree_with_coverage(
     ct_idx = 0
     if profile.function_call_depths is None:
         return
+
+    target_name = profile.get_key()
+    target_coverage_url = fuzz_utils.get_target_coverage_url(coverage_url, target_name)
+    logger.info(f"Using coverage url: {target_coverage_url}")
+
     for node in fuzz_cfg_load.extract_all_callsites(profile.function_call_depths):
         node.cov_ct_idx = ct_idx
         ct_idx += 1
@@ -130,7 +135,7 @@ def overlay_calltree_with_coverage(
         link = "#"
         for fd_k, fd in profile.all_class_functions.items():
             if fd.function_name == node.dst_function_name:
-                link = coverage_url + \
+                link = target_coverage_url + \
                     "%s.html#L%d" % (
                         fd.function_source_file, fd.function_linenumber)
                 break
@@ -142,7 +147,7 @@ def overlay_calltree_with_coverage(
             parent_fname = callstack_get_parent(node, callstack)
             for fd_k, fd in profile.all_class_functions.items():
                 if fuzz_utils.demangle_cpp_func(fd.function_name) == parent_fname:
-                    callsite_link = coverage_url + "%s.html#L%d" % (
+                    callsite_link = target_coverage_url + "%s.html#L%d" % (
                         fd.function_source_file,   # parent source file
                         node.src_linenumber)       # callsite line number
         node.cov_callsite_link = callsite_link

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -774,17 +774,6 @@ def create_calltree(
     return calltree_html_file
 
 
-def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
-    """
-    This function changes overall coverage URL to per-target coverage URL. Like:
-        https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports/<report-date>/linux
-        to
-        https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports-by-target/<report-date>/<target-name>/linux
-    """
-    return coverage_url.replace("reports", "reports-by-target").replace("linux",
-                                                                        f"{target_name}/linux")
-
-
 def create_fuzzer_detailed_section(
         profile: fuzz_data_loader.FuzzerProfile,
         toc_list: List[Tuple[str, str, int]],
@@ -1269,11 +1258,9 @@ def create_html_report(
     html_report_core += "<div class=\"report-box\">"
     html_report_core += html_add_header_with_link("Fuzzer details", 1, toc_list)
     for profile_idx in range(len(profiles)):
-        if os.environ.get('FUZZ_INTROSPECTOR'):
-            target_name = profiles[profile_idx].fuzzer_source_file
-            target_coverage_url = get_target_coverage_url(coverage_url, target_name)
-        else:  # This is temporary for local runs.
-            target_coverage_url = coverage_url
+        target_name = profiles[profile_idx].get_key()
+        target_coverage_url = fuzz_utils.get_target_coverage_url(coverage_url, target_name)
+        logger.info(f"Using coverage url: {target_coverage_url}")
         html_report_core += create_fuzzer_detailed_section(
             profiles[profile_idx],
             toc_list,

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -127,3 +127,17 @@ def scan_executables_for_fuzz_introspector_logs(exec_dir: str):
                             'fuzzer_log_file': found_str
                         })
     return executable_to_fuzz_reports
+
+
+def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
+    """
+    This function changes overall coverage URL to per-target coverage URL. Like:
+        https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports/<report-date>/linux
+        to
+        https://storage.googleapis.com/oss-fuzz-coverage/<project>/reports-by-target/<report-date>/<target-name>/linux
+    """
+    if os.environ.get('FUZZ_INTROSPECTOR'):
+        return coverage_url.replace("reports", "reports-by-target").replace("linux",
+                                                                            f"{target_name}/linux")
+    else:  # (TODO) This is temporary for local runs.
+        return coverage_url


### PR DESCRIPTION
#160 was incomplete. This one does the actual job of setting call-site urls using per-coverage url.