### PR TITLE
oss-fuzz: remove patch for coverage_url

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -10,19 +10,6 @@ index afaf860e..9cc474df 100644
 +COPY post-processing /fuzz-introspector/post-processing
  
  CMD ["compile"]
-diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
-index 372e89a8..be760cc3 100755
---- a/infra/base-images/base-builder/compile
-+++ b/infra/base-images/base-builder/compile
-@@ -217,7 +217,7 @@ if [ "$SANITIZER" = "introspector" ]; then
-   
-   cd $SRC/inspector
-   python3 /fuzz-introspector/post-processing/main.py correlate --binaries_dir=$OUT/
--  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --coverage_url=$COVERAGE_URL --correlation_file=exe_to_fuzz_introspector_logs.yaml
-+  python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector --correlation_file=exe_to_fuzz_introspector_logs.yaml
- 
-   cp -rf $SRC/inspector $OUT/inspector
- fi
 diff --git a/infra/base-images/base-clang/Dockerfile b/infra/base-images/base-clang/Dockerfile
 index fec65ab1..dfe7826e 100644
 --- a/infra/base-images/base-clang/Dockerfile


### PR DESCRIPTION
This is now upstreamed.

Ref: https://github.com/google/oss-fuzz/pull/7502