### PR TITLE
post-process: analyses: file_path: extend columns in tables

### DIFF
--- a/post-processing/analyses/fuzz_filepath_analyser.py
+++ b/post-processing/analyses/fuzz_filepath_analyser.py
@@ -93,7 +93,8 @@ class FuzzFilepathAnalyser(fuzz_analysis.AnalysisInterface):
             tables[-1],
             [
                 ("Source file", ""),
-                ("Reached by", "")
+                ("Reached by", ""),
+                ("Covered by", "")
             ]
         )
         for fnm in all_proj_files:
@@ -101,10 +102,21 @@ class FuzzFilepathAnalyser(fuzz_analysis.AnalysisInterface):
             for profile in profiles:
                 if profile.reaches_file(fnm, project_profile.basefolder):
                     profiles_that_hit.append(profile.get_key())
+
+            profiles_that_cover = []
+            for profile in profiles:
+                is_file_covered = profile.is_file_covered(
+                    fnm,
+                    project_profile.basefolder
+                )
+                if is_file_covered:
+                    profiles_that_cover.append(profile.get_key())
+
             html_string += fuzz_html_helpers.html_table_add_row(
                 [
                     f"{fnm}",
-                    f"{str(profiles_that_hit)}"
+                    f"{str(profiles_that_hit)}",
+                    f"{str(profiles_that_cover)}"
                 ]
             )
         html_string += "</table>"

--- a/post-processing/analyses/fuzz_filepath_analyser.py
+++ b/post-processing/analyses/fuzz_filepath_analyser.py
@@ -93,10 +93,20 @@ class FuzzFilepathAnalyser(fuzz_analysis.AnalysisInterface):
             tables[-1],
             [
                 ("Source file", ""),
+                ("Reached by" , "")
             ]
         )
         for fnm in all_proj_files:
-            html_string += fuzz_html_helpers.html_table_add_row([f"{fnm}"])
+            profiles_that_hit = []
+            for profile in profiles:
+                if profile.reaches_file(fnm, project_profile.basefolder):
+                    profiles_that_hit.append(profile.get_key())
+            html_string += fuzz_html_helpers.html_table_add_row(
+                [
+                    f"{fnm}",
+                    f"{str(profiles_that_hit)}"
+                ]
+            )
         html_string += "</table>"
 
         # Table with all directories

--- a/post-processing/analyses/fuzz_filepath_analyser.py
+++ b/post-processing/analyses/fuzz_filepath_analyser.py
@@ -93,7 +93,7 @@ class FuzzFilepathAnalyser(fuzz_analysis.AnalysisInterface):
             tables[-1],
             [
                 ("Source file", ""),
-                ("Reached by" , "")
+                ("Reached by", "")
             ]
         )
         for fnm in all_proj_files:

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -258,7 +258,7 @@ class FuzzerProfile:
     def reaches_file(
         self,
         file_name: str,
-        basefolder: Optional[set] = None
+        basefolder: Optional[str] = None
     ) -> bool:
         logger.info(f"Checking up {file_name}")
         if basefolder is not None:

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -393,9 +393,12 @@ class FuzzerProfile:
     ) -> bool:
         # We need to refine the pathname to match how coverage file paths are.
         file_name = os.path.abspath(file_name)
+
         # Refine filename if needed
         if basefolder is not None and basefolder != "/":
-            file_name = file_name.replace(basefolder, "")
+            new_file_name = file_name.replace(basefolder, "")
+        else:
+            new_file_name = file_name
 
         for funcname in self.all_class_functions:
             # Check it's a relevant filename
@@ -404,14 +407,12 @@ class FuzzerProfile:
                 new_func_file_name = func_file_name.replace(basefolder, "")
             else:
                 new_func_file_name = func_file_name
-
-            if func_file_name != file_name and new_func_file_name != file_name:
+            if func_file_name != file_name and new_func_file_name != new_file_name:
                 continue
-
             # Return true if the function is hit
             tf, hl, hp = self.get_cov_metrics(funcname)
             if hp is not None and hp > 0.0:
-                if func_file_name in self.file_targets:
+                if func_file_name in self.file_targets or new_file_name in self.file_targets:
                     return True
         return False
 

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -255,6 +255,20 @@ class FuzzerProfile:
         # TODO: make fuzz-introspector exceptions
         raise Exception
 
+    def reaches_file(
+        self,
+        file_name: str,
+        basefolder: Optional[set] = None
+    ) -> bool:
+        logger.info(f"Checking up {file_name}")
+        if basefolder is not None:
+            file_name = file_name.replace(basefolder, "")
+
+        for ff in self.file_targets:
+            logger.info(f"\t{ff}")
+        logger.info(f"{file_name in self.file_targets}")
+        return file_name in self.file_targets
+
     def reaches(self, func_name: str) -> bool:
         return func_name in self.functions_reached_by_fuzzer
 

--- a/post-processing/fuzz_data_loader.py
+++ b/post-processing/fuzz_data_loader.py
@@ -260,14 +260,16 @@ class FuzzerProfile:
         file_name: str,
         basefolder: Optional[str] = None
     ) -> bool:
-        logger.info(f"Checking up {file_name}")
         if basefolder is not None:
-            file_name = file_name.replace(basefolder, "")
+            new_file_name = file_name.replace(basefolder, "")
+        else:
+            new_file_name = file_name
 
         for ff in self.file_targets:
             logger.info(f"\t{ff}")
-        logger.info(f"{file_name in self.file_targets}")
-        return file_name in self.file_targets
+
+        # Only some file paths have removed base folder. We must check for both.
+        return (file_name in self.file_targets) or (new_file_name in self.file_targets)
 
     def reaches(self, func_name: str) -> bool:
         return func_name in self.functions_reached_by_fuzzer
@@ -383,6 +385,35 @@ class FuzzerProfile:
             if hit_lines == 0:
                 uncovered_funcs.append(funcname)
         return uncovered_funcs
+
+    def is_file_covered(
+        self,
+        file_name: str,
+        basefolder: Optional[str] = None
+    ) -> bool:
+        # We need to refine the pathname to match how coverage file paths are.
+        file_name = os.path.abspath(file_name)
+        # Refine filename if needed
+        if basefolder is not None and basefolder != "/":
+            file_name = file_name.replace(basefolder, "")
+
+        for funcname in self.all_class_functions:
+            # Check it's a relevant filename
+            func_file_name = self.all_class_functions[funcname].function_source_file
+            if basefolder is not None and basefolder != "/":
+                new_func_file_name = func_file_name.replace(basefolder, "")
+            else:
+                new_func_file_name = func_file_name
+
+            if func_file_name != file_name and new_func_file_name != file_name:
+                continue
+
+            # Return true if the function is hit
+            tf, hl, hp = self.get_cov_metrics(funcname)
+            if hp is not None and hp > 0.0:
+                if func_file_name in self.file_targets:
+                    return True
+        return False
 
     def get_cov_metrics(
         self,


### PR DESCRIPTION
Adds more information to the tables which can be used to
understand how the fuzzers target the file structure.