### PR TITLE
Calltree page: Make callsite links scroll on page

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -279,16 +279,13 @@ class Analysis(analysis.AnalysisInterface):
         )
         for node in fuzz_blockers:
             link_prefix = "0" * (5 - len(str(node.cov_ct_idx)))
-            node_link = "%s?scrollToNode=%s%s" % (
-                calltree_file_name,
-                link_prefix,
-                node.cov_ct_idx
-            )
+            node_id = "%s%s" % (link_prefix, node.cov_ct_idx)
             html_table_string += html_helpers.html_table_add_row([
                 str(node.cov_forward_reds),
                 str(node.cov_ct_idx),
                 node.cov_parent,
-                f"<a href={node_link}>call site</a>",
+                f"""<span class=\"text-link\"
+                 onclick=\"scrollToNodeInCT('{node_id}')\">call site</span>""",
                 node.cov_largest_blocked_func
             ])
         html_table_string += "</table>"

--- a/src/fuzz_introspector/styling/calltree.js
+++ b/src/fuzz_introspector/styling/calltree.js
@@ -92,6 +92,17 @@ function scrollOnLoad() {
   }
 }
 
+// Scrolls to a node
+function scrollToNodeInCT(nodeId) {
+  var dataValue = "[data-calltree-idx='"+nodeId+"']";
+  var elementToScrollTo = document.querySelector(dataValue);
+  if(elementToScrollTo===null) {
+    return
+  }
+  elementToScrollTo.style.background = "#ffe08c";
+  elementToScrollTo.scrollIntoView({behavior: "smooth", block: "center"})
+}
+
 // Checks whether child is a descendant of parent.
 function isDescendant(parent, child) {
   var node = child.parentNode;

--- a/src/fuzz_introspector/styling/styles.css
+++ b/src/fuzz_introspector/styling/styles.css
@@ -941,3 +941,10 @@ button.dt-button:active:not(.disabled):hover:not(.disabled), button.dt-button.ac
 .mt-0 {
 	margin-top: 0px;
 }
+.text-link {
+	font-weight: 650;
+	color: #FCC200;
+}
+.text-link:hover {
+	cursor: pointer;
+}


### PR DESCRIPTION
Currently, the callsite links in table in the top of the calltree page will reload the page and then scroll to the callsite id.

This PR changes that behaviour to scroll on-page without reloading.

Signed-off-by: AdamKorcz <Adam@adalogics.com>