### PR TITLE
post-process: refactor, bug fix and enable return codes

### DIFF
--- a/post-processing/fuzz_cfg_load.py
+++ b/post-processing/fuzz_cfg_load.py
@@ -65,7 +65,7 @@ def extract_all_callsites_recursive(
 def extract_all_callsites(calltree: Optional[CalltreeCallsite]) -> List[CalltreeCallsite]:
     if calltree is None:
         logger.error("Trying to extract from a None calltree")
-        exit(0)
+        exit(1)
     cs_list: List[CalltreeCallsite] = []
     extract_all_callsites_recursive(calltree, cs_list)
     return cs_list

--- a/post-processing/fuzz_constants.py
+++ b/post-processing/fuzz_constants.py
@@ -18,5 +18,5 @@ GIT_BRANCH_URL = f"{GIT_REPO}/tree/main/"
 ENGINE_INPUT_FILE = "fuzz-introspector-engine-input.json"
 SUMMARY_FILE = "summary.json"
 
-APP_EXIT_ERROR=1
-APP_EXIT_SUCCESS=0
+APP_EXIT_ERROR = 1
+APP_EXIT_SUCCESS = 0

--- a/post-processing/fuzz_constants.py
+++ b/post-processing/fuzz_constants.py
@@ -17,3 +17,6 @@ GIT_BRANCH_URL = f"{GIT_REPO}/tree/main/"
 
 ENGINE_INPUT_FILE = "fuzz-introspector-engine-input.json"
 SUMMARY_FILE = "summary.json"
+
+APP_EXIT_ERROR=1
+APP_EXIT_SUCCESS=0

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -561,7 +561,7 @@ def add_func_to_reached_and_clone(merged_profile_old: MergedProjectProfile,
 
     if merged_profile.all_functions[func_to_add.function_name].hitcount == 0:
         logger.info("Error. Hitcount did not get set for some reason. Exiting")
-        exit(0)
+        exit(1)
 
     return merged_profile
 

--- a/post-processing/main.py
+++ b/post-processing/main.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import yaml
-import logging
 import argparse
+import logging
+import sys
+import yaml
+from typing import List
 
 import fuzz_analysis
+import fuzz_constants
 import fuzz_data_loader
 import fuzz_html
 import fuzz_utils
@@ -24,18 +27,21 @@ import fuzz_utils
 logger = logging.getLogger(name=__name__)
 
 
-def correlate_binaries_to_logs(binaries_dir):
-    pairings = fuzz_utils.scan_executables_for_fuzz_introspector_logs(args.binaries_dir)
+def correlate_binaries_to_logs(binaries_dir: str) -> None:
+    pairings = fuzz_utils.scan_executables_for_fuzz_introspector_logs(binaries_dir)
     logger.info(f"Pairings: {str(pairings)}")
     with open("exe_to_fuzz_introspector_logs.yaml", "w+") as etf:
         etf.write(yaml.dump({'pairings': pairings}))
+    return fuzz_constants.APP_EXIT_SUCCESS
 
 
-def run_analysis_on_dir(target_folder,
-                        coverage_url,
-                        analyses_to_run,
-                        correlation_file,
-                        enable_all_analyses):
+def run_analysis_on_dir(
+    target_folder: str,
+    coverage_url: str,
+    analyses_to_run: List[str],
+    correlation_file: str,
+    enable_all_analyses: bool
+) -> int:
     if enable_all_analyses:
         all_analyses = [
             "OptimalTargets",
@@ -51,7 +57,7 @@ def run_analysis_on_dir(target_folder,
     profiles = fuzz_data_loader.load_all_profiles(target_folder)
     if len(profiles) == 0:
         logger.info("Found no profiles. Exiting")
-        exit(0)
+        return fuzz_constants.APP_EXIT_ERROR
 
     logger.info("[+] Accummulating profiles")
     for profile in profiles:
@@ -78,34 +84,44 @@ def run_analysis_on_dir(target_folder,
             profile,
             project_profile,
             coverage_url,
-            project_profile.basefolder)
+            project_profile.basefolder
+        )
 
     logger.info(f"Analyses to run: {str(analyses_to_run)}")
 
     logger.info("[+] Creating HTML report")
-    fuzz_html.create_html_report(profiles,
-                                 project_profile,
-                                 analyses_to_run,
-                                 coverage_url,
-                                 project_profile.basefolder)
+    fuzz_html.create_html_report(
+        profiles,
+        project_profile,
+        analyses_to_run,
+        coverage_url,
+        project_profile.basefolder
+    )
+    return fuzz_constants.APP_EXIT_SUCCESS
 
 
-def parse_cmdline():
+def get_cmdline_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
 
     subparsers = parser.add_subparsers(dest='command')
 
-    # Report generation
+    # Report generation command
     report_parser = subparsers.add_parser(
-        'report', help='generate fuzz-introspector HTML report')
-    report_parser.add_argument("--target_dir",
-                               type=str,
-                               help="Directory where the data files are",
-                               required=True)
-    report_parser.add_argument('--coverage_url',
-                               type=str,
-                               help="URL with coverage information",
-                               default="/covreport/linux")
+        "report",
+        help="generate fuzz-introspector HTML report",
+    )
+    report_parser.add_argument(
+        "--target_dir",
+        type=str,
+        help="Directory where the data files are",
+        required=True
+    )
+    report_parser.add_argument(
+        "--coverage_url",
+        type=str,
+        help="URL with coverage information",
+        default="/covreport/linux"
+    )
     report_parser.add_argument(
         "--analyses",
         nargs="+",
@@ -122,34 +138,47 @@ def parse_cmdline():
         default=False,
         help="Enables all analyses"
     )
+    report_parser.add_argument(
+        "--correlation_file",
+        type=str,
+        default="",
+        help="File with correlation data"
+    )
 
-    report_parser.add_argument("--correlation_file",
-                               type=str,
-                               default="",
-                               help="File with correlation data")
-
-    # Correlate binary files to fuzzerLog files
+    # Command for correlating binary files to fuzzerLog files
     correlate_parser = subparsers.add_parser(
-        'correlate', help='correlate executable files to fuzzer introspector logs')
-    correlate_parser.add_argument("--binaries_dir",
-                                  type=str,
-                                  required=True,
-                                  help="Directory with binaries to scan for Fuzz introspector tags")
+        "correlate",
+        help="correlate executable files to fuzzer introspector logs"
+    )
+    correlate_parser.add_argument(
+        "--binaries_dir",
+        type=str,
+        required=True,
+        help="Directory with binaries to scan for Fuzz introspector tags"
+    )
 
+    return parser
+
+
+def main() -> int:
+    logger.info("Running fuzz introspector post-processing")
+    logging.basicConfig(level=logging.INFO)
+
+    parser = get_cmdline_parser()
     args = parser.parse_args()
-    return args
+    if args.command == 'report':
+        return_code = run_analysis_on_dir(
+            args.target_dir,
+            args.coverage_url,
+            args.analyses,
+            args.correlation_file,
+            args.enable_all_analyses
+        )
+    elif args.command == 'correlate':
+        return_code = correlate_binaries_to_logs(args.binaries_dir)
+    logger.info("Ending fuzz introspector post-processing")
+    sys.exit(return_code)
 
 
 if __name__ == "__main__":
-    logger.info("Running fuzz introspector post-processing")
-    logging.basicConfig(level=logging.INFO)
-    args = parse_cmdline()
-    if args.command == 'report':
-        run_analysis_on_dir(args.target_dir,
-                            args.coverage_url,
-                            args.analyses,
-                            args.correlation_file,
-                            args.enable_all_analyses)
-    elif args.command == 'correlate':
-        correlate_binaries_to_logs(args.binaries_dir)
-    logger.info("Ending fuzz introspector post-processing")
+    main()

--- a/post-processing/main.py
+++ b/post-processing/main.py
@@ -27,7 +27,7 @@ import fuzz_utils
 logger = logging.getLogger(name=__name__)
 
 
-def correlate_binaries_to_logs(binaries_dir: str) -> None:
+def correlate_binaries_to_logs(binaries_dir: str) -> int:
     pairings = fuzz_utils.scan_executables_for_fuzz_introspector_logs(binaries_dir)
     logger.info(f"Pairings: {str(pairings)}")
     with open("exe_to_fuzz_introspector_logs.yaml", "w+") as etf:


### PR DESCRIPTION
Refactoring: improving strong typing and style.

Bug fix in `correlate_binaries_to_logs` which uses an argument in
args.binaries_dir rather than the argument to the function. It only
works now because args is not wrapper in a function -- which this commit
changes.

Adds return codes as well. This is nice to have for fuzz-introspector to
communicate whether the process was successful or not.