### PR TITLE
tests: add python targets

### DIFF
--- a/tests/python/test1/README.md
+++ b/tests/python/test1/README.md
@@ -1,0 +1,1 @@
+Simplest possible fuzzer

--- a/tests/python/test1/fuzz_test.py
+++ b/tests/python/test1/fuzz_test.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import atheris
+
+@atheris.instrument_func
+def TestOneInput(data):
+    return
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test2/README.md
+++ b/tests/python/test2/README.md
@@ -1,0 +1,1 @@
+Test case with reachable and unreachable functions

--- a/tests/python/test2/fuzz_test.py
+++ b/tests/python/test2/fuzz_test.py
@@ -15,7 +15,7 @@
 import sys
 import atheris
 with atheris.instrument_imports():
-    os
+    import os
 
 def reachable_1(data):
     return

--- a/tests/python/test2/fuzz_test.py
+++ b/tests/python/test2/fuzz_test.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import atheris
+with atheris.instrument_imports():
+    os
+
+def reachable_1(data):
+    return
+
+def reachable_2(data):
+    return
+
+def unreachable_1():
+    return
+
+@atheris.instrument_func
+def TestOneInput(data):
+    if len(data) < 1:
+        reachable_1(data)
+    else:
+        reachable_2(data)
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test3/README.md
+++ b/tests/python/test3/README.md
@@ -1,0 +1,1 @@
+Test case with reachable/unreachable functions by way of an imported module.

--- a/tests/python/test3/fuzz_lib.py
+++ b/tests/python/test3/fuzz_lib.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def reachable_1(data):
+    return
+
+def reachable_2(data):
+    return
+
+def unreachable_1():
+    return

--- a/tests/python/test3/fuzz_test.py
+++ b/tests/python/test3/fuzz_test.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import atheris
+with atheris.instrument_imports():
+    import fuzz_lib
+
+@atheris.instrument_func
+def TestOneInput(data):
+    if len(data) < 1:
+        fuzz_lib.reachable_1(data)
+    else:
+        fuzz_lib.reachable_2(data)
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test4/README.md
+++ b/tests/python/test4/README.md
@@ -1,0 +1,1 @@
+Test case with reachable/unreachable functions by way of an imported module.

--- a/tests/python/test4/fuzz_lib.py
+++ b/tests/python/test4/fuzz_lib.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def nested_reachable_1(data):
+    return
+
+def reachable_1(data):
+    nested_reachable_1(data)
+    return
+
+def reachable_2(data):
+    return
+
+def unreachable_1():
+    reachable_2()
+    reachable_1()
+    return

--- a/tests/python/test4/fuzz_test.py
+++ b/tests/python/test4/fuzz_test.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import atheris
+with atheris.instrument_imports():
+    import fuzz_lib
+
+@atheris.instrument_func
+def TestOneInput(data):
+    if len(data) < 1:
+        fuzz_lib.reachable_1(data)
+    else:
+        fuzz_lib.reachable_2(data)
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Python test cases such that once these are analysed properly we
have basic support for python.

Step 1 of Python target integration

Ref: https://github.com/ossf/fuzz-introspector/issues/280