### PR TITLE
engine-input: write to file

### DIFF
--- a/post-processing/analyses/fuzz_engine_input.py
+++ b/post-processing/analyses/fuzz_engine_input.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Analysis for creating input consumed by a fuzzer, e.g. a dictionary"""
 
+import json
 import logging
+import os
 
 from typing import (
     List,
@@ -144,7 +146,7 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
             logger.info("Could not find focus function")
             return ""
 
-        fuzz_utils.add_to_json_file(
+        self.add_to_json_file(
             fuzz_constants.ENGINE_INPUT_FILE,
             profile.get_key(),
             "focus-function",
@@ -158,3 +160,27 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
             f"</code></pre><br>"
         )
         return html_string
+
+    def add_to_json_file(
+	    json_file_path: str,
+	    fuzzer_name: str,
+	    key: str,
+	    val: str):
+	# Create file if it does not exist
+	if not os.path.isfile(json_file_path):
+	    json_data = dict()
+	else:
+	    json_fd = open(json_file_path)
+	    json_data = json.load(json_fd)
+	    json_fd.close()
+	if 'fuzzers' not in json_data:
+	    json_data['fuzzers'] = dict()
+
+	if fuzzer_name not in json_data['fuzzers']:
+	    json_data['fuzzers'][fuzzer_name] = dict()
+
+	json_data['fuzzers'][fuzzer_name][key] = val
+
+	with open(json_file_path, 'w') as json_file:
+	    json.dump(json_data, json_file)
+

--- a/post-processing/analyses/fuzz_engine_input.py
+++ b/post-processing/analyses/fuzz_engine_input.py
@@ -21,8 +21,11 @@ from typing import (
 )
 
 import fuzz_analysis
+import fuzz_constants
 import fuzz_data_loader
 import fuzz_html_helpers
+import fuzz_utils
+
 from analyses import fuzz_calltree_analysis
 
 logger = logging.getLogger(name=__name__)
@@ -121,10 +124,26 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
             logger.info("Found no fuzz blockers and thus no focus function")
             return ""
 
+        # Only succeed if we can get the name of the function in which the
+        # fuzz blocker callsite resides.
+        if fuzz_blocker[0].src_function_name != None:
+            fuzzer_focus_function = fuzz_blocker[0].src_function_name
+            logger.info(f"Found focus function: {fuzzer_focus_function}")
+        else:
+            logger.info("Could not find focus function")
+            return ""
+
+        fuzz_utils.add_to_json_file(
+            fuzz_constants.ENGINE_INPUT_FILE,
+            profile.get_key(),
+            "focus-function",
+            fuzzer_focus_function
+        )
+
         html_string += (
             f"<p>Use this as input to libfuzzer with flag: -focus_function name </p>"
             f"<pre><code class='language-clike'>"
-            f"-focus_function={fuzz_blocker[0].dst_function_name}"
+            f"-focus_function={fuzzer_focus_function}"
             f"</code></pre><br>"
         )
         return html_string

--- a/post-processing/analyses/fuzz_engine_input.py
+++ b/post-processing/analyses/fuzz_engine_input.py
@@ -162,25 +162,24 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
         return html_string
 
     def add_to_json_file(
-	    json_file_path: str,
-	    fuzzer_name: str,
-	    key: str,
-	    val: str):
-	# Create file if it does not exist
-	if not os.path.isfile(json_file_path):
-	    json_data = dict()
-	else:
-	    json_fd = open(json_file_path)
-	    json_data = json.load(json_fd)
-	    json_fd.close()
-	if 'fuzzers' not in json_data:
-	    json_data['fuzzers'] = dict()
+            json_file_path: str,
+            fuzzer_name: str,
+            key: str,
+            val: str):
+        # Create file if it does not exist
+        if not os.path.isfile(json_file_path):
+            json_data = dict()
+        else:
+            json_fd = open(json_file_path)
+            json_data = json.load(json_fd)
+            json_fd.close()
+        if 'fuzzers' not in json_data:
+            json_data['fuzzers'] = dict()
 
-	if fuzzer_name not in json_data['fuzzers']:
-	    json_data['fuzzers'][fuzzer_name] = dict()
+        if fuzzer_name not in json_data['fuzzers']:
+            json_data['fuzzers'][fuzzer_name] = dict()
 
-	json_data['fuzzers'][fuzzer_name][key] = val
+        json_data['fuzzers'][fuzzer_name][key] = val
 
-	with open(json_file_path, 'w') as json_file:
-	    json.dump(json_data, json_file)
-
+        with open(json_file_path, 'w') as json_file:
+            json.dump(json_data, json_file)

--- a/post-processing/analyses/fuzz_engine_input.py
+++ b/post-processing/analyses/fuzz_engine_input.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(name=__name__)
 class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
     def __init__(self):
         self.name = "FuzzEngineInputAnalysis"
+        self.display_html = False
 
     def analysis_func(self,
                       toc_list: List[Tuple[str, str, int]],
@@ -45,10 +46,17 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
                       conclusions) -> str:
         logger.info(f" - Running analysis {self.name}")
 
+        if not self.display_html:
+            tables = []
+            toc_list = []
+
         html_string = ""
         html_string += "<div class=\"report-box\">"
         html_string += fuzz_html_helpers.html_add_header_with_link(
-            "Fuzz engine guidance", 1, toc_list)
+            "Fuzz engine guidance",
+            1,
+            toc_list
+        )
         html_string += "<p>This sections provides heuristics that can be used as input " \
                        "to a fuzz engine when running a given fuzz target. The current " \
                        "focus is on providing input that is usable by libFuzzer.</p>"
@@ -56,9 +64,10 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
         for profile_idx in range(len(profiles)):
             logger.info(f"Generating input for {profiles[profile_idx].get_key()}")
             html_string += fuzz_html_helpers.html_add_header_with_link(
-                "%s" % (profiles[profile_idx].fuzzer_source_file),
+                profiles[profile_idx].fuzzer_source_file,
                 2,
-                toc_list)
+                toc_list
+            )
 
             # Create dictionary section
             html_string += self.get_dictionary_section(
@@ -76,6 +85,9 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
         html_string += "</div>"  # report-box
 
         logger.info(f" - Completed analysis {self.name}")
+        if not self.display_html:
+            html_string = ""
+
         return html_string
 
     def get_dictionary(self, profile):

--- a/post-processing/analyses/fuzz_engine_input.py
+++ b/post-processing/analyses/fuzz_engine_input.py
@@ -47,7 +47,6 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
         logger.info(f" - Running analysis {self.name}")
 
         if not self.display_html:
-            tables = []
             toc_list = []
 
         html_string = ""
@@ -138,7 +137,7 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
 
         # Only succeed if we can get the name of the function in which the
         # fuzz blocker callsite resides.
-        if fuzz_blocker[0].src_function_name != None:
+        if fuzz_blocker[0].src_function_name is not None:
             fuzzer_focus_function = fuzz_blocker[0].src_function_name
             logger.info(f"Found focus function: {fuzzer_focus_function}")
         else:

--- a/post-processing/analyses/fuzz_engine_input.py
+++ b/post-processing/analyses/fuzz_engine_input.py
@@ -26,7 +26,6 @@ import fuzz_analysis
 import fuzz_constants
 import fuzz_data_loader
 import fuzz_html_helpers
-import fuzz_utils
 
 from analyses import fuzz_calltree_analysis
 
@@ -162,6 +161,7 @@ class FuzzEngineInputAnalysis(fuzz_analysis.AnalysisInterface):
         return html_string
 
     def add_to_json_file(
+            self,
             json_file_path: str,
             fuzzer_name: str,
             key: str,

--- a/post-processing/fuzz_cfg_load.py
+++ b/post-processing/fuzz_cfg_load.py
@@ -142,6 +142,7 @@ def data_file_read_calltree(filename: str) -> Optional[CalltreeCallsite]:
                 # Add the node to the current parent
                 if curr_depth != -1 and curr_ctcs_node is not None:
                     ctcs.parent_calltree_callsite = curr_ctcs_node
+                    ctcs.src_function_name = ctcs.parent_calltree_callsite.dst_function_name
                     curr_ctcs_node.children.append(ctcs)
                 curr_depth = depth
 

--- a/post-processing/fuzz_constants.py
+++ b/post-processing/fuzz_constants.py
@@ -14,3 +14,5 @@
 
 GIT_REPO = "https://github.com/ossf/fuzz-introspector"
 GIT_BRANCH_URL = f"{GIT_REPO}/tree/main/"
+
+ENGINE_INPUT_FILE = "fuzz-introspector-engine-input.json"

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """ Utility functions """
 
+import json
 import logging
 import cxxfilt
 import os
@@ -127,6 +128,31 @@ def scan_executables_for_fuzz_introspector_logs(exec_dir: str):
                             'fuzzer_log_file': found_str
                         })
     return executable_to_fuzz_reports
+
+
+def add_to_json_file(
+    json_file_path: str,
+    fuzzer_name: str,
+    key: str,
+    val: str):
+
+    # Create file if it does not exist
+    if not os.path.isfile(json_file_path):
+        json_data = dict()
+    else:
+        json_fd = open(json_file_path)
+        json_data = json.load(json_fd)
+        json_fd.close()
+    if 'fuzzers' not in json_data:
+        json_data['fuzzers'] = dict()
+
+    if fuzzer_name not in json_data['fuzzers']:
+        json_data['fuzzers'][fuzzer_name] = dict()
+
+    json_data['fuzzers'][fuzzer_name][key] = val
+
+    with open(json_file_path, 'w') as json_file:
+        json.dump(json_data, json_file)
 
 
 def get_target_coverage_url(coverage_url: str, target_name: str) -> str:

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """ Utility functions """
 
-import logging
 import cxxfilt
+import logging
+import os
 import re
 
 from typing import (

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -16,6 +16,7 @@
 import logging
 import cxxfilt
 import re
+
 from typing import (
     Any,
     List,

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -131,11 +131,11 @@ def scan_executables_for_fuzz_introspector_logs(exec_dir: str):
 
 
 def add_to_json_file(
-    json_file_path: str,
-    fuzzer_name: str,
-    key: str,
-    val: str):
-
+        json_file_path: str,
+        fuzzer_name: str,
+        key: str,
+        val: str
+        ):
     # Create file if it does not exist
     if not os.path.isfile(json_file_path):
         json_data = dict()

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 """ Utility functions """
 
-import json
 import logging
 import cxxfilt
-import os
 import re
 from typing import (
     Any,
@@ -128,30 +126,6 @@ def scan_executables_for_fuzz_introspector_logs(exec_dir: str):
                             'fuzzer_log_file': found_str
                         })
     return executable_to_fuzz_reports
-
-
-def add_to_json_file(
-        json_file_path: str,
-        fuzzer_name: str,
-        key: str,
-        val: str):
-    # Create file if it does not exist
-    if not os.path.isfile(json_file_path):
-        json_data = dict()
-    else:
-        json_fd = open(json_file_path)
-        json_data = json.load(json_fd)
-        json_fd.close()
-    if 'fuzzers' not in json_data:
-        json_data['fuzzers'] = dict()
-
-    if fuzzer_name not in json_data['fuzzers']:
-        json_data['fuzzers'][fuzzer_name] = dict()
-
-    json_data['fuzzers'][fuzzer_name][key] = val
-
-    with open(json_file_path, 'w') as json_file:
-        json.dump(json_data, json_file)
 
 
 def get_target_coverage_url(coverage_url: str, target_name: str) -> str:

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -134,8 +134,7 @@ def add_to_json_file(
         json_file_path: str,
         fuzzer_name: str,
         key: str,
-        val: str
-        ):
+        val: str):
     # Create file if it does not exist
     if not os.path.isfile(json_file_path):
         json_data = dict()

--- a/post-processing/main.py
+++ b/post-processing/main.py
@@ -112,6 +112,7 @@ def parse_cmdline():
         default=[
             "OptimalTargets",
             "RuntimeCoverageAnalysis",
+            "FuzzEngineInputAnalysis",
         ],
         help="Analyses to run. Available options: OptimalTargets, FuzzEngineInput"
     )


### PR DESCRIPTION
Ref: https://github.com/ossf/fuzz-introspector/pull/237

Adds it so the fuzz_engine_input analysis runs without generating any HTML for the HTML report, but instead creates a file called `fuzz-introspector-engine-input.json` with data for the fuzzers.

A few points:
- the file `fuzz-introspector-engine-input.json` is not guaranteed to be there
- it is not guaranteed that there is an entry for each fuzzer in the `fuzzers` section
- c++ function names are mangled (I assume this is what libfuzzer needs)

Besides this, the json file is super simple and intuitive:
htslib:
```
{
    "fuzzers": {
        "hts_open_fuzzer": {
            "focus-function": "view_sam"
        }
    }
}
```

libdwarf:
```
{
    "fuzzers": {
        "fuzz_init_path": {
            "focus-function": "dwarf_object_init_b"
        },
        "fuzz_init_binary": {
            "focus-function": "dwarfstring_destructor"
        }
    }
}
```

jsoncpp:
```
{
    "fuzzers": {
        "jsoncpp_fuzzer": {
            "focus-function": "_ZN4Json5Value13nullSingletonEv"
        },
        "jsoncpp_proto_fuzzer": {
            "focus-function": "_ZN10json_proto12JsonParseAPIC2Ev"
        }
    }
}
```

elfutils:
```
{
    "fuzzers": {
        "fuzz-libdwfl": {
            "focus-function": "find_debuginfo"
        },
        "fuzz-libelf": {
            "focus-function": "pread_retry"
        },
        "fuzz-dwfl-core": {
            "focus-function": "find_elf_build_id"
        }
    }
}
```