### PR TITLE
post-processing: add link to repository issues

### DIFF
--- a/post-processing/fuzz_html_helpers.py
+++ b/post-processing/fuzz_html_helpers.py
@@ -82,8 +82,13 @@ def html_get_navbar(title: str) -> str:
             </g>
         </svg>
     </div>
-    <div class="top-navbar-title">
-        { title }
+    <div class="top-navbar-title-wrapper" style="text-align: center">
+        <div class="top-navbar-title" style="margin-bottom: 10px; font-size:25px">
+            { title }
+        </div>
+        <div style="margin:0; font-size: 10px">
+          For issues and ideas: https://github.com/ossf/fuzz-introspector/issues
+        </div>
     </div>
 </div>"""
     return navbar

--- a/post-processing/fuzz_html_helpers.py
+++ b/post-processing/fuzz_html_helpers.py
@@ -87,7 +87,11 @@ def html_get_navbar(title: str) -> str:
             { title }
         </div>
         <div style="margin:0; font-size: 10px">
-          For issues and ideas: https://github.com/ossf/fuzz-introspector/issues
+          For issues and ideas:
+          <a href="https://github.com/ossf/fuzz-introspector/issues"
+             style="color:#FFFFFF;">
+            https://github.com/ossf/fuzz-introspector/issues
+          </a>
         </div>
     </div>
 </div>"""


### PR DESCRIPTION
When fuzz-introspector is used on OSS-Fuzz it may be non-obvious where
to file suggestions and issues. To guide the user to the
fuzz-introspector repository include a short message in the navigation
bar directing where to file this.