### PR TITLE
post-processing: enable reading of Python output

### DIFF
--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -140,7 +140,7 @@ def overlay_calltree_with_coverage(
             # have a single seed, and in this specific case LLVMFuzzerTestOneInput
             # will be red.
             if demangled_name != "LLVMFuzzerTestOneInput" and "TestOneInput" not in demangled_name:
-                logger.info("LLVMFuzzerTestOneInput or TestOneInput must be the first node in the calltree")
+                logger.info("Unexpected first node in the calltree.")
                 logger.info(f"Found: {demangled_name}")
                 exit(1)
             coverage_data = profile.coverage.get_hit_details("LLVMFuzzerTestOneInput")

--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -139,8 +139,9 @@ def overlay_calltree_with_coverage(
             # hardcoding LLVMFuzzerTestOneInput to be green because some fuzzers may not
             # have a single seed, and in this specific case LLVMFuzzerTestOneInput
             # will be red.
-            if not demangled_name == "LLVMFuzzerTestOneInput":
-                logger.error("LLVMFuzzerTestOneInput must be the first node in the calltree")
+            if demangled_name != "LLVMFuzzerTestOneInput" and "TestOneInput" not in demangled_name:
+                logger.info("LLVMFuzzerTestOneInput or TestOneInput must be the first node in the calltree")
+                logger.info(f"Found: {demangled_name}")
                 exit(1)
             coverage_data = profile.coverage.get_hit_details("LLVMFuzzerTestOneInput")
             if len(coverage_data) == 0:

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -517,7 +517,9 @@ class MergedProjectProfile:
             logger.info("Total complexity is 0")
             reached_complexity_percentage = 0
         try:
-            unreached_complexity_percentage = (float(complexity_unreached) / (total_complexity)) * 100.0
+            unreached_complexity_percentage = (
+                (float(complexity_unreached) / (total_complexity)) * 100.0
+            )
         except Exception:
             logger.info("Total complexity is 0")
             unreached_complexity_percentage = 0

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -160,6 +160,7 @@ class FuzzerProfile:
                     )
 
             func_profile = FunctionProfile(elem)
+            logger.info("Adding %s"%(func_profile.function_name))
             self.all_class_functions[func_profile.function_name] = func_profile
 
     def refine_paths(self, basefolder: str) -> None:
@@ -187,9 +188,20 @@ class FuzzerProfile:
         sets self.functions_reached_by_fuzzer to all functions reached
         by LLVMFuzzerTestOneInput
         """
-        self.functions_reached_by_fuzzer = (self
-                                            .all_class_functions["LLVMFuzzerTestOneInput"]
-                                            .functions_reached)
+        if "LLVMFuzzerTestOneInput" in self.all_class_functions:
+            self.functions_reached_by_fuzzer = (
+                self.all_class_functions["LLVMFuzzerTestOneInput"].functions_reached
+            )
+            return
+
+        # Find Python entrypoint
+        for func_name in self.all_class_functions:
+            if "TestOneInput" in func_name:
+                self.functions_reached_by_fuzzer = self.all_class_functions[func_name].functions_reached
+                return
+
+        # TODO: make fuzz-introspector exceptions
+        raise Exception
 
     def reaches(self, func_name: str) -> bool:
         return func_name in self.functions_reached_by_fuzzer
@@ -495,12 +507,19 @@ class MergedProjectProfile:
         )
 
     def get_complexity_summaries(self) -> Tuple[int, int, int, float, float]:
-
         complexity_reached, complexity_unreached = self.get_total_complexity()
         total_complexity = complexity_unreached + complexity_reached
 
-        reached_complexity_percentage = (float(complexity_reached) / (total_complexity)) * 100.0
-        unreached_complexity_percentage = (float(complexity_unreached) / (total_complexity)) * 100.0
+        try:
+            reached_complexity_percentage = (float(complexity_reached) / (total_complexity)) * 100.0
+        except:
+            logger.info("Total complexity is 0")
+            reached_complexity_percentage = 0
+        try:
+            unreached_complexity_percentage = (float(complexity_unreached) / (total_complexity)) * 100.0
+        except:
+            logger.info("Total complexity is 0")
+            unreached_complexity_percentage = 0
 
         return (
             total_complexity,
@@ -560,10 +579,19 @@ def read_fuzzer_data_file_to_profile(filename: str) -> Optional[FuzzerProfile]:
         return None
 
     FP = FuzzerProfile(filename, data_dict_yaml)
-    if "LLVMFuzzerTestOneInput" not in FP.all_class_functions:
-        return None
 
-    return FP
+    # Check we have a valid entrypoint
+    if "LLVMFuzzerTestOneInput" in FP.all_class_functions:
+        return FP
+
+    # Check for python fuzzers. The following assumes the entrypoint
+    # currently has "TestOneInput" int its name
+    for name in FP.all_class_functions:
+        if "TestOneInput" in name:
+            return FP
+
+    logger.info("Found no fuzzer entrypoints")
+    return None
 
 
 def add_func_to_reached_and_clone(merged_profile_old: MergedProjectProfile,

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -160,7 +160,7 @@ class FuzzerProfile:
                     )
 
             func_profile = FunctionProfile(elem)
-            logger.info(f"Adding {func_profile.function_name}"%)
+            logger.info(f"Adding {func_profile.function_name}")
             self.all_class_functions[func_profile.function_name] = func_profile
 
     def refine_paths(self, basefolder: str) -> None:

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -160,7 +160,7 @@ class FuzzerProfile:
                     )
 
             func_profile = FunctionProfile(elem)
-            logger.info("Adding %s"%(func_profile.function_name))
+            logger.info(f"Adding {func_profile.function_name}"%)
             self.all_class_functions[func_profile.function_name] = func_profile
 
     def refine_paths(self, basefolder: str) -> None:
@@ -197,7 +197,8 @@ class FuzzerProfile:
         # Find Python entrypoint
         for func_name in self.all_class_functions:
             if "TestOneInput" in func_name:
-                self.functions_reached_by_fuzzer = self.all_class_functions[func_name].functions_reached
+                reached = self.all_class_functions[func_name].functions_reached
+                self.functions_reached_by_fuzzer = reached
                 return
 
         # TODO: make fuzz-introspector exceptions
@@ -512,12 +513,12 @@ class MergedProjectProfile:
 
         try:
             reached_complexity_percentage = (float(complexity_reached) / (total_complexity)) * 100.0
-        except:
+        except Exception:
             logger.info("Total complexity is 0")
             reached_complexity_percentage = 0
         try:
             unreached_complexity_percentage = (float(complexity_unreached) / (total_complexity)) * 100.0
-        except:
+        except Exception:
             logger.info("Total complexity is 0")
             unreached_complexity_percentage = 0
 

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -626,7 +626,7 @@ def create_fuzzer_detailed_section(
     reached_funcs = reachable_funcs - uncovered_reachable_funcs
     try:
         cov_reach_proportion = (float(reached_funcs) / float(reachable_funcs)) * 100.0
-    except:
+    except Exception:
         logger.info("reachable funcs is 0")
         cov_reach_proportion=0.0
     str_percentage = "%.5s%%" % str(cov_reach_proportion)

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -624,7 +624,11 @@ def create_fuzzer_detailed_section(
     uncovered_reachable_funcs = len(profile.get_cov_uncovered_reachable_funcs())
     reachable_funcs = len(profile.functions_reached_by_fuzzer)
     reached_funcs = reachable_funcs - uncovered_reachable_funcs
-    cov_reach_proportion = (float(reached_funcs) / float(reachable_funcs)) * 100.0
+    try:
+        cov_reach_proportion = (float(reached_funcs) / float(reachable_funcs)) * 100.0
+    except:
+        logger.info("reachable funcs is 0")
+        cov_reach_proportion=0.0
     str_percentage = "%.5s%%" % str(cov_reach_proportion)
     fuzz_utils.write_to_summary_file(
         profile.get_key(),

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -628,7 +628,7 @@ def create_fuzzer_detailed_section(
         cov_reach_proportion = (float(reached_funcs) / float(reachable_funcs)) * 100.0
     except Exception:
         logger.info("reachable funcs is 0")
-        cov_reach_proportion=0.0
+        cov_reach_proportion = 0.0
     str_percentage = "%.5s%%" % str(cov_reach_proportion)
     fuzz_utils.write_to_summary_file(
         profile.get_key(),


### PR DESCRIPTION
This provides a few minor changes and some bug fixes, which enables
reading of the Python frontend's output as is. There will have to be
further changes to make the project more friendly for having data from
sources in different languages.

Ref: https://github.com/ossf/fuzz-introspector/issues/280