### PR TITLE
post-process: Add ability to load data about bugs

### DIFF
--- a/post-processing/analyses/fuzz_bug_digestor.py
+++ b/post-processing/analyses/fuzz_bug_digestor.py
@@ -1,0 +1,89 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis for creating input consumed by a fuzzer, e.g. a dictionary"""
+
+import json
+import logging
+import os
+
+from typing import (
+    List,
+    Tuple,
+)
+
+import fuzz_analysis
+import fuzz_constants
+import fuzz_data_loader
+import fuzz_html_helpers
+import fuzz_utils
+
+from analyses import fuzz_calltree_analysis
+
+logger = logging.getLogger(name=__name__)
+
+
+class FuzzBugDigestorAnalysis(fuzz_analysis.AnalysisInterface):
+    def __init__(self):
+        self.name = "BugDigestorAnalysis"
+        self.display_html = False
+
+    def analysis_func(self,
+                      toc_list: List[Tuple[str, str, int]],
+                      tables: List[str],
+                      project_profile: fuzz_data_loader.MergedProjectProfile,
+                      profiles: List[fuzz_data_loader.FuzzerProfile],
+                      basefolder: str,
+                      coverage_url: str,
+                      conclusions) -> str:
+        logger.info(f" - Running analysis {self.name}")
+        input_bugs = fuzz_data_loader.try_load_input_bugs()
+        if len(input_bugs) == 0:
+            return ""
+
+        html_string = ""
+        html_string += "<div class=\"report-box\">"
+        html_string += fuzz_html_helpers.html_add_header_with_link(
+            "Bug detector analysis",
+            1,
+            toc_list
+        )
+
+        html_string += (
+            "<p>This section provices analysis that matches bugs "
+            "found by fuzzers with data about the rest of the analysis. "
+            "This section is still in development and should be considered "
+            "beta at most.</p>"
+            
+        )
+
+        # Create table header
+        tables.append(f"myTable{len(tables)}")
+        html_string += fuzz_html_helpers.html_create_table_head(
+            tables[-1],
+            [
+                ("Bug type", "The type of bug."),
+                ("Function", "The function in which the bug occurs")
+            ]
+        )
+        for bug in input_bugs:
+            logger.info("Adding row in input bugs table")
+            html_string += fuzz_html_helpers.html_table_add_row(
+                [
+                    bug.bug_type,
+                    bug.function_name
+                ]
+            )
+        html_string += "</table>"
+        html_string += "</div>"
+        return html_string

--- a/post-processing/analyses/fuzz_bug_digestor.py
+++ b/post-processing/analyses/fuzz_bug_digestor.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 """Analysis for creating input consumed by a fuzzer, e.g. a dictionary"""
 
-import json
 import logging
-import os
 
 from typing import (
     List,
@@ -23,12 +21,8 @@ from typing import (
 )
 
 import fuzz_analysis
-import fuzz_constants
 import fuzz_data_loader
 import fuzz_html_helpers
-import fuzz_utils
-
-from analyses import fuzz_calltree_analysis
 
 logger = logging.getLogger(name=__name__)
 
@@ -64,7 +58,6 @@ class FuzzBugDigestorAnalysis(fuzz_analysis.AnalysisInterface):
             "found by fuzzers with data about the rest of the analysis. "
             "This section is still in development and should be considered "
             "beta at most.</p>"
-            
         )
 
         # Create table header

--- a/post-processing/analyses/fuzz_bug_digestor.py
+++ b/post-processing/analyses/fuzz_bug_digestor.py
@@ -32,14 +32,16 @@ class FuzzBugDigestorAnalysis(fuzz_analysis.AnalysisInterface):
         self.name = "BugDigestorAnalysis"
         self.display_html = False
 
-    def analysis_func(self,
-                      toc_list: List[Tuple[str, str, int]],
-                      tables: List[str],
-                      project_profile: fuzz_data_loader.MergedProjectProfile,
-                      profiles: List[fuzz_data_loader.FuzzerProfile],
-                      basefolder: str,
-                      coverage_url: str,
-                      conclusions) -> str:
+    def analysis_func(
+        self,
+        toc_list: List[Tuple[str, str, int]],
+        tables: List[str],
+        project_profile: fuzz_data_loader.MergedProjectProfile,
+        profiles: List[fuzz_data_loader.FuzzerProfile],
+        basefolder: str,
+        coverage_url: str,
+        conclusions
+    ) -> str:
         logger.info(f" - Running analysis {self.name}")
         input_bugs = fuzz_data_loader.try_load_input_bugs()
         if len(input_bugs) == 0:

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -54,13 +54,15 @@ def get_all_analyses() -> List[AnalysisInterface]:
         fuzz_engine_input,
         fuzz_optimal_targets,
         fuzz_runtime_coverage_analysis,
+        fuzz_bug_digestor
     )
 
     analysis_array = [
         fuzz_optimal_targets.FuzzOptimalTargetAnalysis(),
         fuzz_engine_input.FuzzEngineInputAnalysis(),
         fuzz_runtime_coverage_analysis.FuzzRuntimeCoverageAnalysis(),
-        fuzz_driver_synthesizer.FuzzDriverSynthesizerAnalysis()
+        fuzz_driver_synthesizer.FuzzDriverSynthesizerAnalysis(),
+        fuzz_bug_digestor.FuzzBugDigestorAnalysis()
     ]
     return analysis_array
 

--- a/post-processing/fuzz_cfg_load.py
+++ b/post-processing/fuzz_cfg_load.py
@@ -160,5 +160,5 @@ def data_file_read_calltree(filename: str) -> Optional[CalltreeCallsite]:
         ctcs_root = ctcs_root.parent_calltree_callsite
         if ctcs_root is None:
             return None
-    print_ctcs_tree(ctcs_root)
+    # print_ctcs_tree(ctcs_root)
     return ctcs_root

--- a/post-processing/fuzz_constants.py
+++ b/post-processing/fuzz_constants.py
@@ -20,3 +20,5 @@ SUMMARY_FILE = "summary.json"
 
 APP_EXIT_ERROR = 1
 APP_EXIT_SUCCESS = 0
+
+INPUT_BUG_FILE = "input_bugs.json"

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -611,7 +611,7 @@ def try_load_input_bugs() -> List[InputBug]:
 
 
 def load_input_bugs(bug_file: str) -> List[InputBug]:
-    input_bugs = []
+    input_bugs: List[InputBug]= []
     if not os.path.isfile(bug_file):
         return input_bugs
 

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -15,6 +15,7 @@
 
 import os
 import copy
+import json
 import logging
 
 from typing import (
@@ -27,11 +28,33 @@ from typing import (
 )
 
 import fuzz_cfg_load
+import fuzz_constants
 import fuzz_cov_load
 import fuzz_utils
 
 logger = logging.getLogger(name=__name__)
 logger.setLevel(logging.INFO)
+
+
+class InputBug:
+    """
+    Holds data about a given bug found by fuzzers.
+    """
+    def __init__(
+        self,
+        source_file: str,
+        source_line: str,
+        function_name: str,
+        fuzzer_name: str,
+        description: str,
+        bug_type: str
+    ) -> None:
+        self.source_file = source_file
+        self.source_line = source_line
+        self.function_name = function_name
+        self.fuzzer_name = fuzzer_name
+        self.description = description
+        self.bug_type = bug_type
 
 
 class FunctionProfile:
@@ -578,3 +601,42 @@ def load_all_profiles(target_folder: str) -> List[FuzzerProfile]:
         if profile is not None:
             profiles.append(profile)
     return profiles
+
+
+def try_load_input_bugs() -> List[InputBug]:
+    """Loads input bugs as list. Returns empty list if none"""
+    if not os.path.isfile(fuzz_constants.INPUT_BUG_FILE):
+        return []
+    return load_input_bugs(fuzz_constants.INPUT_BUG_FILE)
+
+
+def load_input_bugs(bug_file: str) -> List[InputBug]:
+    input_bugs = []
+    if not os.path.isfile(bug_file):
+        return input_bugs
+
+    # Read file line by line
+    with open(bug_file, "r") as f:
+        data = json.load(f)
+
+    if type(data) != dict:
+        return input_bugs
+
+    if "bugs" not in data:
+        return input_bugs
+
+    for bug_dict in data["bugs"]:
+        try:
+            ib = InputBug(
+                bug_dict['source_file'],
+                bug_dict['source_line'],
+                bug_dict['function_name'],
+                bug_dict['fuzzer_name'],
+                bug_dict['description'],
+                bug_dict['bug_type']
+            )
+            input_bugs.append(ib)
+        except:
+            continue
+
+    return input_bugs

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -611,7 +611,7 @@ def try_load_input_bugs() -> List[InputBug]:
 
 
 def load_input_bugs(bug_file: str) -> List[InputBug]:
-    input_bugs: List[InputBug]= []
+    input_bugs: List[InputBug] = []
     if not os.path.isfile(bug_file):
         return input_bugs
 
@@ -636,7 +636,7 @@ def load_input_bugs(bug_file: str) -> List[InputBug]:
                 bug_dict['bug_type']
             )
             input_bugs.append(ib)
-        except:
+        except Exception:
             continue
 
     return input_bugs

--- a/post-processing/main.py
+++ b/post-processing/main.py
@@ -59,6 +59,9 @@ def run_analysis_on_dir(
         logger.info("Found no profiles. Exiting")
         return fuzz_constants.APP_EXIT_ERROR
 
+    input_bugs = fuzz_data_loader.try_load_input_bugs()
+    logger.info(f"[+] Loaded {len(input_bugs)} bugs")
+
     logger.info("[+] Accummulating profiles")
     for profile in profiles:
         profile.accummulate_profile(target_folder)


### PR DESCRIPTION
This adds a feature load in data about bugs. Next steps is to use this
in the report, e.g. displaying it in the calltree.

Ref: https://github.com/ossf/fuzz-introspector/issues/255