### PR TITLE
oss-fuzz: add python support

### DIFF
--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -83,12 +83,13 @@ def run_fuzz_pass(fuzzer, package, sources, scan):
         package = resolve_package(fuzzer)
         if package is None:
             print("No package. Exiting early now as the results will not be good")
-            sys.exit(1)
+            package=""
+            #sys.exit(1)
 
     # Check if we should scan
     scanned_sources = []
-    package_abs_path = os.path.abspath(package)
     if scan:
+        package_abs_path = os.path.abspath(package)
         for l in os.listdir(package_abs_path):
             if not l.endswith(".py"):
                 continue

--- a/oss_fuzz_integration/build_patched_oss_fuzz.sh
+++ b/oss_fuzz_integration/build_patched_oss_fuzz.sh
@@ -29,6 +29,7 @@ else
 fi
 
 rm -rf ./oss-fuzz/infra/base-images/base-builder/post-processing/
+rm -rf ./oss-fuzz/infra/base-images/base-builder/frontends
 rm -rf ./oss-fuzz/infra/base-images/base-clang/fuzz-introspector/
 
 mkdir ./oss-fuzz/infra/base-images/base-clang/fuzz-introspector/
@@ -37,6 +38,8 @@ cp -rf ../llvm ./oss-fuzz/infra/base-images/base-clang/fuzz-introspector/llvm
 cp ../sed_cmds.sh ./oss-fuzz/infra/base-images/base-clang/fuzz-introspector/sed_cmds.sh
 cp -rf ../post-processing ./oss-fuzz/infra/base-images/base-clang/fuzz-introspector/post-processing
 cp -rf ../post-processing ./oss-fuzz/infra/base-images/base-builder/post-processing
+
+cp -rf ../frontends ./oss-fuzz/infra/base-images/base-builder/frontends
 
 # Skip all.sh if CLOUD_BUILD_ENV is set (it is in cloud build).
 if [[ -z ${CLOUD_BUILD_ENV:+dummy} ]]; then
@@ -49,6 +52,7 @@ if [[ -z ${CLOUD_BUILD_ENV:+dummy} ]]; then
   docker build -t gcr.io/oss-fuzz-base/base-clang --build-arg introspector=local infra/base-images/base-clang
   docker build -t gcr.io/oss-fuzz-base/base-builder "$@" infra/base-images/base-builder
   docker build -t gcr.io/oss-fuzz-base/base-runner "$@" infra/base-images/base-runner
+  docker build -t gcr.io/oss-fuzz-base/base-builder-python "$@" infra/base-images/base-builder-python
 
   #./infra/base-images/all.sh
 fi

--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -1,17 +1,124 @@
 diff --git a/infra/base-images/base-builder/Dockerfile b/infra/base-images/base-builder/Dockerfile
-index afaf860e..9cc474df 100644
+index df23f03b..2f1acf9f 100644
 --- a/infra/base-images/base-builder/Dockerfile
 +++ b/infra/base-images/base-builder/Dockerfile
-@@ -162,5 +162,7 @@ COPY cargo compile compile_afl compile_dataflow compile_libfuzzer compile_honggf
+@@ -164,5 +164,8 @@ COPY cargo compile compile_afl compile_dataflow compile_libfuzzer compile_honggf
  COPY llvmsymbol.diff $SRC
  COPY detect_repo.py /opt/cifuzz/
  COPY bazel.bazelrc /root/.bazelrc
 +RUN rm -rf /fuzz-introspector/post-processing
 +COPY post-processing /fuzz-introspector/post-processing
++COPY frontends /fuzz-introspector/frontends
  
  CMD ["compile"]
+diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
+index f783b277..5439780b 100755
+--- a/infra/base-images/base-builder/compile
++++ b/infra/base-images/base-builder/compile
+@@ -18,7 +18,7 @@
+ echo "---------------------------------------------------------------"
+ 
+ # This is a temporary fix: fall back to LLVM14's old pass manager
+-if [ -n "$OLD_LLVMPASS" ]; then
++if [ -n "${OLD_LLVMPASS-}" ]; then
+   export SANITIZER_FLAGS_introspector=$(echo $SANITIZER_FLAGS_introspector | sed -r 's/-O0/-flegacy-pass-manager/')
+ fi
+ 
+@@ -47,8 +47,8 @@ if [ "$FUZZING_LANGUAGE" = "python" ]; then
+     echo "ERROR: Python projects can be fuzzed with libFuzzer engine only."
+     exit 1
+   fi
+-  if [ "$SANITIZER" != "address" ] && [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "coverage" ]; then
+-    echo "ERROR: Python projects can be fuzzed with AddressSanitizer or UndefinedBehaviorSanitizer or Coverage only."
++  if [ "$SANITIZER" != "address" ] && [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "introspector" ]; then
++    echo "ERROR: Python projects can be fuzzed with AddressSanitizer or UndefinedBehaviorSanitizer or Coverage only or Introspector."
+     exit 1
+   fi
+   if [ "$ARCHITECTURE" != "x86_64" ]; then
+@@ -215,11 +215,11 @@ if [ "$SANITIZER" = "introspector" ]; then
+   unset CFLAGS
+   apt-get install -y libjpeg-dev zlib1g-dev
+   pip3 install --upgrade setuptools
+-  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve matplotlib
++  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve matplotlib html5lib
+   mkdir -p $SRC/inspector
+ 
+-  find $SRC/ -name "*.data" -exec cp {} $SRC/inspector/ \;
+-  find $SRC/ -name "*.data.yaml" -exec cp {} $SRC/inspector/ \;
++  find $SRC/ -name "fuzzerLogFile-*.data" -exec cp {} $SRC/inspector/ \;
++  find $SRC/ -name "fuzzerLogFile-*.data.yaml" -exec cp {} $SRC/inspector/ \;
+   # Move coverage report.
+   if [ -d "$OUT/textcov_reports" ]
+   then
+@@ -228,21 +228,29 @@ if [ "$SANITIZER" = "introspector" ]; then
+ 
+   cd $SRC/inspector
+ 
+-  # Correlate fuzzer binaries to fuzz-introspector's raw data
+-  python3 /fuzz-introspector/post-processing/main.py correlate --binaries_dir=$OUT/
+-
+-  # Generate fuzz-introspector HTML report, this generates
+-  # the file exe_to_fuzz_introspector_logs.yaml
+-  REPORT_ARGS="--target_dir=$SRC/inspector"
+-  # Only pass coverage_url when COVERAGE_URL is set (in cloud builds)
+-  if [[ ! -z "${COVERAGE_URL+x}" ]]; then
+-    REPORT_ARGS="$REPORT_ARGS --coverage_url=${COVERAGE_URL}"
++  # Do different things depending on languages
++  if [ "$FUZZING_LANGUAGE" = "python" ]; then
++    python3 /fuzz-introspector/post-processing/main.py report --target_dir=$SRC/inspector
++    cp -rf $SRC/inspector $OUT/inspector
++  else
++    # C/C++
++
++    # Correlate fuzzer binaries to fuzz-introspector's raw data
++    python3 /fuzz-introspector/post-processing/main.py correlate --binaries_dir=$OUT/
++
++    # Generate fuzz-introspector HTML report, this generates
++    # the file exe_to_fuzz_introspector_logs.yaml
++    REPORT_ARGS="--target_dir=$SRC/inspector"
++    # Only pass coverage_url when COVERAGE_URL is set (in cloud builds)
++    if [[ ! -z "${COVERAGE_URL+x}" ]]; then
++      REPORT_ARGS="$REPORT_ARGS --coverage_url=${COVERAGE_URL}"
++    fi
++    # Use the just-generated correlation file
++    REPORT_ARGS="$REPORT_ARGS --correlation_file=exe_to_fuzz_introspector_logs.yaml"
++    python3 /fuzz-introspector/post-processing/main.py report $REPORT_ARGS
++
++    cp -rf $SRC/inspector $OUT/inspector
+   fi
+-  # Use the just-generated correlation file
+-  REPORT_ARGS="$REPORT_ARGS --correlation_file=exe_to_fuzz_introspector_logs.yaml"
+-  python3 /fuzz-introspector/post-processing/main.py report $REPORT_ARGS
+-
+-  cp -rf $SRC/inspector $OUT/inspector
+ fi
+ 
+ if [[ "$FUZZING_ENGINE" = "dataflow" ]]; then
+diff --git a/infra/base-images/base-builder/compile_python_fuzzer b/infra/base-images/base-builder/compile_python_fuzzer
+index e7c7f0a3..8727b935 100755
+--- a/infra/base-images/base-builder/compile_python_fuzzer
++++ b/infra/base-images/base-builder/compile_python_fuzzer
+@@ -24,6 +24,18 @@ fuzzer_package=${fuzzer_basename}.pkg
+ PYFUZZ_WORKPATH=$SRC/pyfuzzworkdir/
+ FUZZ_WORKPATH=$PYFUZZ_WORKPATH/$fuzzer_basename
+ 
++if [[ $SANITIZER = *introspector* ]]; then
++    pip3 install pyyaml
++    rm -rf ./PyCG
++    git clone --depth=1 https://github.com/AdaLogics/PyCG
++    export PYTHONPATH=$PWD/PyCG/
++
++    ARGS="--fuzzer $fuzzer_path"
++    python3 /fuzz-introspector/frontends/python/main.py $ARGS
++    ls -la ./
++    exit 0
++fi
++
+ # In coverage mode prepend coverage logic to the fuzzer source
+ if [[ $SANITIZER = *coverage* ]]; then
+   cat <<EOF > coverage_wrapper.py
 diff --git a/infra/base-images/base-clang/Dockerfile b/infra/base-images/base-clang/Dockerfile
