### PR TITLE
Update local example script

### DIFF
--- a/tests/simple-example-0/build_cov.sh
+++ b/tests/simple-example-0/build_cov.sh
@@ -17,7 +17,9 @@
 #rm -rf ./work_cov
 #mkdir work_cov
 #cd work_cov
-cd work
+if [ -d "work" ]; then
+    cd work
+fi
 
 ../../../build/llvm-build/bin/clang -flegacy-pass-manager -fprofile-instr-generate -fcoverage-mapping -fsanitize=fuzzer -g ../fuzzer.c -o fuzzer
 ./fuzzer -max_total_time=3


### PR DESCRIPTION
It seems this script is invoked in dir `work`:
https://github.com/ossf/fuzz-introspector/blob/22822c81cf2cfb0f6bd12e06ac8c14266a333ba4/README.md?plain=1#L189-L194
so it doesn't need `cd work` again.