### PR TITLE
oss-fuzz: sync patch: remove git_repo_url usage

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -18,8 +18,8 @@ index 372e89a8..be760cc3 100755
    
    cd $SRC/inspector
    python3 /fuzz-introspector/post-processing/main.py correlate --binaries_dir=$OUT/
--  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --git_repo_url=$GIT_REPO --coverage_url=$COVERAGE_URL --correlation_file=exe_to_fuzz_introspector_logs.yaml
-+  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --git_repo_url=$GIT_REPO --correlation_file=exe_to_fuzz_introspector_logs.yaml
+-  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --coverage_url=$COVERAGE_URL --correlation_file=exe_to_fuzz_introspector_logs.yaml
++  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --correlation_file=exe_to_fuzz_introspector_logs.yaml
  
    cp -rf $SRC/inspector $OUT/inspector
  fi


### PR DESCRIPTION
This is no longer used by OSS-Fuzz as fuzz-introspector removed it
Ref: https://github.com/google/oss-fuzz/pull/7497