### PR TITLE
post-process: fix coverage function correlation

### DIFF
--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -113,6 +113,7 @@ def llvm_cov_load(target_dir, target_name=None):
                         curr_func = line.split(":")[1].replace(" ", "").replace(":", "")
                     else:
                         curr_func = line.replace(" ", "").replace(":", "")
+                    curr_func = fuzz_utils.demangle_cpp_func(curr_func)
                     cp.covmap[curr_func] = list()
 
                     # Normalise the function name and add it to functions_hit.
@@ -122,10 +123,10 @@ def llvm_cov_load(target_dir, target_name=None):
                     fname = line
                     if ".cpp" in fname:
                         fname = fname.split(".cpp")[-1].replace(":", "")
-                        fname = fuzz_utils.demangle_cpp_func(fname)
                     elif ".c" in fname:
                         fname = fname.split(".c")[-1].replace(":", "")
                     fname = fname.replace(":", "")
+                    fname = fuzz_utils.demangle_cpp_func(fname)
                     cp.functions_hit.add(fname)
 
                 # Parse lines that signal specific line of code. These lines only
@@ -157,6 +158,7 @@ def llvm_cov_load(target_dir, target_name=None):
 
 
 if __name__ == "__main__":
+    logging.basicConfig()
     logger.info("Starting coverage loader")
     cp = llvm_cov_load(".")
     logger.info("Functions hit:")

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -773,6 +773,14 @@ def create_fuzzer_detailed_section(
             (total_func_lines,
              hit_lines,
              hit_percentage) = profile.get_cov_metrics(fuzz_utils.demangle_cpp_func(funcname))
+
+            # This is a bit hacky, but in case of failure above we try again without
+            # demangling the function name, which may help.
+            if hit_percentage is None:
+                (total_func_lines,
+                 hit_lines,
+                 hit_percentage) = profile.get_cov_metrics(funcname)
+
             if hit_percentage is not None:
                 total_hit_functions += 1
                 fuzzer_table_data[table_name].append({


### PR DESCRIPTION
The logic around this should be improved. We should have a single key
for function reference rather than how it currently is. When do we/do we
not demangle?

Fixes: https://github.com/ossf/fuzz-introspector/issues/218