### PR TITLE
post-process: reduce logging to debug

### DIFF
--- a/post-processing/fuzz_analysis.py
+++ b/post-processing/fuzz_analysis.py
@@ -178,7 +178,7 @@ def overlay_calltree_with_coverage(
         elif callstack_has_parent(node, callstack):
             # Find the parent function and check coverage of the node
             logger.debug("Extracting data")
-            logger.info(
+            logger.debug(
                 f"Getting hit details {node.dst_function_name} -- "
                 f"{node.cov_ct_idx} -- {node.src_linenumber}"
             )

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -173,7 +173,7 @@ class FuzzerProfile:
                     )
 
             func_profile = FunctionProfile(elem)
-            logger.info(f"Adding {func_profile.function_name}")
+            logger.debug(f"Adding {func_profile.function_name}")
             self.all_class_functions[func_profile.function_name] = func_profile
 
     def resolve_coverage_link(


### PR DESCRIPTION
Reduces two places that spam the log into only being logged when in
debug mode.