### PR TITLE
Add Branch profile and branch-level blocker detection

### DIFF
--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -1304,7 +1304,7 @@ std::string FuzzIntrospector::getInsnDebugInfo(Instruction *I) {
   if (Loc != NULL)
   {
     ret_string = Loc->getFilename().str() +
-              +":" + std::to_string(Loc->getLine());
+              +":" + std::to_string(Loc->getLine()) + "," + std::to_string(Loc->getColumn());
   }
   else {
     logPrintf(L1, "No debug info!!\n");

--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -13,19 +13,21 @@
  * limitations under the License.
  */
 
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/Transforms/FuzzIntrospector/FuzzIntrospector.h"
-#include "llvm/IR/DebugInfoMetadata.h"
+
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/InstIterator.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
@@ -34,12 +36,8 @@
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/InitializePasses.h"
-//#include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#include "llvm/Transforms/Utils/CallGraphUpdater.h"
-
-#include "llvm/InitializePasses.h"
-#include "llvm/Pass.h"
+// #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include <unistd.h>
 
 #include <algorithm>
 #include <bitset>
@@ -50,8 +48,10 @@
 #include <iostream>
 #include <set>
 #include <vector>
-#include <unistd.h>
 
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Transforms/Utils/CallGraphUpdater.h"
 
 using namespace std;
 using namespace llvm;
@@ -119,10 +119,12 @@ typedef struct BranchSidesComplexity {
   std::string FalseSideString;
   size_t FalseSideComp;
 
-  BranchSidesComplexity ()
-      : TrueSideString(), TrueSideComp(0), FalseSideString(), FalseSideComp(0) {}
+  BranchSidesComplexity()
+      : TrueSideString(), TrueSideComp(0), FalseSideString(), FalseSideComp(0) {
+  }
   BranchSidesComplexity(std::string TS, size_t TC, std::string FS, size_t FC)
-      : TrueSideString(TS), TrueSideComp(TC), FalseSideString(FS), FalseSideComp(FC) {}
+      : TrueSideString(TS), TrueSideComp(TC), FalseSideString(FS),
+        FalseSideComp(FC) {}
 } BranchSidesComplexity;
 
 typedef struct BranchProfileEntry {
@@ -191,7 +193,6 @@ template <> struct yaml::MappingTraits<BranchProfileEntry> {
 };
 LLVM_YAML_IS_SEQUENCE_VECTOR(BranchProfileEntry)
 
-
 // end of YAML mappings
 
 namespace {
@@ -259,19 +260,23 @@ struct FuzzIntrospector : public ModulePass {
   bool runOnModule(Module &M) override;
 
   void branchProfiler(Module &M);
-  SmallPtrSet<BasicBlock *, 32> findReachables(BasicBlock *src);
-  std::pair<size_t, size_t> findComplexities(SmallPtrSet<BasicBlock *, 32>, SmallPtrSet<BasicBlock *, 32>, std::map<BasicBlock *, size_t>);
+  SmallPtrSet<BasicBlock *, 32> findReachables(BasicBlock *);
+  std::pair<size_t, size_t> findComplexities(SmallPtrSet<BasicBlock *, 32>,
+                                             SmallPtrSet<BasicBlock *, 32>,
+                                             std::map<BasicBlock *, size_t>);
   std::pair<std::string, std::string> getInsnDebugInfo(Instruction *I);
-  std::pair<std::string, std::string> getBBDebugInfo(BasicBlock *BB, DILocation *prevLoc);
-  void writeOutMap(std::vector<BranchProfileEntry> outMap, std::string fileName);
-  size_t calculateBBComplexity(BasicBlock *BB);
+  std::pair<std::string, std::string> getBBDebugInfo(BasicBlock *,
+                                                     DILocation *);
+  void writeOutMap(std::vector<BranchProfileEntry>, std::string);
+  size_t calculateBBComplexity(BasicBlock *);
 };
 } // end of anonymous namespace
 
+INITIALIZE_PASS_BEGIN(FuzzIntrospector, "fuzz-introspector",
+                      "fuzz-introspector pass", false, false)
 
-INITIALIZE_PASS_BEGIN(FuzzIntrospector, "fuzz-introspector", "fuzz-introspector pass", false, false)
-
-INITIALIZE_PASS_END(FuzzIntrospector, "fuzz-introspector", "fuzz-introspector pass", false, false)
+INITIALIZE_PASS_END(FuzzIntrospector, "fuzz-introspector",
+                    "fuzz-introspector pass", false, false)
 char FuzzIntrospector::ID = 0;
 
 Pass *llvm::createFuzzIntrospectorPass() { return new FuzzIntrospector(); }
@@ -281,12 +286,12 @@ void FuzzIntrospector::logPrintf(int LogLevel, const char *Fmt, ...) {
     return;
   }
   // Print time
-  struct tm * timeinfo;
+  struct tm *timeinfo;
   auto SC = std::chrono::system_clock::now();
   std::time_t end_time = std::chrono::system_clock::to_time_t(SC);
-  timeinfo = localtime (&end_time);
-  char buffer [80];
-  strftime (buffer,80,"%H:%M:%S",timeinfo);
+  timeinfo = localtime(&end_time);
+  char buffer[80];
+  strftime(buffer, 80, "%H:%M:%S", timeinfo);
   fprintf(OutputFile, "[Log level %d] : %s : ", LogLevel, buffer);
 
   // Print log statement
@@ -314,8 +319,7 @@ void FuzzIntrospector::readConfig() {
     if (line.find("FUNCS_TO_AVOID") != std::string::npos) {
       current = &ConfigFuncsToAvoid;
       shouldAnalyse = true;
-    }
-    else if (line.find("FILES_TO_AVOID") != std::string::npos) {
+    } else if (line.find("FILES_TO_AVOID") != std::string::npos) {
       current = &ConfigFilesToAvoid;
       shouldAnalyse = true;
     }
@@ -326,18 +330,20 @@ void FuzzIntrospector::makeDefaultConfig() {
   logPrintf(L2, "Using default configuration\n");
 
   std::vector<std::string> FuncsToAvoid = {
-    "^_ZNSt3",                       // mangled std::
-    "^_ZSt",                         // functions in std:: library
-    "^_ZNKSt",                       // std::__xxxbasic_string
-    "^_ZTv0_n24_NSt",                // Some virtual functions for basic streams, e.g. virtual thunk to std::__1::basic_ostream<char, std::__1::char_traits<char> >::~basic_ostream()
-    "^_ZN18FuzzedDataProvider",      // FuzzedDataProvider
-    "^_Zd",                          // "operator delete(...)"
-    "^_Zn",                          // operator new (...)"
-    "^free$",
-    "^malloc$",
-    "llvm[.]",
-    "sanitizer_cov",
-    "sancov[.]module",
+      "^_ZNSt3",        // mangled std::
+      "^_ZSt",          // functions in std:: library
+      "^_ZNKSt",        // std::__xxxbasic_string
+      "^_ZTv0_n24_NSt", // Some virtual functions for basic streams, e.g.
+                        // virtual thunk to std::__1::basic_ostream<char,
+                        // std::__1::char_traits<char> >::~basic_ostream()
+      "^_ZN18FuzzedDataProvider", // FuzzedDataProvider
+      "^_Zd",                     // "operator delete(...)"
+      "^_Zn",                     // operator new (...)"
+      "^free$",
+      "^malloc$",
+      "llvm[.]",
+      "sanitizer_cov",
+      "sancov[.]module",
   };
 
   std::vector<string> *current = &ConfigFuncsToAvoid;
@@ -375,16 +381,14 @@ bool FuzzIntrospector::runOnModule(Module &M) {
   // Extract and log reachability graph
   std::string nextCalltreeFile = getNextLogFile();
 
-  // Insert the logfile as a global variable. We use this to associate a given binary
-  // with a given fuzz report.
-  Constant *FuzzIntrospectorTag = ConstantDataArray::getString(M.getContext(), nextCalltreeFile, false);
-  llvm::GlobalVariable *GV = new GlobalVariable(
-                                      M,
-                                      FuzzIntrospectorTag->getType(),
-                                      true,
-                                      llvm::GlobalValue::LinkageTypes::ExternalLinkage,
-                                      FuzzIntrospectorTag,
-                                      "FuzzIntrospectorTag");
+  // Insert the logfile as a global variable. We use this to associate a given
+  // binary with a given fuzz report.
+  Constant *FuzzIntrospectorTag =
+      ConstantDataArray::getString(M.getContext(), nextCalltreeFile, false);
+  llvm::GlobalVariable *GV =
+      new GlobalVariable(M, FuzzIntrospectorTag->getType(), true,
+                         llvm::GlobalValue::LinkageTypes::ExternalLinkage,
+                         FuzzIntrospectorTag, "FuzzIntrospectorTag");
   GV->setInitializer(FuzzIntrospectorTag);
 
   extractFuzzerReachabilityGraph(M);
@@ -398,14 +402,13 @@ bool FuzzIntrospector::runOnModule(Module &M) {
     branchProfiler(M);
   }
 
-
   logPrintf(L1, "Finished introspector module\n");
   return true;
 }
 
 // Write details about all functions in the module to a YAML file
 void FuzzIntrospector::extractAllFunctionDetailsToYaml(std::string nextYamlName,
-                                                Module &M) {
+                                                       Module &M) {
   std::error_code EC;
   logPrintf(L1, "Logging next yaml tile to %s\n", nextYamlName.c_str());
 
@@ -435,18 +438,17 @@ FuzzerFunctionList FuzzIntrospector::wrapAllFunctions(Module &M) {
 }
 
 std::string FuzzIntrospector::GenRandom(const int len) {
-    static const char alphanum[] =
-        "0123456789"
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        "abcdefghijklmnopqrstuvwxyz";
-    std::string tmp_s;
-    tmp_s.reserve(len);
+  static const char alphanum[] = "0123456789"
+                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                 "abcdefghijklmnopqrstuvwxyz";
+  std::string tmp_s;
+  tmp_s.reserve(len);
 
-    for (int i = 0; i < len; ++i) {
-        tmp_s += alphanum[rand() % (sizeof(alphanum) - 1)];
-    }
-    
-    return tmp_s;
+  for (int i = 0; i < len; ++i) {
+    tmp_s += alphanum[rand() % (sizeof(alphanum) - 1)];
+  }
+
+  return tmp_s;
 }
 
 std::string FuzzIntrospector::getNextLogFile() {
@@ -458,14 +460,16 @@ std::string FuzzIntrospector::getNextLogFile() {
     prefix = std::string(getenv("FUZZINTRO_OUTDIR")) + "/";
   }
   do {
-    TargetLogName = formatv("{0}fuzzerLogFile-{1}-{2}.data", prefix, std::to_string(Idx++), RandomStr);
+    TargetLogName = formatv("{0}fuzzerLogFile-{1}-{2}.data", prefix,
+                            std::to_string(Idx++), RandomStr);
   } while (llvm::sys::fs::exists(TargetLogName));
 
-  // Add a UID to the logname. The reason we do this is when fuzzers are compiled in different
-  // locaitons, then the count may end up being the same for different log files at different locations.
-  // The problem is that this can be annoying when doing some scripting, e.g. in the oss-fuzz integration
-  // at some point. In reality it's not really fuzz introspectors responsibility, however,
-  // to make things a bit easier we just do it here.
+  // Add a UID to the logname. The reason we do this is when fuzzers are
+  // compiled in different locaitons, then the count may end up being the same
+  // for different log files at different locations. The problem is that this
+  // can be annoying when doing some scripting, e.g. in the oss-fuzz integration
+  // at some point. In reality it's not really fuzz introspectors
+  // responsibility, however, to make things a bit easier we just do it here.
 
   return TargetLogName;
 }
@@ -573,8 +577,8 @@ std::string FuzzIntrospector::resolveTypeName(Type *T) {
 // This should be changed to a proper data structure in the future,
 // for example something that we can attribute extensively
 // would be nice to have.
-void FuzzIntrospector::logCalltree(CalltreeNode *Calltree, std::ofstream *CalltreeOut,
-                            int Depth) {
+void FuzzIntrospector::logCalltree(CalltreeNode *Calltree,
+                                   std::ofstream *CalltreeOut, int Depth) {
   if (!Calltree) {
     return;
   }
@@ -587,7 +591,8 @@ void FuzzIntrospector::logCalltree(CalltreeNode *Calltree, std::ofstream *Calltr
   }
 }
 
-void FuzzIntrospector::dumpCalltree(CalltreeNode *Calltree, std::string TargetFile) {
+void FuzzIntrospector::dumpCalltree(CalltreeNode *Calltree,
+                                    std::string TargetFile) {
   std::ofstream CalltreeOut;
   CalltreeOut.open(TargetFile);
   CalltreeOut << "Call tree\n";
@@ -613,7 +618,8 @@ bool FuzzIntrospector::isFunctionPointerType(Type *T) {
   if (PointerType *pointerType = dyn_cast<PointerType>(T)) {
 #if LLVM_VERSION_MAJOR >= 15
     if (!pointerType->isOpaque()) {
-      return isFunctionPointerType(pointerType->getNonOpaquePointerElementType());
+      return isFunctionPointerType(
+          pointerType->getNonOpaquePointerElementType());
     }
 #else
     return isFunctionPointerType(pointerType->getPointerElementType());
@@ -622,8 +628,8 @@ bool FuzzIntrospector::isFunctionPointerType(Type *T) {
   return T->isFunctionTy();
 }
 
-void FuzzIntrospector::getFunctionsInAllNodes(std::vector<CalltreeNode *> *allNodes,
-                                       std::set<StringRef> *UniqueNames) {
+void FuzzIntrospector::getFunctionsInAllNodes(
+    std::vector<CalltreeNode *> *allNodes, std::set<StringRef> *UniqueNames) {
   for (auto PP : *allNodes) {
     UniqueNames->insert(PP->FunctionName);
   }
@@ -648,19 +654,25 @@ void FuzzIntrospector::getFunctionsInAllNodes(std::vector<CalltreeNode *> *allNo
 //   %this1 = load %class.dng_info*, %class.dng_info** %this.addr, align 8
 //
 //   [A virtual call based on a vtable resolution]
-//   %43 = bitcast %class.dng_info* %this1 to void (%class.dng_info*, %class.dng_host .....
-//   %vtable32 = load void (%class.dng_info*, %class.dng ..... d*, i64, i64, i32)*** %43, 
-//   %vfn33 = getelementptr inbounds void (%class.dng .... 4, i64, i32)** %vtable32, i64 8, !dbg !4560
-//   %44 = load void (%class.dng_info*, %class ...... i64, i64, i32)** %vfn33,
-//   call void %44(%class.dng_info* nonnull dereferenceable(332) %this1,  ...
+//   %43 = bitcast %class.dng_info* %this1 to void (%class.dng_info*,
+//   %class.dng_host ..... %vtable32 = load void (%class.dng_info*, %class.dng
+//   ..... d*, i64, i64, i32)*** %43, %vfn33 = getelementptr inbounds void
+//   (%class.dng .... 4, i64, i32)** %vtable32, i64 8, !dbg !4560 %44 = load
+//   void (%class.dng_info*, %class ...... i64, i64, i32)** %vfn33, call void
+//   %44(%class.dng_info* nonnull dereferenceable(332) %this1,  ...
 //
 //   with the following global variable declared:
-//   _ZTV8dng_info = { [15 x i8*] [i8* null, 
-//                                 i8* bitcast ({ i8*, i8* }* @_ZTI8dng_info to i8*), 
-//                                 i8* bitcast (void (%class.dng_info*)* @_ZN8dng_infoD1Ev to i8*), 
-//                                 i8* bitcast (void (%class.dng_info*)* @_ZN8dng_infoD0Ev to i8*), 
-//                                 i8* bitcast (void (%class.dng_info*, %class.dng_host*, %class.dng_stream*)* @_ZN8dng_info5ParseER8dng_hostR10dng_stream to i8*),
-//                                 i8* bitcast (void (%class.dng_info*, %class.dng_host*)* @_ZN8dng_info9PostParseER8dng_host to i8*),
+//   _ZTV8dng_info = { [15 x i8*] [i8* null,
+//                                 i8* bitcast ({ i8*, i8* }* @_ZTI8dng_info to
+//                                 i8*), i8* bitcast (void (%class.dng_info*)*
+//                                 @_ZN8dng_infoD1Ev to i8*), i8* bitcast (void
+//                                 (%class.dng_info*)* @_ZN8dng_infoD0Ev to
+//                                 i8*), i8* bitcast (void (%class.dng_info*,
+//                                 %class.dng_host*, %class.dng_stream*)*
+//                                 @_ZN8dng_info5ParseER8dng_hostR10dng_stream
+//                                 to i8*), i8* bitcast (void (%class.dng_info*,
+//                                 %class.dng_host*)*
+//                                 @_ZN8dng_info9PostParseER8dng_host to i8*),
 //                                 ...
 //                                 ...
 //   }
@@ -671,8 +683,8 @@ void FuzzIntrospector::getFunctionsInAllNodes(std::vector<CalltreeNode *> *allNo
 //   a global variable called "vtable for dng_info" where this name is mangled.
 //   If the global variable is found then get the right index in the vtable
 //   based on the index of the "getelementptr" instruction.
-Function *FuzzIntrospector::extractVTableIndirectCall(Function *F, Instruction &I) {
-
+Function *FuzzIntrospector::extractVTableIndirectCall(Function *F,
+                                                      Instruction &I) {
   Value *opnd = cast<CallInst>(&I)->getCalledOperand();
 
   LoadInst *LI = nullptr;
@@ -711,7 +723,6 @@ Function *FuzzIntrospector::extractVTableIndirectCall(Function *F, Instruction &
   }
 #endif
 
-
 #if LLVM_VERSION_MAJOR >= 15
   Type *v13 = pointerType3->getNonOpaquePointerElementType();
 #else
@@ -724,7 +735,8 @@ Function *FuzzIntrospector::extractVTableIndirectCall(Function *F, Instruction &
   StructType *SSM = cast<StructType>(v13);
   // Now we remove the "class." from the name, and then we have it.
   std::string originalTargetClass = SSM->getName().str().substr(6);
-  logPrintf(L3, "Shortened name that we can use for analysis: %s\n", originalTargetClass.c_str());
+  logPrintf(L3, "Shortened name that we can use for analysis: %s\n",
+            originalTargetClass.c_str());
 
   // We find the global variable corresponding to the vtable by
   // way of naming convetions. Specifically, we look for the
@@ -765,7 +777,8 @@ Function *FuzzIntrospector::extractVTableIndirectCall(Function *F, Instruction &
   // Extract the function pointer corresponding to the constant expression.
   Function *VTableTargetFunc = value2Func(FunctionPtrConstant);
   if (VTableTargetFunc != nullptr) {
-    logPrintf(L3, "The actual function name (from earlyCaught) %s\n", VTableTargetFunc->getName().str().c_str());
+    logPrintf(L3, "The actual function name (from earlyCaught) %s\n",
+              VTableTargetFunc->getName().str().c_str());
   }
   return VTableTargetFunc;
 }
@@ -826,34 +839,35 @@ void FuzzIntrospector::resolveOutgoingEdges(
       const llvm::DebugLoc &debugInfo = I.getDebugLoc();
       // Get the line number of the instruction.
       // We use this when visualizing the calltree.
-      //errs() << "\n";
-      //I.print(errs());
+      // errs() << "\n";
+      // I.print(errs());
       if (debugInfo) {
-        //errs() << "Printing debugLoc\n";
-        //debugInfo.print(errs());
-       // errs() << "\n---------------\n";
+        // errs() << "Printing debugLoc\n";
+        // debugInfo.print(errs());
+        // errs() << "\n---------------\n";
         if (llvm::DebugLoc InlinedAtDL = debugInfo.getInlinedAt()) {
-          //errs() << "Getting inlined line number\n";
+          // errs() << "Getting inlined line number\n";
           CSLinenumber = InlinedAtDL.getLine();
-        }
-        else {
-          //errs() << "Getting non-inlined line number\n";
+        } else {
+          // errs() << "Getting non-inlined line number\n";
           CSLinenumber = debugInfo.getLine();
         }
-        //errs() << "line number: " << CSLinenumber << "\n";
+        // errs() << "line number: " << CSLinenumber << "\n";
       }
 
       StringRef NormalisedDstName = removeDecSuffixFromName(CSElem->getName());
       CalltreeNode *Node = new CalltreeNode(
           NormalisedDstName, getFunctionFilename(CSElem), CSLinenumber, CSElem);
-      //errs() << "Inserting callsite " << NormalisedDstName.str() << " -- line number: " << CSLinenumber << " destination file " << getFunctionFilename(CSElem) << "\n";
+      // errs() << "Inserting callsite " << NormalisedDstName.str() << " -- line
+      // number: " << CSLinenumber << " destination file " <<
+      // getFunctionFilename(CSElem) << "\n";
       OutgoingEdges->push_back(Node);
     }
   }
 }
 
 bool FuzzIntrospector::isNodeInVector(CalltreeNode *Src,
-                               std::vector<CalltreeNode *> *Vec) {
+                                      std::vector<CalltreeNode *> *Vec) {
   for (CalltreeNode *TmpN : *Vec) {
     if (TmpN->LineNumber == Src->LineNumber &&
         TmpN->FileName.compare(Src->FileName) == 0) {
@@ -893,8 +907,9 @@ bool FuzzIntrospector::shouldAvoidFunction(Function *Func) {
 // Collects all functions reachable by the target function. This
 // is an approximation, e.g. we make few efforts into resolving
 // indirect calls.
-int FuzzIntrospector::extractCalltree(Function *F, CalltreeNode *Calltree,
-                               std::vector<CalltreeNode *> *allNodesInTree) {
+int FuzzIntrospector::extractCalltree(
+    Function *F, CalltreeNode *Calltree,
+    std::vector<CalltreeNode *> *allNodesInTree) {
   std::vector<CalltreeNode *> OutgoingEdges;
   resolveOutgoingEdges(F, &OutgoingEdges);
 
@@ -908,8 +923,8 @@ int FuzzIntrospector::extractCalltree(Function *F, CalltreeNode *Calltree,
     if (Calltree != nullptr) {
       Calltree->Outgoings.push_back(OutEdge);
     }
-    int OutEdgeDepth = 1 + extractCalltree(OutEdge->CallsiteDst, OutEdge,
-                                    allNodesInTree);
+    int OutEdgeDepth =
+        1 + extractCalltree(OutEdge->CallsiteDst, OutEdge, allNodesInTree);
     MaxDepthOfEdges = std::max(MaxDepthOfEdges, OutEdgeDepth);
   }
   return MaxDepthOfEdges;
@@ -1011,55 +1026,61 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
         continue;
       }
 
-      //I.dump();
-      // Check if the operands refer to a global value and extract data.
+      // I.dump();
+      //  Check if the operands refer to a global value and extract data.
       for (int opndIdx = 0; opndIdx < I.getNumOperands(); opndIdx++) {
         Value *opndI = I.getOperand(opndIdx);
-        //opndI->dump();
-        // Is this a global variable?
+        // opndI->dump();
+        //  Is this a global variable?
         if (GlobalVariable *GV = dyn_cast<GlobalVariable>(opndI)) {
-          //GV->dump();
+          // GV->dump();
           if (GV->hasInitializer()) {
             Constant *GVI = GV->getInitializer();
             if (ConstantData *GD = dyn_cast<ConstantData>(GVI)) {
-              //logPrintf(L1, "ConstantData\n");
-              // Integer case
+              // logPrintf(L1, "ConstantData\n");
+              //  Integer case
               if (ConstantInt *GI = dyn_cast<ConstantInt>(GD)) {
                 logPrintf(L1, "Constant Int\n");
                 uint64_t zext_val = GI->getZExtValue();
                 errs() << "Zexct val: " << zext_val << "\n";
               }
-            }
-            else if (ConstantExpr *GE = dyn_cast<ConstantExpr>(GVI)) {
+            } else if (ConstantExpr *GE = dyn_cast<ConstantExpr>(GVI)) {
               logPrintf(L1, "Constant expr: %s\n", GE->getName().str().c_str());
-              //GE->dump();
-              if (GEPOperator* gepo = dyn_cast<GEPOperator>(GE)) {
+              // GE->dump();
+              if (GEPOperator *gepo = dyn_cast<GEPOperator>(GE)) {
                 errs() << "GEPOperator\n";
-                if (GlobalVariable* gv12 = dyn_cast<GlobalVariable>(gepo->getPointerOperand())) {
+                if (GlobalVariable *gv12 =
+                        dyn_cast<GlobalVariable>(gepo->getPointerOperand())) {
                   errs() << "GV - " << *gv12 << "\n";
                   if (gv12->hasInitializer()) {
                     errs() << "Has initializer\n";
                     Constant *C222 = gv12->getInitializer();
                     if (ConstantData *GD23 = dyn_cast<ConstantData>(C222)) {
                       errs() << "ConstantData\n";
-                      if (ConstantDataArray *Carr = dyn_cast<ConstantDataArray>(GD23)) {
-                        // This is constant data. We should be able to dump it down.
+                      if (ConstantDataArray *Carr =
+                              dyn_cast<ConstantDataArray>(GD23)) {
+                        // This is constant data. We should be able to dump it
+                        // down.
                         errs() << "ConstantArray. Type:\n";
-                        //Carr->getElementType()->dump();
-                        errs() << "Number of elements: " << Carr->getNumElements() << "\n";
+                        // Carr->getElementType()->dump();
+                        errs()
+                            << "Number of elements: " << Carr->getNumElements()
+                            << "\n";
                         Type *baseType = Carr->getElementType();
                         if (baseType->isIntegerTy()) {
-                            errs() << "Base types\n";
-                            for (int i = 0; i < Carr->getNumElements(); i++) {
-                              std::string s1 = toHex(Carr->getElementAsInteger(i));
-                              errs() << "0x" << s1 << "\n";
-                            }
+                          errs() << "Base types\n";
+                          for (int i = 0; i < Carr->getNumElements(); i++) {
+                            std::string s1 =
+                                toHex(Carr->getElementAsInteger(i));
+                            errs() << "0x" << s1 << "\n";
+                          }
                         }
                         if (Carr->isString()) {
-                          errs() << "The string: " << Carr->getAsString() << "\n";
-                          FuncWrap.ConstantsTouched.push_back(Carr->getAsString().str());
-                        }
-                        else {
+                          errs()
+                              << "The string: " << Carr->getAsString() << "\n";
+                          FuncWrap.ConstantsTouched.push_back(
+                              Carr->getAsString().str());
+                        } else {
                           errs() << "No this is not a string\n";
                         }
                       }
@@ -1108,11 +1129,12 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
 // linked, which is often used in projects to have "standalone-tests". In this
 // case we do not want to proceed to avoid having duplicate information.
 // There are cases where there will be a main function in the fuzzer, but which
-// is weakly defined (see details: https://github.com/ossf/fuzz-introspector/issues/66#issuecomment-1063475323).
+// is weakly defined (see details:
+// https://github.com/ossf/fuzz-introspector/issues/66#issuecomment-1063475323).
 // In these cases we check if the main function is empty and if there is an
-// LLVMFuzzerTestOneInput function, and, if so, determine that we should do analysis.
-// More heuristics may come in the future for determining if a linking operation
-// is for a fuzz target.
+// LLVMFuzzerTestOneInput function, and, if so, determine that we should do
+// analysis. More heuristics may come in the future for determining if a linking
+// operation is for a fuzz target.
 bool FuzzIntrospector::shouldRunIntrospector(Module &M) {
   Function *FuzzEntryFunc = M.getFunction("LLVMFuzzerTestOneInput");
   Function *MainFunc = M.getFunction("main");
@@ -1121,18 +1143,21 @@ bool FuzzIntrospector::shouldRunIntrospector(Module &M) {
     logPrintf(L1, "Main function filename: %s\n", MainFuncFilename.c_str());
 
     if (MainFunc->empty()) {
-      logPrintf(L1, "Main function is empty. Checking if there is a LLVMFuzzerTestOneInput\n");
+      logPrintf(L1, "Main function is empty. Checking if there is a "
+                    "LLVMFuzzerTestOneInput\n");
       if (FuzzEntryFunc != nullptr) {
-        logPrintf(L1, "There is an LLVMFuzzerTestOneInput function. Doing introspector analysis\n");
+        logPrintf(L1, "There is an LLVMFuzzerTestOneInput function. Doing "
+                      "introspector analysis\n");
         return true;
       }
     }
     logPrintf(L1, "Main function is non-empty\n");
-    logPrintf(L1, "This means a main function is in the source code rather in the "
-                  "libfuzzer "
-                  "library, and thus we do not care about it. We only want to "
-                  "study the "
-                  "actual fuzzers. Exiting this run.\n");
+    logPrintf(L1,
+              "This means a main function is in the source code rather in the "
+              "libfuzzer "
+              "library, and thus we do not care about it. We only want to "
+              "study the "
+              "actual fuzzers. Exiting this run.\n");
     return false;
   }
 
@@ -1161,7 +1186,8 @@ void FuzzIntrospector::extractFuzzerReachabilityGraph(Module &M) {
   // reach target code, and should be considered another fuzzer entrypoint.
 }
 
-PreservedAnalyses FuzzIntrospectorPass::run(Module &M, ModuleAnalysisManager &AM) {
+PreservedAnalyses FuzzIntrospectorPass::run(Module &M,
+                                            ModuleAnalysisManager &AM) {
   FuzzIntrospector Impl;
   bool Changed = Impl.runOnModule(M);
   if (!Changed)
@@ -1174,9 +1200,8 @@ PreservedAnalyses FuzzIntrospectorPass::run(Module &M, ModuleAnalysisManager &AM
 // LLVM currently does not support dynamically loading LTO passes. Thus,
 // we dont register it as a pass as we have hardcoded it into Clang instead.
 // Ref: https://reviews.llvm.org/D77704
-static RegisterPass<FuzzIntrospector> X("fuzz-introspector", "FuzzIntrospector Pass",
-                                 false,
-                                 false );
+static RegisterPass<FuzzIntrospector> X("fuzz-introspector", "FuzzIntrospector
+Pass", false, false );
 
 static RegisterStandardPasses
     Y(PassManagerBuilder::EP_FullLinkTimeOptimizationEarly,
@@ -1186,18 +1211,16 @@ static RegisterStandardPasses
 */
 
 void FuzzIntrospector::branchProfiler(Module &M) {
-
-  SmallPtrSet<const BasicBlock *, 32> visistedBBs;
-  SmallVector<const BasicBlock *, 32> worklist;
-  std::string outFileName = getNextLogFile() + ".branchProfile.yaml";
-  std::vector<BranchProfileEntry> outMap;
-
+  std::string OutFileName = getNextLogFile() + ".branchProfile.yaml";
+  std::vector<BranchProfileEntry> OutMap;
 
   logPrintf(L1, "We are in branch profiler.\n");
 
-  for (const auto &F: M) {
-    // Skip declarations or the functions that are not wrapped e.g. not reachable from entry point
-    if(F.isDeclaration() || FuncComplexityMap.find(&F) == FuncComplexityMap.end()) {
+  for (const auto &F : M) {
+    // Skip declarations or the functions that are not wrapped e.g. not
+    // reachable from entry point
+    if (F.isDeclaration() ||
+        FuncComplexityMap.find(&F) == FuncComplexityMap.end()) {
       continue;
     }
     auto fName = F.getName().str();
@@ -1206,212 +1229,210 @@ void FuzzIntrospector::branchProfiler(Module &M) {
     // This map is function level
     std::map<BasicBlock *, size_t> BBComplexityMap;
 
-    for (const auto &BB: F) {
+    for (const auto &BB : F) {
       auto TI = BB.getTerminator();
       auto BI = dyn_cast<BranchInst>(TI);
       if (BI && BI->isConditional()) {
-        auto side0 = BI->getSuccessor(0); 
-        auto side1 = BI->getSuccessor(1);
+        auto Side0 = BI->getSuccessor(0);
+        auto Side1 = BI->getSuccessor(1);
         auto BILoc = BI->getDebugLoc();
 
-        auto reachable0 = findReachables(side0);
-        auto reachable1 = findReachables(side1);
+        auto Reachable0 = findReachables(Side0);
+        auto Reachable1 = findReachables(Side1);
 
-        std::pair<size_t, size_t> complexities = findComplexities(reachable0, reachable1, BBComplexityMap);
+        std::pair<size_t, size_t> Complexities =
+            findComplexities(Reachable0, Reachable1, BBComplexityMap);
 
-        auto side0Comp = complexities.first;
-        auto side1Comp = complexities.second;
+        auto Side0Comp = Complexities.first;
+        auto Side1Comp = Complexities.second;
 
-        std::pair<std::string, std::string> dbgExtracts;
-        dbgExtracts = getInsnDebugInfo((Instruction *)BI);
-        auto BRstring = dbgExtracts.first;
+        std::pair<std::string, std::string> DbgExtracts;
+        DbgExtracts = getInsnDebugInfo((Instruction *)BI);
+        auto BRstring = DbgExtracts.first;
         if (BRstring.length() == 0) {
           continue; // Failed to get debug info
         }
-        dbgExtracts = getBBDebugInfo(side0, BILoc);
-        auto side0String = dbgExtracts.first;
-        if (side0String.length() == 0)
+        DbgExtracts = getBBDebugInfo(Side0, BILoc);
+        auto Side0String = DbgExtracts.first;
+        if (Side0String.length() == 0)
           continue;
-        auto side0Line = std::stoi(dbgExtracts.second);
-        dbgExtracts = getBBDebugInfo(side1, BILoc);
-        auto side1String = dbgExtracts.first;
-        if (side1String.length() == 0)
+        auto Side0Line = std::stoi(DbgExtracts.second);
+        DbgExtracts = getBBDebugInfo(Side1, BILoc);
+        auto Side1String = DbgExtracts.first;
+        if (Side1String.length() == 0)
           continue;
-        auto side1Line = std::stoi(dbgExtracts.second);
+        auto Side1Line = std::stoi(DbgExtracts.second);
 
-        // Decide on the sides based on line number distance; This is how coverage reports the sides
-        std::string trueSideString, falseSideString;
-        size_t trueSideCmp, falseSideComp;
-        if (side0Line > side1Line) {
-          trueSideString = side1String;
-          trueSideCmp = side1Comp;
-          falseSideString = side0String;
-          falseSideComp = side0Comp;
+        // Decide on the sides based on line number distance; This is how
+        // coverage reports the sides
+        std::string TrueSideString, FalseSideString;
+        size_t TrueSideCmp, FalseSideComp;
+        if (Side0Line > Side1Line) {
+          TrueSideString = Side1String;
+          TrueSideCmp = Side1Comp;
+          FalseSideString = Side0String;
+          FalseSideComp = Side0Comp;
         } else {
-          trueSideString = side0String;
-          trueSideCmp = side0Comp;
-          falseSideString = side1String;
-          falseSideComp = side1Comp;
+          TrueSideString = Side0String;
+          TrueSideCmp = Side0Comp;
+          FalseSideString = Side1String;
+          FalseSideComp = Side1Comp;
         }
 
-        BranchSidesComplexity entry_val(trueSideString, trueSideCmp, falseSideString, falseSideComp);
-        BranchProfileEntry entry = {BRstring, entry_val};
-        outMap.push_back(entry);
-
+        BranchSidesComplexity Entry_val(TrueSideString, TrueSideCmp,
+                                        FalseSideString, FalseSideComp);
+        BranchProfileEntry Entry = {BRstring, Entry_val};
+        OutMap.push_back(Entry);
       }
     }
 
   } // End of loop over M
-  writeOutMap(outMap, outFileName);
+  writeOutMap(OutMap, OutFileName);
 }
 
 // Simple intra-procedural CFG traversal
-SmallPtrSet<BasicBlock *, 32> FuzzIntrospector::findReachables(BasicBlock *src) {
-  SmallVector<BasicBlock *, 32> worklist;
-  SmallPtrSet<BasicBlock *, 32> allReachables;
+SmallPtrSet<BasicBlock *, 32>
+FuzzIntrospector::findReachables(BasicBlock *Src) {
+  SmallVector<BasicBlock *, 32> Worklist;
+  SmallPtrSet<BasicBlock *, 32> AllReachables;
 
-  worklist.push_back(src);
+  Worklist.push_back(Src);
 
-  while (!worklist.empty())
-  {
-    auto currBB = worklist.pop_back_val();
+  while (!Worklist.empty()) {
+    auto CurrBB = Worklist.pop_back_val();
 
-    // This adds to the set and returns false if already was in the set: avoids loop
-    if (!allReachables.insert(currBB).second) {
+    // This adds to the set and returns false if already was in the set: avoids
+    // loop
+    if (!AllReachables.insert(CurrBB).second) {
       continue;
     }
 
-    if (auto TI = currBB->getTerminator()) {
+    if (auto TI = CurrBB->getTerminator()) {
       for (unsigned i = 0, NSucc = TI->getNumSuccessors(); i < NSucc; ++i) {
-        worklist.push_back(TI->getSuccessor(i));
+        Worklist.push_back(TI->getSuccessor(i));
       }
     }
   }
 
-  return allReachables;
+  return AllReachables;
 }
 
 // Calculate complexities reachable from each reachable unique BBs
-// TODO: for now, this function just accounts for complexity of callee functions from 
-// the reachable BBs. We can do better by carefully calculating complexity of the reachable
-// regions of the code i.e. intra-procedural complexity by counting the number of unique 
-// edges and nodes for each reachable set.
-std::pair<size_t, size_t> FuzzIntrospector::findComplexities(SmallPtrSet<BasicBlock *, 32> trueReachable, SmallPtrSet<BasicBlock *, 32> falseReachable, std::map<BasicBlock *, size_t> BBComplexityMap) {
-  size_t trueComp = 0, falseComp = 0;
+// TODO: for now, this function just accounts for complexity of callee functions
+// from the reachable BBs. We can do better by carefully calculating complexity
+// of the reachable regions of the code i.e. intra-procedural complexity by
+// counting the number of unique edges and nodes for each reachable set.
+std::pair<size_t, size_t> FuzzIntrospector::findComplexities(
+    SmallPtrSet<BasicBlock *, 32> TrueReachable,
+    SmallPtrSet<BasicBlock *, 32> FalseReachable,
+    std::map<BasicBlock *, size_t> BBComplexityMap) {
+  size_t TrueComp = 0, FalseComp = 0;
 
   // iterate and skip those reachable by false side
-  for (auto BB: trueReachable) {
-    if (falseReachable.find(BB) != falseReachable.end()) {
+  for (auto BB : TrueReachable) {
+    if (FalseReachable.find(BB) != FalseReachable.end()) {
       continue;
     }
 
     if (BBComplexityMap.find(BB) == BBComplexityMap.end()) {
       BBComplexityMap[BB] = calculateBBComplexity(BB);
     }
-    trueComp += BBComplexityMap[BB];
+    TrueComp += BBComplexityMap[BB];
   }
 
   // iterate and skip those reachable by true side
-  for (auto BB: falseReachable) {
-    if (trueReachable.find(BB) != trueReachable.end()) {
+  for (auto BB : FalseReachable) {
+    if (TrueReachable.find(BB) != TrueReachable.end()) {
       continue;
     }
 
     if (BBComplexityMap.find(BB) == BBComplexityMap.end()) {
       BBComplexityMap[BB] = calculateBBComplexity(BB);
     }
-    falseComp += BBComplexityMap[BB];
+    FalseComp += BBComplexityMap[BB];
   }
 
-  return make_pair(trueComp, falseComp);
+  return make_pair(TrueComp, FalseComp);
 }
 
-std::pair<std::string, std::string> FuzzIntrospector::getInsnDebugInfo(Instruction *I) {
-  std::string ret_string = "", ret_line = "";
+std::pair<std::string, std::string>
+FuzzIntrospector::getInsnDebugInfo(Instruction *I) {
+  std::string Ret_string = "", Ret_line = "";
 
   DILocation *Loc = I->getDebugLoc();
-  if (Loc != NULL)
-  {
-    ret_line = std::to_string(Loc->getLine());
-    ret_string = Loc->getFilename().str() +
-              +":" + ret_line + "," + std::to_string(Loc->getColumn());
-  }
-  else {
+  if (Loc != NULL) {
+    Ret_line = std::to_string(Loc->getLine());
+    Ret_string = Loc->getFilename().str() + +":" + Ret_line + "," +
+                 std::to_string(Loc->getColumn());
+  } else {
     logPrintf(L1, "No debug info!!\n");
   }
 
-  return make_pair(ret_string, ret_line);
+  return make_pair(Ret_string, Ret_line);
 }
 
-std::pair<std::string, std::string> FuzzIntrospector::getBBDebugInfo(BasicBlock *BB, DILocation *prevLoc) {
-  std::pair<std::string, std::string> result = make_pair("", "");
+std::pair<std::string, std::string>
+FuzzIntrospector::getBBDebugInfo(BasicBlock *BB, DILocation *PrevLoc) {
+  std::pair<std::string, std::string> Result = make_pair("", "");
 
-  BasicBlock *currBB = BB;
-  BranchInst *currBI;
-  Instruction *currTI, *currI;
-  DILocation *currLoc;
+  BasicBlock *CurrBB = BB;
+  BranchInst *CurrBI;
+  Instruction *CurrTI, *CurrI;
+  DILocation *CurrLoc;
 
   do {
-    currTI = currBB->getTerminator();
-    currI = currBB->getFirstNonPHIOrDbgOrLifetime(true);
-    if (currI == nullptr)
+    CurrTI = CurrBB->getTerminator();
+    CurrI = CurrBB->getFirstNonPHIOrDbgOrLifetime(true);
+    if (CurrI == nullptr)
       break;
-    currLoc = currI->getDebugLoc();
-    currBI = dyn_cast<BranchInst>(currTI);
-    if (currBI && !currBI->isConditional()){
-      currBB = currBI->getSuccessor(0);
-    }
-    else
+    CurrLoc = CurrI->getDebugLoc();
+    CurrBI = dyn_cast<BranchInst>(CurrTI);
+    if (CurrBI && !CurrBI->isConditional()) {
+      CurrBB = CurrBI->getSuccessor(0);
+    } else
       break;
-  } while (currLoc == prevLoc);
+  } while (CurrLoc == PrevLoc);
 
-  if (currI)
-    result = getInsnDebugInfo(currI);
-  // for (auto &I: *BB) {
-  //   result = getInsnDebugInfo(&I);
-  //   if (result.first.length() > 0) {
-  //     break;
-  //   }
-  // }
-  return result;
+  if (CurrI)
+    Result = getInsnDebugInfo(CurrI);
+
+  return Result;
 }
 
-// void FuzzIntrospector::writeOutMap(std::map<std::string, std::vector<std::pair<std::string, size_t>>> outMap, std::string fileName) {
-// void FuzzIntrospector::writeOutMap(std::map<std::string, BranchSidesComplexity> outMap, std::string fileName) {
-void FuzzIntrospector::writeOutMap(std::vector<BranchProfileEntry> outMap, std::string fileName) {
+void FuzzIntrospector::writeOutMap(std::vector<BranchProfileEntry> OutMap,
+                                   std::string FileName) {
   std::error_code EC;
-  logPrintf(L1, "Logging branchProfile to %s\n", fileName.c_str());
+  logPrintf(L1, "Logging branchProfile to %s\n", FileName.c_str());
 
   auto YamlStream = std::make_unique<raw_fd_ostream>(
-      fileName, EC, llvm::sys::fs::OpenFlags::OF_None);
+      FileName, EC, llvm::sys::fs::OpenFlags::OF_None);
   yaml::Output YamlOut(*YamlStream);
 
-  YamlOut << outMap;
+  YamlOut << OutMap;
 }
 
 // Return cyclomatic complexity of called functions in the BB
 size_t FuzzIntrospector::calculateBBComplexity(BasicBlock *BB) {
-  size_t cc = 0;
+  size_t CC = 0;
 
-  for (auto &I: *BB) {
+  for (auto &I : *BB) {
     // Skip debugging insns
     if (isa<DbgInfoIntrinsic>(&I)) {
       continue;
     }
 
     if (isa<CallInst>(I) || isa<InvokeInst>(I)) {
-      Function *callee;
+      Function *Callee;
       if (auto CI = dyn_cast<CallInst>(&I)) {
-        callee = value2Func(CI->getCalledOperand());
+        Callee = value2Func(CI->getCalledOperand());
       } else if (auto II = dyn_cast<InvokeInst>(&I)) {
-        callee = value2Func(II->getCalledOperand());
+        Callee = value2Func(II->getCalledOperand());
       }
-      if (FuncComplexityMap.find(callee) != FuncComplexityMap.end()) {
-        cc += FuncComplexityMap[callee];
+      if (FuncComplexityMap.find(Callee) != FuncComplexityMap.end()) {
+        CC += FuncComplexityMap[Callee];
       }
     }
-
   }
 
-  return cc;
+  return CC;
 }

--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -394,7 +394,10 @@ bool FuzzIntrospector::runOnModule(Module &M) {
   std::string nextYamlName = nextCalltreeFile + ".yaml";
   extractAllFunctionDetailsToYaml(nextYamlName, M);
 
-  branchProfiler(M);
+  if (getenv("FI_BRANCH_PROFILE")) {
+    branchProfiler(M);
+  }
+
 
   logPrintf(L1, "Finished introspector module\n");
   return true;

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -26,7 +26,7 @@ from typing import (
 import fuzz_utils
 import fuzz_cfg_load
 import fuzz_data_loader
-import fuzz_cov_load
+from enum import Enum
 
 logger = logging.getLogger(name=__name__)
 logger.setLevel(logging.INFO)
@@ -46,6 +46,20 @@ class AnalysisInterface(abc.ABC):
                       conclusions) -> str:
         """Core analysis function."""
         pass
+
+
+class BlockedSide(Enum):
+    TRUE = 1
+    FALSE = 2
+
+class FuzzBlocker:
+    def __init__(self, side, comp, filename, b_line, s_line, fname) -> None:
+        self.blocked_side = side
+        self.blocked_complexity = comp
+        self.source_file_name = filename
+        self.branch_line_number = b_line
+        self.blocked_side_line_numder = s_line
+        self.function_name = fname
 
 
 def get_all_analyses() -> List[AnalysisInterface]:
@@ -236,8 +250,8 @@ def overlay_calltree_with_coverage(
         n1.cov_forward_reds = forward_red
         n1.cov_largest_blocked_func = largest_blocked_name
 
-    branch_blockers = detect_branch_level_blockers(profile.coverage, branch_profiles)
-    print("[+] found %d branch blockers." %len(branch_blockers))
+    branch_blockers = detect_branch_level_blockers(profile, branch_profiles)
+    logger.info(f"[+] found {len(branch_blockers)} branch blockers.")
     #TODO: use these results appropriately ...
 
 def analysis_coverage_runtime_analysis(
@@ -273,6 +287,40 @@ def analysis_coverage_runtime_analysis(
             logger.error(f"Error getting hit-summary information for {funcname}")
     return functions_of_interest
 
-def detect_branch_level_blockers(coverage: fuzz_cov_load.CoverageProfile, branch_profile_dict: Dict[str, fuzz_data_loader.BranchProfile]) -> List[any]:
-    # TODO
-    return []
+def detect_branch_level_blockers(fuzz_profile: fuzz_data_loader.FuzzerProfile, llvm_branch_profile: Dict[str, fuzz_data_loader.BranchProfile]) -> List[any]:
+    fuzz_blockers = []
+
+    coverage = fuzz_profile.coverage
+    functions_profile = fuzz_profile.all_class_functions
+    for branch_string in coverage.branch_cov_map:
+        blocked_side = None
+        true_hitcount, false_hitcount = coverage.branch_cov_map[branch_string]
+        function_name, rest_string = branch_string.split(':')
+        line_number, column_number = rest_string.split(',')
+        source_file_name = functions_profile[function_name].function_source_file
+        llvm_branch_string = f'{source_file_name}:{line_number},{column_number}'
+
+        if llvm_branch_string not in llvm_branch_profile:
+            logger.info(f"[X][X] debug: failed to find branch profile for {llvm_branch_string}")
+            continue
+
+        # For now this checks for not-taken branch sides, instead
+        # it may become interesting to report less-taken side: like
+        # the side that is taken less than 20% of the times
+        if true_hitcount == 0 and false_hitcount != 0:
+            blocked_side = BlockedSide.TRUE
+            blocked_complexity = llvm_branch_profile[llvm_branch_string].branch_true_side_complexity
+            side_line = llvm_branch_profile[llvm_branch_string].branch_true_side_line
+            side_line_number = side_line.split(':')[1].split(',')[0]
+        elif true_hitcount != 0 and false_hitcount == 0:
+            blocked_side = BlockedSide.FALSE
+            blocked_complexity = llvm_branch_profile[llvm_branch_string].branch_false_side_complexity
+            side_line = llvm_branch_profile[llvm_branch_string].branch_false_side_line
+            side_line_number = side_line.split(':')[1].split(',')[0]
+
+        if blocked_side:
+            fuzz_blockers.append(FuzzBlocker(blocked_side, blocked_complexity, source_file_name,
+                line_number, side_line_number, function_name))
+
+    fuzz_blockers.sort(key=lambda x : x.blocked_complexity, reverse=True)
+    return fuzz_blockers

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -26,6 +26,7 @@ from typing import (
 import fuzz_utils
 import fuzz_cfg_load
 import fuzz_data_loader
+import fuzz_cov_load
 
 logger = logging.getLogger(name=__name__)
 logger.setLevel(logging.INFO)
@@ -71,7 +72,8 @@ def overlay_calltree_with_coverage(
         profile: fuzz_data_loader.FuzzerProfile,
         project_profile: fuzz_data_loader.MergedProjectProfile,
         coverage_url: str,
-        basefolder: str) -> None:
+        basefolder: str,
+        branch_profiles: Dict[str, fuzz_data_loader.BranchProfile]) -> None:
     # We use the callstack to keep track of all function parents. We need this
     # when looking up if a callsite was hit or not. This is because the coverage
     # information about a callsite is located in coverage data of the function
@@ -234,6 +236,9 @@ def overlay_calltree_with_coverage(
         n1.cov_forward_reds = forward_red
         n1.cov_largest_blocked_func = largest_blocked_name
 
+    branch_blockers = detect_branch_level_blockers(profile.coverage, branch_profiles)
+    print("[+] found %d branch blockers." %len(branch_blockers))
+    #TODO: use these results appropriately ...
 
 def analysis_coverage_runtime_analysis(
         profiles: List[fuzz_data_loader.FuzzerProfile],
@@ -267,3 +272,7 @@ def analysis_coverage_runtime_analysis(
         except Exception:
             logger.error(f"Error getting hit-summary information for {funcname}")
     return functions_of_interest
+
+def detect_branch_level_blockers(coverage: fuzz_cov_load.CoverageProfile, branch_profile_dict: Dict[str, fuzz_data_loader.BranchProfile]) -> List[any]:
+    # TODO
+    return []

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -297,11 +297,14 @@ def detect_branch_level_blockers(fuzz_profile: fuzz_data_loader.FuzzerProfile, l
         true_hitcount, false_hitcount = coverage.branch_cov_map[branch_string]
         function_name, rest_string = branch_string.split(':')
         line_number, column_number = rest_string.split(',')
-        source_file_name = functions_profile[function_name].function_source_file
+        # Just extract the file name and skip the path
+        source_file_name = functions_profile[function_name].function_source_file.split('/')[-1]
         llvm_branch_string = f'{source_file_name}:{line_number},{column_number}'
 
         if llvm_branch_string not in llvm_branch_profile:
-            logger.info(f"[X][X] debug: failed to find branch profile for {llvm_branch_string}")
+            # TODO: there are cases that the column number of the branch is not consistent between 
+            # llvm and coverage debug info. For now we skip those cases.
+            # logger.info(f"[X][X] debug: failed to find branch profile for {llvm_branch_string}")
             continue
 
         # For now this checks for not-taken branch sides, instead

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -42,6 +42,11 @@ class CoverageProfile:
         self.covmap: Dict[str, List[Tuple[int, int]]] = dict()
         self.covreports: List[str] = list()
 
+        # branch_cov_map is dictionary to collect the branch coverage info 
+        # in the form of current_func:line_number as the key and true_hit and 
+        # false_hit as a tuple value
+        self.branch_cov_map: Dict[str, Tuple[int, int]] = dict()
+
     def get_all_hit_functions(self) -> List[str]:
         # Hacky way to satisfy typing
         all_keys: List[str] = []
@@ -154,12 +159,35 @@ def llvm_cov_load(target_dir, target_name=None) -> CoverageProfile:
                         curr_func = line.replace(" ", "").replace(":", "")
                     curr_func = fuzz_utils.demangle_cpp_func(curr_func)
                     cp.covmap[curr_func] = list()
+                # This parses Branch cov info in the form of:
+                #  |  Branch (81:7): [True: 1.2k, False: 0]
+                if curr_func and "Branch" in line:
+                    try:
+                        line_number = line.split('(')[1].split(':')[0]
+                    except Exception:
+                        continue
 
+                    try:
+                        true_hit = int(line.split('True:')[1].split(',')[0].replace(
+                                "k", "00").replace(
+                                    "M", "0000").replace(
+                                        ".", ""))
+                    except Exception:
+                        continue
+                    try:
+                        false_hit = int(line.split('False:')[1].replace("]", "").replace(
+                                "k", "00").replace(
+                                    "M", "0000").replace(
+                                        ".", ""))
+                    except Exception:
+                        continue
+                    branch_string = curr_func + ':' + line_number
+                    cp.branch_cov_map[branch_string] = (true_hit, false_hit)
                 # Parse lines that signal specific line of code. These lines only
                 # offer after the function names parsed above.
                 # Example line:
                 #  "   83|  5.99M|    char *kldfj = (char*)malloc(123);\n"
-                if curr_func is not None and "|" in line:
+                elif curr_func is not None and "|" in line:
                     # Extract source code line number
                     try:
                         line_number = int(line.split("|")[0])

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -42,8 +42,8 @@ class CoverageProfile:
         self.covmap: Dict[str, List[Tuple[int, int]]] = dict()
         self.covreports: List[str] = list()
 
-        # branch_cov_map is dictionary to collect the branch coverage info 
-        # in the form of current_func:line_number as the key and true_hit and 
+        # branch_cov_map is dictionary to collect the branch coverage info
+        # in the form of current_func:line_number as the key and true_hit and
         # false_hit as a tuple value
         self.branch_cov_map: Dict[str, Tuple[int, int]] = dict()
 
@@ -163,26 +163,26 @@ def llvm_cov_load(target_dir, target_name=None) -> CoverageProfile:
                 #  |  Branch (81:7): [True: 1.2k, False: 0]
                 if curr_func and "Branch (" in line:
                     try:
-                        line_number = line.split('(')[1].split(':')[0]
+                        line_number = int(line.split('(')[1].split(':')[0])
                     except Exception:
                         continue
                     try:
-                        column_number = line.split(':')[1].split(')')[0]
+                        column_number = int(line.split(':')[1].split(')')[0])
                     except Exception:
                         continue
 
                     try:
                         true_hit = int(line.split('True:')[1].split(',')[0].replace(
-                                "k", "00").replace(
-                                    "M", "0000").replace(
-                                        ".", ""))
+                            "k", "00").replace(
+                                "M", "0000").replace(
+                                    ".", ""))
                     except Exception:
                         continue
                     try:
                         false_hit = int(line.split('False:')[1].replace("]", "").replace(
-                                "k", "00").replace(
-                                    "M", "0000").replace(
-                                        ".", ""))
+                            "k", "00").replace(
+                                "M", "0000").replace(
+                                    ".", ""))
                     except Exception:
                         continue
                     branch_string = f'{curr_func}:{line_number},{column_number}'

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -161,9 +161,13 @@ def llvm_cov_load(target_dir, target_name=None) -> CoverageProfile:
                     cp.covmap[curr_func] = list()
                 # This parses Branch cov info in the form of:
                 #  |  Branch (81:7): [True: 1.2k, False: 0]
-                if curr_func and "Branch" in line:
+                if curr_func and "Branch (" in line:
                     try:
                         line_number = line.split('(')[1].split(':')[0]
+                    except Exception:
+                        continue
+                    try:
+                        column_number = line.split(':')[1].split(')')[0]
                     except Exception:
                         continue
 
@@ -181,7 +185,7 @@ def llvm_cov_load(target_dir, target_name=None) -> CoverageProfile:
                                         ".", ""))
                     except Exception:
                         continue
-                    branch_string = curr_func + ':' + line_number
+                    branch_string = curr_func + ':' + line_number + ',' + column_number
                     cp.branch_cov_map[branch_string] = (true_hit, false_hit)
                 # Parse lines that signal specific line of code. These lines only
                 # offer after the function names parsed above.

--- a/post-processing/fuzz_cov_load.py
+++ b/post-processing/fuzz_cov_load.py
@@ -185,7 +185,7 @@ def llvm_cov_load(target_dir, target_name=None) -> CoverageProfile:
                                         ".", ""))
                     except Exception:
                         continue
-                    branch_string = curr_func + ':' + line_number + ',' + column_number
+                    branch_string = f'{curr_func}:{line_number},{column_number}'
                     cp.branch_cov_map[branch_string] = (true_hit, false_hit)
                 # Parse lines that signal specific line of code. These lines only
                 # offer after the function names parsed above.

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -92,9 +92,9 @@ class BranchProfile:
     Class for storing information about conditional branches collected by LLVM pass.
     """
     def __init__(self) -> None:
-        self.branch_line = None
-        self.branch_true_side_line = None
-        self.branch_false_side_line = None
+        self.branch_line = str()
+        self.branch_true_side_line = str()
+        self.branch_false_side_line = str()
         self.branch_true_side_complexity = -1
         self.branch_false_side_complexity = -1
         self.branch_true_side_hitcount = -1
@@ -111,14 +111,14 @@ class BranchProfile:
     def assign_from_coverage(self, true_count, false_count):
         self.branch_true_side_hitcount = int(true_count)
         self.branch_false_side_hitcount = int(false_count)
-    
+
     def dump(self):
         """
         For debugging purposes, may be removed later.
         """
         print(self.branch_line, self.branch_true_side_line, self.branch_false_side_line,
-        self.branch_true_side_complexity, self.branch_false_side_complexity,
-        self.branch_true_side_hitcount, self.branch_true_side_hitcount)
+              self.branch_true_side_complexity, self.branch_false_side_complexity,
+              self.branch_true_side_hitcount, self.branch_true_side_hitcount)
 
 
 class FuzzerProfile:
@@ -422,7 +422,7 @@ class MergedProjectProfile:
                             continue
                         new_line_counts.append((ln1, max(ht1, ht2)))
                     self.runtime_coverage.covmap[func_name] = new_line_counts
-            #TODO (navidem): will need to merge branch coverages (branch_cov_map) if we need to 
+            # TODO (navidem): will need to merge branch coverages (branch_cov_map) if we need to
             # identify blockers based on all fuzz targets coverage
         self.set_basefolder()
         logger.info("Completed creationg of merged profile")
@@ -666,13 +666,14 @@ def load_input_bugs(bug_file: str) -> List[InputBug]:
 
     return input_bugs
 
+
 def read_branch_data_file_to_profile(filename: str, BP_dict: dict):
     """
     Loads branch profiles from LLVM pass output yaml file.
     """
     logger.info(f" - loading {filename}")
     if not os.path.isfile(filename):
-        return 
+        return
 
     data_dict_yaml = fuzz_utils.data_file_read_yaml(filename)
     if data_dict_yaml is None:
@@ -684,9 +685,10 @@ def read_branch_data_file_to_profile(filename: str, BP_dict: dict):
         BP_dict[new_branch.branch_line] = new_branch
 
 
-def load_all_branch_profiles(target_folder: str) -> List[BranchProfile]:
-    all_branch_profiles = {}
-    data_files = fuzz_utils.get_all_files_in_tree_with_regex(target_folder, ".*branchProfile\.yaml$")
+def load_all_branch_profiles(target_folder: str) -> Dict[str, BranchProfile]:
+    all_branch_profiles: Dict[str, BranchProfile] = dict()
+    data_files = fuzz_utils.get_all_files_in_tree_with_regex(target_folder,
+                                                             ".*branchProfile\.yaml$")
     logger.info(f" - found {len(data_files)} branchProfiles to load")
     for data_file in data_files:
         read_branch_data_file_to_profile(data_file, all_branch_profiles)

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -101,7 +101,8 @@ class BranchProfile:
         self.branch_false_side_hitcount = -1
 
     def assign_from_yaml_elem(self, elem):
-        self.branch_line = elem['Branch String']
+        # This skips the path, as it may cause incosistancy vs coverage file names path
+        self.branch_line = elem['Branch String'].split('/')[-1]
         self.branch_true_side_line = elem['Branch Sides']['TrueSide']
         self.branch_false_side_line = elem['Branch Sides']['FalseSide']
         self.branch_true_side_complexity = int(elem['Branch Sides']['TrueSideComp'])

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -421,6 +421,8 @@ class MergedProjectProfile:
                             continue
                         new_line_counts.append((ln1, max(ht1, ht2)))
                     self.runtime_coverage.covmap[func_name] = new_line_counts
+            #TODO (navidem): will need to merge branch coverages (branch_cov_map) if we need to 
+            # identify blockers based on all fuzz targets coverage
         self.set_basefolder()
         logger.info("Completed creationg of merged profile")
 

--- a/post-processing/main.py
+++ b/post-processing/main.py
@@ -92,8 +92,8 @@ def run_analysis_on_dir(
             profile,
             project_profile,
             coverage_url,
-            project_profile.basefolder
-        )
+            project_profile.basefolder,
+            branch_profiles)
 
     logger.info(f"Analyses to run: {str(analyses_to_run)}")
 

--- a/post-processing/main.py
+++ b/post-processing/main.py
@@ -81,6 +81,11 @@ def run_analysis_on_dir(
     for profile in profiles:
         profile.refine_paths(project_profile.basefolder)
 
+    logger.info("[+] Loading branch profiles")
+    branch_profiles = fuzz_data_loader.load_all_branch_profiles(target_folder)
+    if len(branch_profiles) == 0:
+        logger.info("[X][X] Found no branch profiles!")
+
     # Overlay coverage in each profile
     for profile in profiles:
         fuzz_analysis.overlay_calltree_with_coverage(


### PR DESCRIPTION
This PR adds these:

- Branch profiling at LLVM plugin: identify branch sides and their corresponding cyclomatic complexity
- Loading branch profile in fuzz_data_loader.py
- Loading branch coverage information in fuzz_cov_load.py
- Making the calls to branch-level blocker detection in fuzz_analysis.py