### PR TITLE
oss-fuzz: add proper testing set up

### DIFF
--- a/oss_fuzz_integration/README.md
+++ b/oss_fuzz_integration/README.md
@@ -48,7 +48,10 @@ You can now navigate to `http://localhost:8008/fuzz_report.html`
 # Testing before bumping OSS-Fuzz
 To prevent and catch regressions we use a testing framework that verifies
 the results of running fuzz-introspector on various OSS-Fuzz integrations.
-The framework catches build issues and logic issues in the results.
+
+The framework is designed to catch regressions of the form:
+- Build issues that may be introduced, i.e. projects that are expected to succeed no longer succeeds.
+- Logical regressions, focusing on if results are as expected.
 
 The testing framework has some hard-coded boundary checks on the data
 for a given project. It has to be boundaries rather than fixed values

--- a/oss_fuzz_integration/README.md
+++ b/oss_fuzz_integration/README.md
@@ -44,3 +44,31 @@ Serving the report on http://127.0.0.1:8008/linux/index.html
 Serving HTTP on 0.0.0.0 port 8008 (http://0.0.0.0:8008/) ...
 ```
 You can now navigate to `http://localhost:8008/fuzz_report.html`
+
+# Testing before bumping OSS-Fuzz
+To prevent and catch regressions we use a testing framework that verifies
+the results of running fuzz-introspector on various OSS-Fuzz integrations.
+The framework catches build issues and logic issues in the results.
+
+The testing framework has some hard-coded boundary checks on the data
+for a given project. It has to be boundaries rather than fixed values
+since the data may change from run to run depending on the fuzzing
+results.
+
+To run the test suite, please perform the following steps from this
+directory:
+
+```
+# Clean up any installation you may have
+sudo docker system prune -a
+
+# Rebuild images using local set up
+./build_patched_oss_fuzz.sh
+
+# Test fuzz-introspector against various projects
+cd oss-fuzz
+../test_projects.sh
+```
+
+If the above steps end with the string "Successfully finished testing projects."
+being printed, then the tests passed!

--- a/oss_fuzz_integration/project-checker.py
+++ b/oss_fuzz_integration/project-checker.py
@@ -54,10 +54,48 @@ def check_project_htslib(summary_dict):
     # Success
     return
 
+
+def check_project_jsoncpp(summary_dict):
+    """Checks summary dict against htslib details"""
+    fuzzer_list = []
+    for k in summary_dict:
+        if k != "MergedProjectProfile":
+            fuzzer_list.append(k)
+    if len(fuzzer_list) != 2:
+        guide_exit("jsoncpp fuzzer count is wrong")
+    if summary_dict['jsoncpp_fuzzer']['coverage-blocker-stats']['cov-reach-proportion'] < 50.0:
+        guide_exit("coverage reach proportion seems off.")
+    if summary_dict['jsoncpp_proto_fuzzer']['coverage-blocker-stats']['cov-reach-proportion'] < 50.0:
+        guide_exit("coverage reach proportion seems off.")
+
+    # Success
+    return
+
+
+def check_project_unrar(summary_dict):
+    """Checks summary dict against htslib details"""
+    fuzzer_list = []
+    for k in summary_dict:
+        if k != "MergedProjectProfile":
+            fuzzer_list.append(k)
+    if len(fuzzer_list) != 1:
+        guide_exit("unrar fuzzer count is wrong")
+    if summary_dict['unrar_fuzzer']['coverage-blocker-stats']['cov-reach-proportion'] < 10.0:
+        guide_exit("coverage reach proportion seems off.")
+    if summary_dict['unrar_fuzzer']['coverage-blocker-stats']['cov-reach-proportion'] > 80.0:
+        guide_exit("coverage reach proportion seems off.")
+    if summary_dict['unrar_fuzzer']['stats']['file-target-count'] < 40:
+        guide_exit("file target count seems off.")
+
+    # Success
+    return
+
 def check_specific_project(proj_name, build_log_file,coverage_log,summary_json):
     print(f"Checking {proj_name}")
     name_to_check_mapping = {
-        "htslib" : check_project_htslib
+        "htslib":  check_project_htslib,
+        "jsoncpp": check_project_jsoncpp,
+        "unrar":   check_project_unrar
     }
 
     if proj_name not in name_to_check_mapping:
@@ -118,3 +156,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     check_test_directory(args.test_directory)
+
+    print("Successfully finished testing projects.")

--- a/oss_fuzz_integration/project-checker.py
+++ b/oss_fuzz_integration/project-checker.py
@@ -1,0 +1,120 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import sys
+import argparse
+
+def err_exit(msg):
+    print(f"Error {msg}")
+    exit(0)
+
+def guide_exit(msg):
+    msg += (
+        "\n Check the data and determine if there is a bug in fuzz-introspecto "
+        "or the project changed. Please fix test data or fuzz-introspector accordingly."
+    )
+    err_exit(msg)
+
+# We write some checkers for each project. This is a bit hacky, but I think it
+# can quickly break if we make the data too tight.
+def check_project_htslib(summary_dict):
+    """Checks summary dict against htslib details"""
+    fuzzer_list = []
+    for k in summary_dict:
+        if k != "MergedProjectProfile":
+            fuzzer_list.append(k)
+    if len(fuzzer_list) != 1:
+        guide_exit("htslib fuzzer count is wrong")
+    if fuzzer_list[0] != "hts_open_fuzzer":
+        guide_exit("htslib fuzzer name is wrong")
+
+    # check stats
+    if summary_dict['hts_open_fuzzer']['stats']['total-basic-blocks'] < 25000:
+        guide_exit("htslib basic block count seems off.")
+    if (summary_dict['MergedProjectProfile']['stats']['unreached-complexity-percentage'] < 30.0 or
+        summary_dict['MergedProjectProfile']['stats']['unreached-complexity-percentage'] > 40.0):
+        guide_exit("htslib unreached complexity percentage seems off.")
+    if (summary_dict['hts_open_fuzzer']['coverage-blocker-stats']['cov-reach-proportion'] < 10.0 or
+        summary_dict['hts_open_fuzzer']['coverage-blocker-stats']['cov-reach-proportion'] > 20.0):
+        guide_exit("coverage reach proportion seems off.")
+
+    # Success
+    return
+
+def check_specific_project(proj_name, build_log_file,coverage_log,summary_json):
+    print(f"Checking {proj_name}")
+    name_to_check_mapping = {
+        "htslib" : check_project_htslib
+    }
+
+    if proj_name not in name_to_check_mapping:
+        print("Project cannot be checked. Moving on the next")
+        return
+
+    data = json.load(open(summary_json))
+    name_to_check_mapping[proj_name](data)
+    print("Check done")
+
+
+def check_project_dir(proj_dir):
+    print(f"Checking {proj_dir}")
+    build_log_file   = os.path.join(proj_dir, "build_introspector.log")
+    coverage_log     = os.path.join(proj_dir, "get_coverage.log")
+    summary_json     = os.path.join(proj_dir, "inspector-report", "summary.json")
+    proj_name_file   = os.path.join(proj_dir, "project_name")
+
+    if not os.path.isfile(build_log_file):
+        err_exit("No log file")
+    if not os.path.isfile(coverage_log):
+        err_exit("No coverage log")
+    if not os.path.isfile(summary_json):
+        err_exit("No summary file")
+    print(proj_name_file)
+    if not os.path.isfile(proj_name_file):
+        err_exit("No project name file")
+
+    with open(proj_name_file, "r") as pf:
+        proj_name = pf.read().replace("\n","")
+
+    # Check summary file
+    check_specific_project(
+        proj_name,
+        build_log_file,
+        coverage_log,
+        summary_json
+    )
+
+
+def check_test_directory(test_directory):
+    proj_dirs = []
+    if not os.path.isdir(test_directory):
+        err_exit("test directory does not exist")
+
+    for l in os.listdir(test_directory):
+        if "corpus-" in l and os.path.isdir(os.path.join(test_directory, l)):
+            proj_dirs.append(l)
+
+
+    for proj_dir in proj_dirs:
+        check_project_dir(os.path.join(test_directory, proj_dir))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-directory", required=True)
+
+    args = parser.parse_args()
+    check_test_directory(args.test_directory)

--- a/oss_fuzz_integration/test_projects.sh
+++ b/oss_fuzz_integration/test_projects.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -u
+#!/bin/bash -eux
 #
 # Copyright 2022 Fuzz Introspector Authors
 #
@@ -18,24 +18,47 @@
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-for fuzzname in htslib kamailio orbit wuffs croaring nettle; do
+# create next test report directory
+TEST_REPORT_NAME="test-report-"
+if [ $(ls | grep $TEST_REPORT_NAME | wc -l) -gt 0 ]; then
+  echo "once"
+  LATEST_TEST_DIR_NUM=$(ls | grep "$TEST_REPORT_NAME" | sed "s/$TEST_REPORT_NAME//" | sort -n | tail -1)
+
+else
+  LATEST_TEST_DIR_NUM=0
+  echo "twice"
+fi
+NEW_TEST_COUNT=$(($LATEST_TEST_DIR_NUM+1))
+NEW_TEST_DIR="$TEST_REPORT_NAME$NEW_TEST_COUNT"
+echo "NEW_TEST_DIR: $NEW_TEST_DIR"
+mkdir $NEW_TEST_DIR
+
+#exit 0
+
+
+for fuzzname in htslib unrar jsoncpp; do
   echo "Testing $fuzzname"
   python3 ${SCRIPT_DIR}/get_full_coverage.py $fuzzname 10 > get_coverage.log 2>&1
-  python3 ./infra/helper.py build_fuzzers --sanitizer=instrumentor $fuzzname  > build_introspector.log 2>&1
+  python3 ./infra/helper.py build_fuzzers --sanitizer=introspector $fuzzname  > build_introspector.log 2>&1
 
   LATEST_CORPUS_DIR=$(ls | grep "corpus-" | sed 's/corpus-//' | sort -n | tail -1)
 
-  cp -rf ./build/out/${fuzzname}/inspector-tmp/ ./corpus-$LATEST_CORPUS_DIR/inspector-report
+  cp -rf ./build/out/${fuzzname}/inspector/ ./corpus-$LATEST_CORPUS_DIR/inspector-report
   cp -rf ./corpus-$LATEST_CORPUS_DIR/report/ ./corpus-$LATEST_CORPUS_DIR/inspector-report/covreport
+  cp -rf ./corpus-$LATEST_CORPUS_DIR/report_target/* ./corpus-$LATEST_CORPUS_DIR/inspector-report/covreport/
 
   mv get_coverage.log ./corpus-$LATEST_CORPUS_DIR/get_coverage.log
   mv build_introspector.log ./corpus-$LATEST_CORPUS_DIR/build_introspector.log
+  echo "$fuzzname" >> ./corpus-$LATEST_CORPUS_DIR/project_name.txt
 
   # Look for the last logging statement of fuzz-introspector. If that statement is printed, then
   # it means no exceptions were thrown. This shows the build didn't crash.
-  if [ $(grep "Ending fuzz introspector post-processing" ./corpus-$LATEST_CORPUS_DIR/build_introspector.log | wc -l) = 1 ]; then
+  if [ $(grep "Ending fuzz introspector post-processing" ./corpus-$LATEST_CORPUS_DIR/build_introspector.log | wc -l) -gt 0 ]; then
     echo "Success"
   else
     echo "Failure"
   fi
+
+  # Now copy the data into the test directory
+  cp -rf ./corpus-$LATEST_CORPUS_DIR $NEW_TEST_DIR/
 done

--- a/oss_fuzz_integration/test_projects.sh
+++ b/oss_fuzz_integration/test_projects.sh
@@ -58,4 +58,4 @@ for fuzzname in htslib unrar jsoncpp; do
   cp -rf ./corpus-$LATEST_CORPUS_DIR $NEW_TEST_DIR/
 done
 
-python3 $SCRIPTS_DIR/project-checker.py --test-dir=$NEW_TEST_DIR/
+python3 $SCRIPT_DIR/project-checker.py --test-dir=$NEW_TEST_DIR/

--- a/oss_fuzz_integration/test_projects.sh
+++ b/oss_fuzz_integration/test_projects.sh
@@ -21,20 +21,15 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # create next test report directory
 TEST_REPORT_NAME="test-report-"
 if [ $(ls | grep $TEST_REPORT_NAME | wc -l) -gt 0 ]; then
-  echo "once"
   LATEST_TEST_DIR_NUM=$(ls | grep "$TEST_REPORT_NAME" | sed "s/$TEST_REPORT_NAME//" | sort -n | tail -1)
 
 else
   LATEST_TEST_DIR_NUM=0
-  echo "twice"
 fi
 NEW_TEST_COUNT=$(($LATEST_TEST_DIR_NUM+1))
 NEW_TEST_DIR="$TEST_REPORT_NAME$NEW_TEST_COUNT"
 echo "NEW_TEST_DIR: $NEW_TEST_DIR"
 mkdir $NEW_TEST_DIR
-
-#exit 0
-
 
 for fuzzname in htslib unrar jsoncpp; do
   echo "Testing $fuzzname"

--- a/oss_fuzz_integration/test_projects.sh
+++ b/oss_fuzz_integration/test_projects.sh
@@ -44,7 +44,7 @@ for fuzzname in htslib unrar jsoncpp; do
 
   mv get_coverage.log ./corpus-$LATEST_CORPUS_DIR/get_coverage.log
   mv build_introspector.log ./corpus-$LATEST_CORPUS_DIR/build_introspector.log
-  echo "$fuzzname" >> ./corpus-$LATEST_CORPUS_DIR/project_name.txt
+  echo "$fuzzname" >> ./corpus-$LATEST_CORPUS_DIR/project_name
 
   # Look for the last logging statement of fuzz-introspector. If that statement is printed, then
   # it means no exceptions were thrown. This shows the build didn't crash.

--- a/oss_fuzz_integration/test_projects.sh
+++ b/oss_fuzz_integration/test_projects.sh
@@ -57,3 +57,5 @@ for fuzzname in htslib unrar jsoncpp; do
   # Now copy the data into the test directory
   cp -rf ./corpus-$LATEST_CORPUS_DIR $NEW_TEST_DIR/
 done
+
+python3 $SCRIPTS_DIR/project-checker.py --test-dir=$NEW_TEST_DIR/

--- a/post-processing/fuzz_constants.py
+++ b/post-processing/fuzz_constants.py
@@ -16,4 +16,4 @@ GIT_REPO = "https://github.com/ossf/fuzz-introspector"
 GIT_BRANCH_URL = f"{GIT_REPO}/tree/main/"
 
 ENGINE_INPUT_FILE = "fuzz-introspector-engine-input.json"
-SUMMARY_FILE="summary.json"
+SUMMARY_FILE = "summary.json"

--- a/post-processing/fuzz_constants.py
+++ b/post-processing/fuzz_constants.py
@@ -16,3 +16,4 @@ GIT_REPO = "https://github.com/ossf/fuzz-introspector"
 GIT_BRANCH_URL = f"{GIT_REPO}/tree/main/"
 
 ENGINE_INPUT_FILE = "fuzz-introspector-engine-input.json"
+SUMMARY_FILE="summary.json"

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -256,6 +256,18 @@ class FuzzerProfile:
         except Exception:
             return None, None, None
 
+    def write_stats_to_summary_file(self):
+        file_target_count = len(self.file_targets) if self.file_targets is not None else 0
+        fuzz_utils.write_to_summary_file(
+            self.get_key(),
+            "stats",
+            { 
+                "total-basic-blocks" : self.total_basic_blocks,
+                "total-cyclomatic-complexity" : self.total_cyclomatic_complexity,
+                "file-target-count" : file_target_count,
+            }
+        )
+
 
 class MergedProjectProfile:
     """
@@ -436,6 +448,25 @@ class MergedProjectProfile:
             complexity_unreached,
             reached_complexity_percentage,
             unreached_complexity_percentage
+        )
+
+    def write_stats_to_summary_file(self):
+        (total_complexity,
+         complexity_reached,
+         complexity_unreached,
+         reached_complexity_percentage,
+         unreached_complexity_percentage) = self.get_complexity_summaries()
+
+        fuzz_utils.write_to_summary_file(
+            "MergedProjectProfile",
+            "stats",
+            { 
+                "total-complexity" : total_complexity,
+                "complexity-reached" : complexity_reached,
+                "complexity-unreached" : complexity_unreached,
+                "reached-complexity-percentage" : complexity_unreached,
+                "unreached-complexity-percentage": unreached_complexity_percentage
+            }
         )
 
     def set_basefolder(self) -> None:

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -262,9 +262,9 @@ class FuzzerProfile:
             self.get_key(),
             "stats",
             { 
-                "total-basic-blocks" : self.total_basic_blocks,
-                "total-cyclomatic-complexity" : self.total_cyclomatic_complexity,
-                "file-target-count" : file_target_count,
+                "total-basic-blocks": self.total_basic_blocks,
+                "total-cyclomatic-complexity": self.total_cyclomatic_complexity,
+                "file-target-count": file_target_count,
             }
         )
 
@@ -460,11 +460,11 @@ class MergedProjectProfile:
         fuzz_utils.write_to_summary_file(
             "MergedProjectProfile",
             "stats",
-            { 
-                "total-complexity" : total_complexity,
-                "complexity-reached" : complexity_reached,
-                "complexity-unreached" : complexity_unreached,
-                "reached-complexity-percentage" : complexity_unreached,
+            {
+                "total-complexity": total_complexity,
+                "complexity-reached": complexity_reached,
+                "complexity-unreached": complexity_unreached,
+                "reached-complexity-percentage": complexity_unreached,
                 "unreached-complexity-percentage": unreached_complexity_percentage
             }
         )

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -261,7 +261,7 @@ class FuzzerProfile:
         fuzz_utils.write_to_summary_file(
             self.get_key(),
             "stats",
-            { 
+            {
                 "total-basic-blocks": self.total_basic_blocks,
                 "total-cyclomatic-complexity": self.total_cyclomatic_complexity,
                 "file-target-count": file_target_count,

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -591,8 +591,8 @@ def create_fuzzer_detailed_section(
         profile.get_key(),
         "coverage-blocker-stats",
         {
-            "reachable-funcs" : reachable_funcs,
-            "reached-funcs" : reached_funcs,
+            "reachable-funcs": reachable_funcs,
+            "reached-funcs": reached_funcs,
             "cov-reach-proportion": cov_reach_proportion,
         }
     )

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -529,6 +529,8 @@ def create_fuzzer_detailed_section(
         )
         html_string += html_fuzz_blocker_table
 
+    profile.write_stats_to_summary_file()
+
     # Table with all functions hit by this fuzzer
     html_string += fuzz_html_helpers.html_add_header_with_link(
         "Runtime coverage analysis",
@@ -584,10 +586,18 @@ def create_fuzzer_detailed_section(
     reachable_funcs = len(profile.functions_reached_by_fuzzer)
     reached_funcs = reachable_funcs - uncovered_reachable_funcs
     cov_reach_proportion = (float(reached_funcs) / float(reachable_funcs)) * 100.0
-
+    str_percentage = "%.5s%%" % str(cov_reach_proportion)
+    fuzz_utils.write_to_summary_file(
+        profile.get_key(),
+        "coverage-blocker-stats",
+        {
+            "reachable-funcs" : reachable_funcs,
+            "reached-funcs" : reached_funcs,
+            "cov-reach-proportion": cov_reach_proportion,
+        }
+    )
     if extract_conclusion:
         if cov_reach_proportion < 30.0:
-            str_percentage = "%.5s%%" % str(cov_reach_proportion)
             conclusions.append((
                 2,
                 (f"Fuzzer { profile.get_key() } is blocked: runtime coverage only "
@@ -710,6 +720,7 @@ def create_html_report(
     # Start creation of core html
     html_body_start = '<div class="content-section">'
     html_overview = fuzz_html_helpers.html_add_header_with_link("Project overview", 1, toc_list)
+    project_profile.write_stats_to_summary_file()
 
     # Project overview
     # html_overview += fuzz_html_helpers.html_add_header_with_link(

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -152,7 +152,7 @@ def write_to_summary_file(fuzzer, key, value):
 
     with open(fuzz_constants.SUMMARY_FILE, 'w') as json_file:
         json.dump(json_data, json_file)
-        
+ 
 
 def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
     """

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -152,7 +152,7 @@ def write_to_summary_file(fuzzer, key, value):
 
     with open(fuzz_constants.SUMMARY_FILE, 'w') as json_file:
         json.dump(json_data, json_file)
- 
+
 
 def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
     """

--- a/post-processing/fuzz_utils.py
+++ b/post-processing/fuzz_utils.py
@@ -15,8 +15,10 @@
 
 import cxxfilt
 import logging
+import json
 import os
 import re
+import yaml
 
 from typing import (
     Any,
@@ -24,7 +26,8 @@ from typing import (
     Dict,
     Optional,
 )
-import yaml
+
+import fuzz_constants
 
 logger = logging.getLogger(name=__name__)
 
@@ -129,6 +132,27 @@ def scan_executables_for_fuzz_introspector_logs(exec_dir: str):
                         })
     return executable_to_fuzz_reports
 
+
+def write_to_summary_file(fuzzer, key, value):
+    """Writes a key value pair to summary file, for a given fuzzer
+    key. If the fuzzer does not exist as top key in the summary file
+    then it is created"""
+
+    if not os.path.isfile(fuzz_constants.SUMMARY_FILE):
+        json_data = dict()
+    else:
+        json_fd = open(fuzz_constants.SUMMARY_FILE)
+        json_data = json.load(json_fd)
+        json_fd.close()
+
+    if fuzzer not in json_data:
+        json_data[fuzzer] = dict()
+
+    json_data[fuzzer][key] = value
+
+    with open(fuzz_constants.SUMMARY_FILE, 'w') as json_file:
+        json.dump(json_data, json_file)
+        
 
 def get_target_coverage_url(coverage_url: str, target_name: str) -> str:
     """


### PR DESCRIPTION
Add testing set up for oss-fuzz that can automatically analyse
properties against a set of projects. This is achieved by making
fuzz-introspector write .json files with data about the run which is
then processed by the testing framework.

The testing framework has some hard-coded boundary checks on the data
for a given project. It has to be boundaries rather than fixed values
since the data may change from run to run depending on the fuzzing
results.

In order to make the check complete it needs to have hard-coded values
from a diverse set of projects, in particular both c and c++ projects.

Another benefit of this PR is that the output in json format can be consumed by other tools.

Ref: https://github.com/ossf/fuzz-introspector/issues/41