### PR TITLE
Update binutils dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ mkdir build
 cd build
 
 # Build binutils
+apt install texinfo
 git clone --depth 1 git://sourceware.org/git/binutils-gdb.git binutils
 mkdir build
 cd ./build


### PR DESCRIPTION
`texinfo` is the required dependency for command `makeinfo` when building binutils