### PR TITLE
post-process: dont normalise coverage function

### DIFF
--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -133,7 +133,7 @@ def overlay_calltree_with_coverage(
             # Find the parent function and check coverage of the node
             logger.debug("Extracting data")
             coverage_data = profile.coverage.get_hit_details(
-                fuzz_utils.normalise_str(callstack_get_parent(node, callstack))
+                callstack_get_parent(node, callstack)
             )
             for (n_line_number, hit_count_cov) in coverage_data:
                 logger.debug(f"  - iterating {n_line_number} : {hit_count_cov}")

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -62,6 +62,8 @@ class CoverageProfile:
             fuzz_key = funcname
         elif fuzz_utils.demangle_cpp_func(funcname) in self.covmap:
             fuzz_key = fuzz_utils.demangle_cpp_func(funcname)
+        elif fuzz_utils.normalise_str(funcname) in self.covmap:
+            fuzz_key = fuzz_utils.normalise_str(funcname)
 
         if fuzz_key is None or fuzz_key not in self.covmap:
             return []


### PR DESCRIPTION
Function names are not normalised when put in the coverage map. They are
in fact demangled.

Fixes: https://github.com/ossf/fuzz-introspector/issues/249