### PR TITLE
src: refactor analysis interface

### DIFF
--- a/src/fuzz_introspector/analyses/bug_digestor.py
+++ b/src/fuzz_introspector/analyses/bug_digestor.py
@@ -28,10 +28,13 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-class FuzzBugDigestorAnalysis(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "BugDigestorAnalysis"
         self.display_html = False
+
+    @staticmethod
+    def get_name():
+        return "BugDigestorAnalysis"
 
     def analysis_func(
         self,
@@ -43,7 +46,7 @@ class FuzzBugDigestorAnalysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[Tuple[int, str]]
     ) -> str:
-        logger.info(f" - Running analysis {self.name}")
+        logger.info(f" - Running analysis {Analysis.get_name()}")
         input_bugs = data_loader.try_load_input_bugs()
         if len(input_bugs) == 0:
             return ""

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        #self.name = "FuzzCalltreeAnalysis"
         logger.info("Creating FuzzCalltreeAnalysis")
 
     @staticmethod

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -36,10 +36,14 @@ from bs4 import BeautifulSoup as bs
 logger = logging.getLogger(name=__name__)
 
 
-class FuzzCalltreeAnalysis(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "FuzzCalltreeAnalysis"
+        #self.name = "FuzzCalltreeAnalysis"
         logger.info("Creating FuzzCalltreeAnalysis")
+
+    @staticmethod
+    def get_name():
+        return "FuzzCalltreeAnalysis"
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -69,7 +69,7 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "<div class=\"collapsible\">"
 
         if fuzz_targets is None or len(fuzz_targets) == 0:
-            A1 = optimal_targets.FuzzOptimalTargetAnalysis()
+            A1 = optimal_targets.Analysis()
 
             _, optimal_target_functions = A1.iteratively_get_optimal_targets(
                 proj_profile

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -39,9 +39,13 @@ TargetCodesType = TypedDict('TargetCodesType', {
 })
 
 
-class FuzzDriverSynthesizerAnalysis(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "FuzzDriverSynthesizerAnalysis"
+        pass
+
+    @staticmethod
+    def get_name():
+        return "FuzzDriverSynthesizerAnalysis"
 
     def analysis_func(
         self,
@@ -54,7 +58,7 @@ class FuzzDriverSynthesizerAnalysis(analysis.AnalysisInterface):
         conclusions: List[Tuple[int, str]],
         fuzz_targets=None
     ) -> str:
-        logger.info(f" - Running analysis {self.name}")
+        logger.info(f" - Running analysis {Analysis.get_name()}")
         html_string = ""
         html_string += "<div class=\"report-box\">"
         html_string += html_helpers.html_add_header_with_link(
@@ -174,5 +178,5 @@ class FuzzDriverSynthesizerAnalysis(analysis.AnalysisInterface):
 
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
-        logger.info(f" - Completed analysis {self.name}")
+        logger.info(f" - Completed analysis {Analysis.get_name()}")
         return html_string

--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -35,10 +35,13 @@ from fuzz_introspector.datatypes import (
 logger = logging.getLogger(name=__name__)
 
 
-class FuzzEngineInputAnalysis(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "FuzzEngineInputAnalysis"
         self.display_html = False
+
+    @staticmethod
+    def get_name():
+        return "FuzzEngineInputAnalysis"
 
     def analysis_func(
         self,
@@ -50,7 +53,7 @@ class FuzzEngineInputAnalysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[Tuple[int, str]]
     ) -> str:
-        logger.info(f" - Running analysis {self.name}")
+        logger.info(f" - Running analysis {Analysis.get_name()}")
 
         if not self.display_html:
             toc_list = []
@@ -91,7 +94,7 @@ class FuzzEngineInputAnalysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        logger.info(f" - Completed analysis {self.name}")
+        logger.info(f" - Completed analysis {Analysis.get_name()}")
         if not self.display_html:
             html_string = ""
 
@@ -144,7 +147,7 @@ class FuzzEngineInputAnalysis(analysis.AnalysisInterface):
             toc_list
         )
 
-        calltree_analysis = cta.FuzzCalltreeAnalysis()
+        calltree_analysis = cta.Analysis()
         fuzz_blockers = calltree_analysis.get_fuzz_blockers(
             profile,
             max_blockers_to_extract=10

--- a/src/fuzz_introspector/analyses/filepath_analyser.py
+++ b/src/fuzz_introspector/analyses/filepath_analyser.py
@@ -29,9 +29,13 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-class FuzzFilepathAnalyser(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "FilePathAnalyser"
+        pass
+
+    @staticmethod
+    def get_name():
+        return "FilePathAnalyser"
 
     def all_files_targeted(
         self,
@@ -53,7 +57,7 @@ class FuzzFilepathAnalyser(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[Tuple[int, str]]
     ) -> str:
-        logger.info(f" - Running analysis {self.name}")
+        logger.info(f" - Running analysis {Analysis.get_name()}")
 
         all_proj_files = self.all_files_targeted(proj_profile)
         all_proj_dirs = set()

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -37,9 +37,13 @@ from fuzz_introspector.datatypes import (
 logger = logging.getLogger(name=__name__)
 
 
-class FuzzOptimalTargetAnalysis(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "OptimalTargets"
+        pass
+
+    @staticmethod
+    def get_name():
+        return "OptimalTargets"
 
     def analysis_func(
         self,
@@ -64,7 +68,7 @@ class FuzzOptimalTargetAnalysis(analysis.AnalysisInterface):
         any fuzzers. This means it can be used to expand the current fuzzing harness
         rather than substitute it.
         """
-        logger.info(f" - Running analysis {self.name}")
+        logger.info(f" - Running analysis {Analysis.get_name()}")
 
         html_string = ""
         html_string += html_helpers.html_add_header_with_link(
@@ -92,7 +96,7 @@ class FuzzOptimalTargetAnalysis(analysis.AnalysisInterface):
             basefolder
         )
 
-        logger.info(f" - Completed analysis {self.name}")
+        logger.info(f" - Completed analysis {Analysis.get_name()}")
         html_string += "</div>"  # .collapsible
         return html_string
 

--- a/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
+++ b/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
@@ -29,9 +29,13 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-class FuzzRuntimeCoverageAnalysis(analysis.AnalysisInterface):
+class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
-        self.name = "RuntimeCoverageAnalysis"
+        pass
+
+    @staticmethod
+    def get_name():
+        return "RuntimeCoverageAnalysis"
 
     def analysis_func(
         self,
@@ -43,7 +47,7 @@ class FuzzRuntimeCoverageAnalysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[Tuple[int, str]]
     ) -> str:
-        logger.info(f" - Running analysis {self.name}")
+        logger.info(f" - Running analysis {Analysis.get_name()}")
 
         functions_of_interest = self.get_low_cov_high_line_funcs(
             profiles,
@@ -103,7 +107,7 @@ class FuzzRuntimeCoverageAnalysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        logger.info(f" - Completed analysis {self.name}")
+        logger.info(f" - Completed analysis {Analysis.get_name()}")
         return html_string
 
     def get_low_cov_high_line_funcs(

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -63,6 +63,10 @@ class AnalysisInterface(abc.ABC):
         """Return name of analysis"""
         pass
 
+    @staticmethod
+    def instantiate(cls: Type[AnalysisInterface]):
+        cls()
+
 
 class BlockedSide(Enum):
     TRUE = 1

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -65,7 +65,7 @@ class AnalysisInterface(abc.ABC):
         pass
 
     @staticmethod
-    def instantiate(cls: Type[AnalysisInterface]):
+    def instantiate(cls: Type[AnalysisInterface]):  # noqa: F821
         cls()
 
 

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -64,9 +64,9 @@ class AnalysisInterface(abc.ABC):
         """Return name of analysis"""
         pass
 
-    @staticmethod
-    def instantiate(cls: Type[AnalysisInterface]):  # noqa: F821
-        cls()
+def instantiate_analysis_interface(cls: Type[AnalysisInterface]):
+    """Wrapper function to satisfy Mypy semantics"""
+    return cls()
 
 
 class BlockedSide(Enum):

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -57,6 +57,12 @@ class AnalysisInterface(abc.ABC):
         """Core analysis function."""
         pass
 
+    @staticmethod
+    @abc.abstractmethod
+    def get_name():
+        """Return name of analysis"""
+        pass
+
 
 class BlockedSide(Enum):
     TRUE = 1
@@ -88,12 +94,12 @@ def get_all_analyses() -> List[AnalysisInterface]:
     )
 
     analysis_array = [
-        optimal_targets.FuzzOptimalTargetAnalysis(),
-        engine_input.FuzzEngineInputAnalysis(),
-        runtime_coverage_analysis.FuzzRuntimeCoverageAnalysis(),
-        driver_synthesizer.FuzzDriverSynthesizerAnalysis(),
-        bug_digestor.FuzzBugDigestorAnalysis(),
-        filepath_analyser.FuzzFilepathAnalyser()
+        optimal_targets,
+        engine_input,
+        runtime_coverage_analysis,
+        driver_synthesizer,
+        bug_digestor,
+        filepath_analyser
     ]
     return analysis_array
 

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -94,12 +94,12 @@ def get_all_analyses() -> List[AnalysisInterface]:
     )
 
     analysis_array = [
-        optimal_targets,
-        engine_input,
-        runtime_coverage_analysis,
-        driver_synthesizer,
-        bug_digestor,
-        filepath_analyser
+        optimal_targets.Analysis,
+        engine_input.Analysis,
+        runtime_coverage_analysis.Analysis,
+        driver_synthesizer.Analysis,
+        bug_digestor.Analysis,
+        filepath_analyser.Analysis
     ]
     return analysis_array
 

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -24,6 +24,7 @@ from typing import (
     Dict,
     List,
     Tuple,
+    Type,
 )
 
 from fuzz_introspector import utils
@@ -86,7 +87,7 @@ class FuzzBranchBlocker:
         self.function_name = fname
 
 
-def get_all_analyses() -> List[AnalysisInterface]:
+def get_all_analyses() -> List[Type[AnalysisInterface]]:
     # Ordering here is important as top analysis will be shown first in the report
     from fuzz_introspector.analyses import (
         driver_synthesizer,

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -64,6 +64,7 @@ class AnalysisInterface(abc.ABC):
         """Return name of analysis"""
         pass
 
+
 def instantiate_analysis_interface(cls: Type[AnalysisInterface]):
     """Wrapper function to satisfy Mypy semantics"""
     return cls()

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -900,7 +900,7 @@ def create_html_report(
     analysis_array = analysis.get_all_analyses()
     for analysis_interface in analysis_array:
         if analysis_interface.get_name() in analyses_to_run:
-            analysis_instance = analysis_interface()
+            analysis_instance = analysis.AnalysisInterface.instantiate(analysis_interface)
             html_report_core += analysis_instance.analysis_func(
                 toc_list,
                 tables,

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -900,7 +900,9 @@ def create_html_report(
     analysis_array = analysis.get_all_analyses()
     for analysis_interface in analysis_array:
         if analysis_interface.get_name() in analyses_to_run:
-            analysis_instance = analysis.AnalysisInterface.instantiate(analysis_interface)
+            analysis_instance = analysis.instantiate_analysis_interface(
+                analysis_interface
+            )
             html_report_core += analysis_instance.analysis_func(
                 toc_list,
                 tables,

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -547,7 +547,7 @@ def create_fuzzer_detailed_section(
     )
 
     from fuzz_introspector.analyses import calltree_analysis as cta
-    calltree_analysis = cta.FuzzCalltreeAnalysis()
+    calltree_analysis = cta.Analysis()
     calltree_file_name = calltree_analysis.create_calltree(profile)
 
     html_string += f"""<p class='no-top-margin'>The following link provides a visualisation
@@ -899,15 +899,17 @@ def create_html_report(
 
     analysis_array = analysis.get_all_analyses()
     for analysis_interface in analysis_array:
-        if analysis_interface.name in analyses_to_run:
-            html_report_core += analysis_interface.analysis_func(
+        if analysis_interface.Analysis.get_name() in analyses_to_run:
+            analysis_instance = analysis_interface.Analysis()
+            html_report_core += analysis_instance.analysis_func(
                 toc_list,
                 tables,
                 proj_profile,
                 profiles,
                 basefolder,
                 coverage_url,
-                conclusions)
+                conclusions
+            )
     html_report_core += "</div>"  # .collapsible
     html_report_core += "</div>"  # report box
 

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -899,8 +899,8 @@ def create_html_report(
 
     analysis_array = analysis.get_all_analyses()
     for analysis_interface in analysis_array:
-        if analysis_interface.Analysis.get_name() in analyses_to_run:
-            analysis_instance = analysis_interface.Analysis()
+        if analysis_interface.get_name() in analyses_to_run:
+            analysis_instance = analysis_interface()
             html_report_core += analysis_instance.analysis_func(
                 toc_list,
                 tables,

--- a/src/main.py
+++ b/src/main.py
@@ -47,15 +47,10 @@ def run_analysis_on_dir(
     language: str
 ) -> int:
     if enable_all_analyses:
-        all_analyses = [
-            "OptimalTargets",
-            "RuntimeCoverageAnalysis",
-            "FuzzDriverSynthesizerAnalysis",
-            "FuzzEngineInputAnalysis"
-        ]
+        all_anlaysis = analysis.get_all_analyses()
         for analysis_interface in all_analyses:
-            if analysis_interface not in analyses_to_run:
-                analyses_to_run.append(analysis_interface)
+            if analysis_interface.Analysis.get_name() not in analyses_to_run:
+                analyses_to_run.append(analysis_interface.Analysis.get_name())
 
     logger.info("[+] Loading profiles")
     profiles = data_loader.load_all_profiles(target_folder, language)

--- a/src/main.py
+++ b/src/main.py
@@ -48,8 +48,8 @@ def run_analysis_on_dir(
 ) -> int:
     if enable_all_analyses:
         for analysis_interface in analysis.get_all_analyses():
-            if analysis_interface.Analysis.get_name() not in analyses_to_run:
-                analyses_to_run.append(analysis_interface.Analysis.get_name())
+            if analysis_interface.get_name() not in analyses_to_run:
+                analyses_to_run.append(analysis_interface.get_name())
 
     logger.info("[+] Loading profiles")
     profiles = data_loader.load_all_profiles(target_folder, language)

--- a/src/main.py
+++ b/src/main.py
@@ -47,8 +47,7 @@ def run_analysis_on_dir(
     language: str
 ) -> int:
     if enable_all_analyses:
-        all_anlaysis = analysis.get_all_analyses()
-        for analysis_interface in all_analyses:
+        for analysis_interface in analysis.get_all_analyses():
             if analysis_interface.Analysis.get_name() not in analyses_to_run:
                 analyses_to_run.append(analysis_interface.Analysis.get_name())
 


### PR DESCRIPTION
Adds a static method for naming a given analysis. The idea is that it
becomes easier to extend because defining a new analysis no longer
requires specifying the name of the analysis multiple places.

This is aimed at making
https://github.com/ossf/fuzz-introspector/issues/384 more clear.