### PR TITLE
oss-fuzz: add option for quicker build

### DIFF
--- a/oss_fuzz_integration/build_patched_oss_fuzz.sh
+++ b/oss_fuzz_integration/build_patched_oss_fuzz.sh
@@ -48,11 +48,14 @@ if [[ -z ${CLOUD_BUILD_ENV:+dummy} ]]; then
 
   # Only build a subset of the oss-fuzz images because fuzz-introspector
   # only works with C/C++ projets.
-  docker build --pull -t gcr.io/oss-fuzz-base/base-image "$@" infra/base-images/base-image
-  docker build -t gcr.io/oss-fuzz-base/base-clang --build-arg introspector=local infra/base-images/base-clang
-  docker build -t gcr.io/oss-fuzz-base/base-builder "$@" infra/base-images/base-builder
-  docker build -t gcr.io/oss-fuzz-base/base-runner "$@" infra/base-images/base-runner
-  docker build -t gcr.io/oss-fuzz-base/base-builder-python "$@" infra/base-images/base-builder-python
+  # Add an argument to avoid building with base-image and base-clang.
+  if [[ $# -ne 1 ]]; then
+    docker build --pull -t gcr.io/oss-fuzz-base/base-image infra/base-images/base-image
+    docker build -t gcr.io/oss-fuzz-base/base-clang --build-arg introspector=local infra/base-images/base-clang
+  fi
+  docker build -t gcr.io/oss-fuzz-base/base-builder infra/base-images/base-builder
+  docker build -t gcr.io/oss-fuzz-base/base-runner infra/base-images/base-runner
+  docker build -t gcr.io/oss-fuzz-base/base-builder-python infra/base-images/base-builder-python
 
   #./infra/base-images/all.sh
 fi


### PR DESCRIPTION
Enable the option for building from scratch (i.e. clone oss-fuzz and
apply diffs) without needing to build base-image or base-clang.