-index fec65ab1..dfe7826e 100644
+index a920bc35..62452ab4 100644
 --- a/infra/base-images/base-clang/Dockerfile
 +++ b/infra/base-images/base-clang/Dockerfile
 @@ -42,6 +42,8 @@ RUN apt-get update && apt-get install -y git && \
@@ -24,10 +131,10 @@ index fec65ab1..dfe7826e 100644
  RUN rm /root/checkout_build_install_llvm.sh
  
 diff --git a/infra/base-images/base-runner/coverage b/infra/base-images/base-runner/coverage
-index 243c7284..e6f0a91c 100755
+index 400247bf..78353d6d 100755
 --- a/infra/base-images/base-runner/coverage
 +++ b/infra/base-images/base-runner/coverage
-@@ -350,5 +350,5 @@ if [[ -n $HTTP_PORT ]]; then
+@@ -399,5 +399,5 @@ if [[ -n $HTTP_PORT ]]; then
    # Serve the report locally.
    echo "Serving the report on http://127.0.0.1:$HTTP_PORT/linux/index.html"
    cd $REPORT_ROOT_DIR

--- a/oss_fuzz_integration/rebuild_post_processing.sh
+++ b/oss_fuzz_integration/rebuild_post_processing.sh
@@ -20,8 +20,13 @@
 # Copy over new post-processing
 rm -rf ./oss-fuzz/infra/base-images/base-builder/post-processing
 cp -rf ../post-processing ./oss-fuzz/infra/base-images/base-builder/post-processing
+
+rm -rf ./oss-fuzz/infra/base-images/base-builder/frontends
+cp -rf ../frontends/ ./oss-fuzz/infra/base-images/base-builder/frontends
+
 cd oss-fuzz
 docker build -t gcr.io/oss-fuzz-base/base-builder "$@" infra/base-images/base-builder
+docker build -t gcr.io/oss-fuzz-base/base-builder-python "$@" infra/base-images/base-builder-python
 
 # Sometimes you may want to rebuild base runner but only rarely.
 # As such, one should provide an argument for that.

--- a/post-processing/analyses/fuzz_calltree_analysis.py
+++ b/post-processing/analyses/fuzz_calltree_analysis.py
@@ -198,7 +198,7 @@ class FuzzCalltreeAnalysis(fuzz_analysis.AnalysisInterface):
         complete_html_string += "</body></html>"
 
         # Beautify and write HTML
-        soup = bs(complete_html_string, 'lxml')
+        soup = bs(complete_html_string, "html.parser")
         pretty_html = soup.prettify()
         with open(filename, "w+") as cf:
             cf.write(pretty_html)

--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -927,7 +927,7 @@ def create_html_report(
                      + html_footer)
 
     # Pretty print the html document
-    soup = bs(html_full_doc, "lxml")
+    soup = bs(html_full_doc, "html.parser")
     prettyHTML = soup.prettify()
 
     # Remove existing html report


### PR DESCRIPTION
This adds a end-to-end Python support without runtime coverage. It
works, but there is one major issue, namely on how to automatically
identify relevant Python files for the AST iteration. This is coming
next.

Ref: https://github.com/ossf/fuzz-introspector/issues/280