### PR TITLE
reduce logging across project

### DIFF
--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -256,14 +256,14 @@ void FuzzIntrospector::readConfig() {
   std::string configPath = getenv("FUZZ_INTROSPECTOR_CONFIG");
   ifstream configFile(configPath);
 
-  logPrintf(2, "Opening the configuration file %s\n", configPath.c_str());
+  logPrintf(L1, "Opening the configuration file %s\n", configPath.c_str());
 
   std::string line;
   std::vector<string> *current = &ConfigFuncsToAvoid;
   bool shouldAnalyse = false;
   while (std::getline(configFile, line)) {
     if (shouldAnalyse) {
-      logPrintf(2, "Inserting avoidance element %s\n", line.c_str());
+      logPrintf(L2, "Inserting avoidance element %s\n", line.c_str());
       current->push_back(line);
     }
     if (line.find("FUNCS_TO_AVOID") != std::string::npos) {
@@ -278,7 +278,7 @@ void FuzzIntrospector::readConfig() {
 }
 
 void FuzzIntrospector::makeDefaultConfig() {
-  logPrintf(2, "Using default configuration\n");
+  logPrintf(L2, "Using default configuration\n");
 
   std::vector<std::string> FuncsToAvoid = {
     "^_ZNSt3",                       // mangled std::
@@ -370,16 +370,16 @@ void FuzzIntrospector::extractAllFunctionDetailsToYaml(std::string nextYamlName,
 FuzzerFunctionList FuzzIntrospector::wrapAllFunctions(Module &M) {
   FuzzerFunctionList ListWrapper;
   ListWrapper.ListName = "All functions";
-  logPrintf(1, "Wrapping all functions\n");
+  logPrintf(L1, "Wrapping all functions\n");
   for (auto &F : M) {
-    logPrintf(2, "Wrapping function %s\n", F.getName().str().c_str());
+    logPrintf(L3, "Wrapping function %s\n", F.getName().str().c_str());
     if (shouldAvoidFunction(&F)) {
-      logPrintf(2, "Skipping this function\n");
+      logPrintf(L3, "Skipping this function\n");
       continue;
     }
     ListWrapper.Functions.push_back(wrapFunction(&F));
   }
-  logPrintf(2, "Ended wrapping all functions\n");
+  logPrintf(L1, "Ended wrapping all functions\n");
 
   return ListWrapper;
 }
@@ -674,7 +674,7 @@ Function *FuzzIntrospector::extractVTableIndirectCall(Function *F, Instruction &
   StructType *SSM = cast<StructType>(v13);
   // Now we remove the "class." from the name, and then we have it.
   std::string originalTargetClass = SSM->getName().str().substr(6);
-  logPrintf(L1, "Shortened name that we can use for analysis: %s\n", originalTargetClass.c_str());
+  logPrintf(L3, "Shortened name that we can use for analysis: %s\n", originalTargetClass.c_str());
 
   // We find the global variable corresponding to the vtable by
   // way of naming convetions. Specifically, we look for the
@@ -715,7 +715,7 @@ Function *FuzzIntrospector::extractVTableIndirectCall(Function *F, Instruction &
   // Extract the function pointer corresponding to the constant expression.
   Function *VTableTargetFunc = value2Func(FunctionPtrConstant);
   if (VTableTargetFunc != nullptr) {
-    logPrintf(L1, "The actual function name (from earlyCaught) %s\n", VTableTargetFunc->getName().str().c_str());
+    logPrintf(L3, "The actual function name (from earlyCaught) %s\n", VTableTargetFunc->getName().str().c_str());
   }
   return VTableTargetFunc;
 }

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -30,6 +30,7 @@ import fuzz_cfg_load
 import fuzz_data_loader
 
 logger = logging.getLogger(name=__name__)
+logger.setLevel(logging.INFO)
 
 TargetCodesType = TypedDict('TargetCodesType', {
     'source_code': str,
@@ -75,7 +76,7 @@ def overlay_calltree_with_coverage(
         # Add to callstack
         callstack_set_curr_node(node, demangled_name, callstack)
 
-        logger.info(f"Checking callsite: { demangled_name}")
+        logger.debug(f"Checking callsite: { demangled_name}")
 
         # Get hitcount for this node
         node_hitcount: int = 0
@@ -100,13 +101,13 @@ def overlay_calltree_with_coverage(
             is_first = False
         elif callstack_has_parent(node, callstack):
             # Find the parent function and check coverage of the node
-            logger.info("Extracting data")
+            logger.debug("Extracting data")
             coverage_data = profile.get_function_coverage(
                 fuzz_utils.normalise_str(callstack_get_parent(node, callstack)),
                 True
             )
             for (n_line_number, hit_count_cov) in coverage_data:
-                logger.info(f"  - iterating {n_line_number} : {hit_count_cov}")
+                logger.debug(f"  - iterating {n_line_number} : {hit_count_cov}")
                 if n_line_number == node.src_linenumber and hit_count_cov > 0:
                     node_hitcount = hit_count_cov
             node.cov_parent = callstack_get_parent(node, callstack)

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -31,6 +31,7 @@ import fuzz_cov_load
 import fuzz_utils
 
 logger = logging.getLogger(name=__name__)
+logger.setLevel(logging.INFO)
 
 
 class FunctionProfile:
@@ -188,19 +189,19 @@ class FuzzerProfile:
             logger.info("Returning None")
             return []
         if not should_normalise:
-            logger.info("Should not normalise")
+            logger.debug("Should not normalise")
             if function_name not in self.coverage.covmap:
                 return []
             return self.coverage.covmap[function_name]
 
         # should_normalise
-        logger.info("Should normalise")
+        logger.debug("Should normalise")
         for funcname in self.coverage.covmap:
             normalised_funcname = fuzz_utils.normalise_str(
                 fuzz_utils.demangle_cpp_func(fuzz_utils.normalise_str(funcname))
             )
             if normalised_funcname == function_name:
-                logger.info(f"Found normalised: {normalised_funcname}")
+                logger.debug(f"Found normalised: {normalised_funcname}")
                 return self.coverage.covmap[funcname]
 
         # In case of errs return empty list


### PR DESCRIPTION
Several OSS-Fuzz build logs are of many gigabytes (10+), much of which
is only useful for debugging. This silences many of these by default.