### PR TITLE
Report page: add button with links to per-fuzzer coverage reports

### DIFF
--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -945,7 +945,7 @@ def create_html_report(
     ###########################
     # Fix up table of contents.
     ###########################
-    html_toc_string = fuzz_html_helpers.html_get_table_of_contents(toc_list, coverage_url)
+    html_toc_string = fuzz_html_helpers.html_get_table_of_contents(toc_list, coverage_url, profiles)
 
     # Assemble the final HTML report and write it to a file.
     html_full_doc = (html_header

--- a/post-processing/fuzz_html_helpers.py
+++ b/post-processing/fuzz_html_helpers.py
@@ -21,6 +21,9 @@ from typing import (
     Tuple,
 )
 
+import fuzz_utils
+import fuzz_data_loader
+
 
 def html_table_add_row(elems: List[Any]) -> str:
     html_str = "<tr>\n"
@@ -98,17 +101,53 @@ def html_get_navbar(title: str) -> str:
     return navbar
 
 
+def create_pfc_button(
+        profiles: List[fuzz_data_loader.FuzzerProfile],
+        coverage_url: str) -> str:
+    html_string = ""
+    html_string += """
+                    <div class="yellow-button-wrapper"
+                        style="position: relative; margin: 5px 0 30px 0">
+                        <div class="yellow-button"
+                        onclick="displayCollapseByName()" id="per-fuzzer-coverage-button">
+                            Per-fuzzer coverage
+                        </div>
+                    <div class="per-fuzzer-coverage-dropdown" id="per-fuzzer-coverage-dropdown">"""
+    for profile in profiles:
+        target_name = profile.get_key()
+        target_coverage_url = fuzz_utils.get_target_coverage_url(
+            coverage_url,
+            target_name,
+            profile.target_lang
+        )
+        html_string += f"""
+            <a href="{target_coverage_url}">
+                <div class="pfc-list-item">
+                    {target_name}
+                </div>
+            </a>"""
+    html_string += "</div></div>"
+    return html_string
+
+
 def html_get_table_of_contents(
         toc_list: List[Tuple[str, str, int]],
-        coverage_url: str) -> str:
+        coverage_url: str,
+        profiles: List[fuzz_data_loader.FuzzerProfile]) -> str:
+    per_fuzzer_coverage_button = create_pfc_button(profiles, coverage_url)
     html_toc_string = ""
     html_toc_string += f"""<div class="left-sidebar">\
-                            <div class="left-sidebar-content-box">
-                                <a href="{coverage_url}">
-                                    <div class="yellow-button">
-                                        Coverage report
-                                    </div>
-                                </a>
+                            <div class="left-sidebar-content-box"
+                                style="display:flex;flex-direction:column">
+                                <div class="yellow-button-wrapper"
+                                    style="position: relative; margin: 30px 0 5px 0">
+                                    <a href="{coverage_url}">
+                                        <div class="yellow-button">
+                                            Coverage report
+                                        </div>
+                                    </a>
+                                </div>
+                                {per_fuzzer_coverage_button}
                             </div>
                             <div class="left-sidebar-content-box">\
                                 <h2>Table of contents</h2>"""

--- a/post-processing/styling/custom.js
+++ b/post-processing/styling/custom.js
@@ -5,6 +5,15 @@ $("h1:first").css("padding-left", "0px")
 
 $( document ).ready(function() {
 
+  window.onclick = function(event) {
+    if (!event.target.matches(['#per-fuzzer-coverage-button'])) {
+      var stdCDropdown = document.getElementById("per-fuzzer-coverage-dropdown");
+        if(stdCDropdown.classList.contains("show")) {
+          stdCDropdown.classList.remove("show");
+        }
+      }
+    }
+
     createTables();
 
     // Scroll effect for showing in the menu where you are on the page
@@ -226,4 +235,9 @@ function getClassName(val) {
   }
 
 }
+
+function displayCollapseByName() {
+  document.getElementById("per-fuzzer-coverage-dropdown").classList.toggle("show");
+}
+
 

--- a/post-processing/styling/styles.css
+++ b/post-processing/styling/styles.css
@@ -90,6 +90,7 @@ table.dataTable tbody tr.even {
 	/*border-right: 1px solid #d9d9d9;*/
 	background:  #EBEDEE;
 	position: fixed;
+	height: 100vh;
 }
 .content-section {
 	height: calc(100vh - 70px);
@@ -105,11 +106,13 @@ table.dataTable tbody tr.even {
 	height: calc(100vh - 120px);
 }
 .left-sidebar-content-box {
-	width: calc(350px - 60px);
+	width: calc(350px - 80px);
 	/*position:  fixed;*/
-	top: 70px;
+	position: relative;
+	/*top: 70px;*/
 	padding-left:  20px;
-	overflow-y: auto;
+	padding-right: 20px;
+	/*overflow-y: auto;*/
 	max-height: 100vh;
 	margin: 20px;
 	background: white;
@@ -817,17 +820,19 @@ h1.report-title.collapsed::before {
 	display: none;
 }
 .yellow-button {
-	max-width: 80%;
+	max-width: 100%;
 	background: #FCC200;
 	color: #222;
 	font-size: 18px;
 	padding: 10px;
 	text-align: center;
 	font-weight: 700;
-	margin: 30px 0;
+	/*margin: 30px 0;*/
 }
-.yellow-button:hover {
+.yellow-button:hover,
+.pfc-list-item:hover {
 	background: #f4bc00;
+	cursor: pointer;
 }
 /* Column-selection button: */
 .dt-button.buttons-collection.buttons-colvis {
@@ -837,4 +842,30 @@ h1.report-title.collapsed::before {
 /* Search box for datatables */
 input[type=search] {
 	min-height: 38.58px;
+}
+.per-fuzzer-coverage-dropdown {
+	position: absolute;
+	background: #FCC200;
+	color: #222;
+	top: 100%;
+	left: 0px;
+	display: none;
+	width: 100%;
+}
+.per-fuzzer-coverage-dropdown.show {
+	display: block;
+}
+.per-fuzzer-coverage-button:hover {
+	cursor: pointer;
+}
+.pfc-list-item {
+	font-size: 1.3rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
+	padding: 10px;
+}
+.yellow-button-wrapper {
+	margin: 30px 0;
 }


### PR DESCRIPTION
Adds a drop down button to select per-fuzzer coverage reports in the top left corner.

It might be a nice detail to add the coverage percentage after the fuzzer name if we have that available.

Previews:
![btn1](https://user-images.githubusercontent.com/44787359/176791231-40a58452-76b4-4c98-8f16-0c076fbacb30.jpg)
![btn2](https://user-images.githubusercontent.com/44787359/176791244-409e8252-f521-4722-ba0e-79f6e5847792.jpg)
