### PR TITLE
UI: Remove operation in calltree + other small changes

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -90,6 +90,9 @@ class Analysis(analysis.AnalysisInterface):
             else:
                 func_href = ""
 
+            # indentation in html:
+            indentation = "%dpx" % (int(node.depth) * 16 + 100)
+
             if i > 0:
                 previous_node = nodes[i - 1]
                 if previous_node.depth == node.depth:
@@ -103,7 +106,7 @@ class Analysis(analysis.AnalysisInterface):
             calltree_html_string += f"""
     <div class="{color_to_be}-background coverage-line">
         <span class="coverage-line-inner" data-calltree-idx="{ct_idx_str}"
-        data-paddingleft="{int(node.depth)}">
+        data-paddingleft="{indentation}" style="padding-left: {indentation}">
             <span class="node-depth-wrapper">{node.depth}</span>
             <code class="language-clike">
                 {demangled_name}
@@ -122,7 +125,7 @@ class Analysis(analysis.AnalysisInterface):
                 if next_node.depth > node.depth:
                     calltree_html_string += f"""<div
         class="calltree-line-wrapper open level-{int(node.depth)}
-        data-paddingleft="{int(node.depth)}">"""
+        data-paddingleft="{indentation}" >"""
                 elif next_node.depth < node.depth:
                     depth_diff = int(node.depth - next_node.depth)
                     calltree_html_string += "</div>" * depth_diff

--- a/src/fuzz_introspector/styling/calltree.js
+++ b/src/fuzz_introspector/styling/calltree.js
@@ -2,7 +2,6 @@ var StdCFuncNames;
 StdCFuncNames = ["free", "abort", "malloc", "calloc", "exit", "memcmp", "strlen"]
 
 
-
 $( document ).ready(function() {
     $('.coverage-line-inner').click(function(){
       var wrapper = $(this).closest(".calltree-line-wrapper");
@@ -109,6 +108,7 @@ function isDescendant(parent, child) {
 function addFuzzBlockerLines() {
   var coverageLines;
   coverageLines = document.getElementsByClassName("coverage-line-inner");
+  var allDataIdx = document.querySelectorAll('[data-foo="value"]');
   for(var j=0;j<coverageLines.length;j++) {
     var thisDataIdx = coverageLines[j].getAttribute("data-calltree-idx");
     if(thisDataIdx!==null && fuzz_blocker_idxs.includes(thisDataIdx)) {
@@ -139,7 +139,6 @@ function createNavBar() {
 
   // Add buttons to the navbar
   addBackButton(e)
-  addShowIdxButton(e);
   addExpandAllBtn(e);
   addCollapseAllBtn(e);
   addStdCDropdown(e);
@@ -222,16 +221,6 @@ function addBackButton(parentElement) {
   backBtnInner.innerText = "< Back to report";
   backBtn.prepend(backBtnInner);
   parentElement.prepend(backBtn);
-}
-
-// Adds the show-idx btn to "parentElement"
-function addShowIdxButton(parentElement) {  
-  let btn = document.createElement("span");
-  btn.classList.add("calltree-nav-btn");
-  btn.classList.add("active");
-  btn.id = "show-idx-button"
-  btn.innerText = "show idx";
-  parentElement.append(btn);
 }
 
 // Adds the expand all btn to "parentElement"
@@ -332,12 +321,6 @@ function addNavbarClickEffects() {
   // Click click effects for hide/show std c funcs
   createStdCClickeffects();
 
-  // Other click effects
-  $('#show-idx-button').click(function(){
-    $(this).toggleClass("active");
-    $(".calltree-idx").toggleClass("hidden");
-  });
-
   $("#expand-all-button").click(function(){
     $(".calltree-line-wrapper").each(function( index ) {
       if(!$(this).hasClass("open")) {
@@ -406,11 +389,7 @@ function hideNodesWithText(text) {
 }
 
 function addExpandSymbols() {
-  $( ".coverage-line-inner").each(function( index ) {
-    console.log("Setting padding-left:")
-    $(this).css('padding-left', function() {
-      return $(this).data('paddingleft')*16+100;
-    });
+  $(".coverage-line-inner").each(function( index ) {
     var numberOfSubNodes = $(this).closest(".coverage-line").find(".coverage-line-inner").length
     if(numberOfSubNodes>1) {
       $(this).addClass("collapse-symbol");
@@ -458,5 +437,5 @@ function tabLineHover() {
         $(parent).removeClass("hovered");
       }
     }
-});
+  });
 }

--- a/src/fuzz_introspector/styling/styles.css
+++ b/src/fuzz_introspector/styling/styles.css
@@ -502,6 +502,12 @@ input[type="checkbox"] {
 .report-box table {
 	max-width:  100%;
 }
+.report-box h1 {
+	-webkit-user-select: none; /* Safari */        
+	-moz-user-select: none; /* Firefox */
+	-ms-user-select: none; /* IE10+/Edge */
+	user-select: none; /* Standard */
+}
 
 /*********************************************/
 /********** Circular charts ******************/
@@ -623,6 +629,7 @@ input[type="checkbox"] {
 	position: relative;
 	display: block;
 	max-width: 80%;
+	padding-left: attr(data-paddingleft px)
 }
 .coverage-line-inner.fontsize10px {
 	font-size: 10px;


### PR DESCRIPTION
- Removes operation of setting the `padding-left` attribute of nodes in the javascript. This can be done in the backend instead for efficiency.
- Removes "Show IDX" button. This feature is deprecated.
- Makes titles in report page non-highlightable. It is not userfriendly to click the title to expand it, and then you highlight it at the same time.

Signed-off-by: AdamKorcz <Adam@adalogics.com>