### PR TITLE
Report page: Minor improvements

### DIFF
--- a/post-processing/fuzz_html.py
+++ b/post-processing/fuzz_html.py
@@ -317,7 +317,7 @@ def create_collapsible_element(
 
 
 def create_percentage_graph(title: str, percentage: str, numbers: str) -> str:
-    return f"""<div style="flex:1; margin-right: 20px"class="report-box">
+    return f"""<div style="flex:1; margin-right: 20px"class="report-box mt-0">
             <div style="font-weight: 600; text-align: center;">
                 {title}
             </div>
@@ -732,9 +732,12 @@ def extract_highlevel_guidance(conclusions: List[Tuple[int, str]]) -> str:
         else:
             conclusion_color = "green"
         html_string += f"""<div class="line-wrapper">
-    <span class="high-level-conclusion { conclusion_color }-conclusion">
+    <div class="high-level-conclusion { conclusion_color }-conclusion collapsed">
     { sentence }
-    </span>
+        <div class="high-level-extended" style="background:transparent; overflow:hidden">
+            Description
+        </div>
+    </div>
 </div>"""
     html_string += "</div>"
     return html_string
@@ -772,6 +775,7 @@ def create_html_report(
         link="Project-overview"
     )
     project_profile.write_stats_to_summary_file()
+    html_overview += "<div class=\"collapsible\">"
 
     # Project overview
     # html_overview += fuzz_html_helpers.html_add_header_with_link(
@@ -805,6 +809,9 @@ def create_html_report(
         display_coverage=True
     )
     # Boxed summary
+    html_report_core += "</div>"
+
+    # .collapsible
     html_report_core += "</div>"
 
     # report-box

--- a/post-processing/fuzz_html_helpers.py
+++ b/post-processing/fuzz_html_helpers.py
@@ -72,32 +72,21 @@ def html_get_header(calltree: bool = False,
 
 
 def html_get_navbar(title: str) -> str:
-    navbar = f"""<div class="top-navbar">
-    <div class="top-navbar-accordion">
-        <svg
-            viewBox="0 0 24 24"
-            preserveAspectRatio="xMidYMid meet"
-            focusable="false"
-            style="pointer-events: none; display: block; width: 100%; height: 100%;">
-            <g>
-                <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z">
-                </path>
-            </g>
-        </svg>
-    </div>
-    <div class="top-navbar-title-wrapper" style="text-align: center">
-        <div class="top-navbar-title" style="margin-bottom: 10px; font-size:25px">
-            { title }
+    navbar = f"""
+    <div class="top-navbar">
+        <div class="top-navbar-title-wrapper">
+            <div class="top-navbar-title" style="margin-bottom: 10px; font-size:25px">
+                { title }
+            </div>
+            <div style="margin:0; font-size: 10px">
+              For issues and ideas:
+              <a href="https://github.com/ossf/fuzz-introspector/issues"
+                 style="color:#FFFFFF;">
+                https://github.com/ossf/fuzz-introspector/issues
+              </a>
+            </div>
         </div>
-        <div style="margin:0; font-size: 10px">
-          For issues and ideas:
-          <a href="https://github.com/ossf/fuzz-introspector/issues"
-             style="color:#FFFFFF;">
-            https://github.com/ossf/fuzz-introspector/issues
-          </a>
-        </div>
-    </div>
-</div>"""
+    </div>"""
     return navbar
 
 
@@ -138,7 +127,8 @@ def html_get_table_of_contents(
     html_toc_string = ""
     html_toc_string += f"""<div class="left-sidebar">\
                             <div class="left-sidebar-content-box"
-                                style="display:flex;flex-direction:column">
+                                style="display:flex;flex-direction:column;
+                                 padding: 0 20px; margin-top: 30px">
                                 <div class="yellow-button-wrapper"
                                     style="position: relative; margin: 30px 0 5px 0">
                                     <a href="{coverage_url}">
@@ -150,7 +140,7 @@ def html_get_table_of_contents(
                                 {per_fuzzer_coverage_button}
                             </div>
                             <div class="left-sidebar-content-box">\
-                                <h2>Table of contents</h2>"""
+                                <h2 style="margin-top:0px">Table of contents</h2>"""
     for k, v, d in toc_list:
         indentation = d * 16
         html_toc_string += "<div style='margin-left: %spx'>" % indentation

--- a/post-processing/styling/custom.js
+++ b/post-processing/styling/custom.js
@@ -1,9 +1,14 @@
 // TODO AdamKorcz: This is too hacky. It should be handled during code generation.
-$("h1:first").addClass("no-pseudo");
-$("h1:first").css("padding-left", "0px")
+//$("h1:first").addClass("no-pseudo");
+//$("h1:first").css("padding-left", "0px")
 
 
 $( document ).ready(function() {
+
+  $('.high-level-conclusion').click(function(){
+    $(this).toggleClass("collapsed");
+    $(this).find(".high-level-extended").toggleClass("open");
+  })
 
   window.onclick = function(event) {
     if (!event.target.matches(['#per-fuzzer-coverage-button'])) {

--- a/post-processing/styling/styles.css
+++ b/post-processing/styling/styles.css
@@ -61,7 +61,8 @@ table.dataTable tbody tr.even {
 	position: relative;
 	color: white;
 	align-items: center;
-	justify-content: center;
+	/*justify-content: center;*/
+	padding-left: 20px;
 }
 .section-wrapper {
 	width:  calc(100% - 34px);
@@ -109,9 +110,10 @@ table.dataTable tbody tr.even {
 	width: calc(350px - 80px);
 	/*position:  fixed;*/
 	position: relative;
+	display: flex;
+	flex-direction: column;
 	/*top: 70px;*/
-	padding-left:  20px;
-	padding-right: 20px;
+	padding: 20px;
 	/*overflow-y: auto;*/
 	max-height: 100vh;
 	margin: 20px;
@@ -404,10 +406,34 @@ input[type="checkbox"] {
 }
 .high-level-conclusions-wrapper .line-wrapper {
     margin-bottom: 23px;
+    position: relative;
+}
+.line-wrapper:hover {
+	cursor: pointer;
 }
 .high-level-conclusion {
 	border-radius: 5px;
-    padding: 10px 20px;
+  padding: 10px 30px;
+  display: flex;
+  flex-direction: column;
+  max-width: 600px;
+  width: 50%;
+}
+.high-level-conclusion::before {
+	content: "\27A4";
+	transform: rotate(90deg);
+	position: absolute;
+	top: 8px;
+	left: 10px;
+}
+.high-level-conclusion.collapsed::before {
+	content: "\27A4";
+	transform: rotate(0deg);
+	top: 8px;
+	left: 10px;
+}
+.high-level-conclusion.collapsed .high-level-extended {
+	height: 0px;
 }
 .high-level-conclusion.yellow-conclusion {
     background: #fffddb;
@@ -828,6 +854,7 @@ h1.report-title.collapsed::before {
 	text-align: center;
 	font-weight: 700;
 	/*margin: 30px 0;*/
+	margin: 0 auto;
 }
 .yellow-button:hover,
 .pfc-list-item:hover {
@@ -868,4 +895,14 @@ input[type=search] {
 }
 .yellow-button-wrapper {
 	margin: 30px 0;
+}
+/* Buttons for selecting columns in tables */
+div.dt-button-collection button.dt-button:active:not(.disabled), div.dt-button-collection button.dt-button.active:not(.disabled), div.dt-button-collection div.dt-button:active:not(.disabled), div.dt-button-collection div.dt-button.active:not(.disabled), div.dt-button-collection a.dt-button:active:not(.disabled), div.dt-button-collection a.dt-button.active:not(.disabled) {
+	background: #FCC200!important;
+}
+button.dt-button:active:not(.disabled):hover:not(.disabled), button.dt-button.active:not(.disabled):hover:not(.disabled), div.dt-button:active:not(.disabled):hover:not(.disabled), div.dt-button.active:not(.disabled):hover:not(.disabled), a.dt-button:active:not(.disabled):hover:not(.disabled), a.dt-button.active:not(.disabled):hover:not(.disabled), input.dt-button:active:not(.disabled):hover:not(.disabled), input.dt-button.active:not(.disabled):hover:not(.disabled) {
+	background: #f4bc00!important;
+}
+.mt-0 {
+	margin-top: 0px;
 }


### PR DESCRIPTION
Makes several low-profile improvements to the report page UI:

1. Change color of buttons for sorting tables to match the new yellow buttons.
2. Make the high-level conclusions collapsible and add the possibility to add further information.
3. Make the top "Project overview" box collapsible.
4. Minor alignment adjustments.
5. Move the title and link in the top navbar to the left side. This is slightly experimental.

Signed-off-by: AdamKorcz <adam@adalogics.com>