### PR TITLE
oss-fuzz: install matplotlib using binaries

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -12,7 +12,7 @@ index df23f03b..2f1acf9f 100644
  
  CMD ["compile"]
 diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
-index 1cd367af..bbc35301 100755
+index 1cd367af..2519c94c 100755
 --- a/infra/base-images/base-builder/compile
 +++ b/infra/base-images/base-builder/compile
 @@ -47,8 +47,8 @@ if [ "$FUZZING_LANGUAGE" = "python" ]; then
@@ -26,12 +26,13 @@ index 1cd367af..bbc35301 100755
      exit 1
    fi
    if [ "$ARCHITECTURE" != "x86_64" ]; then
-@@ -215,35 +215,48 @@ if [ "$SANITIZER" = "introspector" ]; then
+@@ -215,35 +215,49 @@ if [ "$SANITIZER" = "introspector" ]; then
    unset CFLAGS
    apt-get install -y libjpeg-dev zlib1g-dev
    pip3 install --upgrade setuptools
 -  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve matplotlib
-+  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve matplotlib html5lib
++  pip3 install cxxfilt pyyaml beautifulsoup4 lxml soupsieve html5lib
++  pip3 install --prefer-binary matplotlib
    mkdir -p $SRC/inspector
  
 -  find $SRC/ -name "*.data" -exec cp {} $SRC/inspector/ \;
@@ -136,10 +137,10 @@ index 82a21cdf..dd907935 100644
  RUN rm /root/checkout_build_install_llvm.sh
  
 diff --git a/infra/base-images/base-runner/coverage b/infra/base-images/base-runner/coverage
-index 400247bf..5f2da460 100755
+index 6b662dbf..a9f7c3d6 100755
 --- a/infra/base-images/base-runner/coverage
 +++ b/infra/base-images/base-runner/coverage
-@@ -310,13 +310,20 @@ elif [[ $FUZZING_LANGUAGE == "python" ]]; then
+@@ -309,13 +309,20 @@ elif [[ $FUZZING_LANGUAGE == "python" ]]; then
      mv $OUT/.coverage_$fuzzer .coverage
      python3 /usr/local/bin/python_coverage_runner_help.py translate /pythoncovmergedfiles/medio
      cp .new_coverage $PYCOVDIR/.coverage_$fuzzer
@@ -160,7 +161,7 @@ index 400247bf..5f2da460 100755
  
    # Create an empty summary file for now
    echo "{}" >> $SUMMARY_FILE
-@@ -399,5 +406,5 @@ if [[ -n $HTTP_PORT ]]; then
+@@ -398,5 +405,5 @@ if [[ -n $HTTP_PORT ]]; then
    # Serve the report locally.
    echo "Serving the report on http://127.0.0.1:$HTTP_PORT/linux/index.html"
    cd $REPORT_ROOT_DIR


### PR DESCRIPTION
This is in contrast to compiling which takes much longer. This should
speedup development quite a bit as testing will go much faster.