### PR TITLE
Branch blocker: Extract reached funcs for each branch side

### DIFF
--- a/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -1444,6 +1444,7 @@ FuzzIntrospector::getBBDebugInfo(BasicBlock *BB, DILocation *PrevLoc) {
   Instruction *CurrTI, *CurrI;
   DILocation *CurrLoc;
 
+  // Traverse all dummy BBs associated with the previous Loc.
   do {
     CurrTI = CurrBB->getTerminator();
     CurrI = CurrBB->getFirstNonPHIOrDbgOrLifetime(true);
@@ -1457,6 +1458,10 @@ FuzzIntrospector::getBBDebugInfo(BasicBlock *BB, DILocation *PrevLoc) {
       break;
   } while (CurrLoc == PrevLoc);
 
+  // To skip the return BB in optimized CFG.
+  if (dyn_cast<ReturnInst>(CurrTI)){
+    CurrI = BB->getFirstNonPHIOrDbgOrLifetime(true);
+  }
   if (CurrI)
     Result = getInsnDebugInfo(CurrI);
 

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -99,14 +99,16 @@ class BranchProfile:
         self.branch_false_side_complexity = -1
         self.branch_true_side_hitcount = -1
         self.branch_false_side_hitcount = -1
+        self.branch_true_side_funcs = list()
+        self.branch_false_side_funcs = list()
 
     def assign_from_yaml_elem(self, elem):
         # This skips the path, as it may cause incosistancy vs coverage file names path
         self.branch_pos = elem['Branch String'].split('/')[-1]
         self.branch_true_side_pos = elem['Branch Sides']['TrueSide']
         self.branch_false_side_pos = elem['Branch Sides']['FalseSide']
-        self.branch_true_side_complexity = int(elem['Branch Sides']['TrueSideComp'])
-        self.branch_false_side_complexity = int(elem['Branch Sides']['FalseSideComp'])
+        self.branch_true_side_funcs = elem['Branch Sides']['TrueSideFuncs']
+        self.branch_false_side_complexity = elem['Branch Sides']['FalseSideFuncs']
 
     def assign_from_coverage(self, true_count, false_count):
         self.branch_true_side_hitcount = int(true_count)


### PR DESCRIPTION
This changes the way branches are profiled:
- for each conditional branch, identifies reachable functions for each branch side
- the post-process measures the complexity of un-hit reachable functions for each side