### PR TITLE
Calltree page: Make buttons yellow

### DIFF
--- a/src/fuzz_introspector/styling/styles.css
+++ b/src/fuzz_introspector/styling/styles.css
@@ -599,20 +599,24 @@ input[type="checkbox"] {
 .calltree-navbar .calltree-nav-btn {
 	height: calc(100% - 14px);
 	width: auto;
-	padding: 5px;
-	color: #7d7d7d;
-	background: white;
+	padding: 10px;
+	color: #222;
+	/*background: white;*/
+	background: #FCC200;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	border-radius: 4px;
-	border:  1px solid #c9c9c9;
+	/*border-radius: 4px;*/
+	/*border:  1px solid #c9c9c9;*/
 	min-width: 30px;
 	font-size: .8rem;
-	font-weight: 550;
+	font-weight: 700;
 	margin-right: 5px;
 	cursor: pointer;
 	transition: .2s ease-out;
+}
+.calltree-navbar .calltree-nav-btn:hover {
+	background: #f4bc00;
 }
 .calltree-navbar .calltree-nav-btn.active {	
 	color: #b800f0;
@@ -698,27 +702,28 @@ input[type="checkbox"] {
 }
 /* Dropdown Button */
 .dropbtn {
-  height: 100%;
+  height: 41px;
 	width: auto;
-	padding: 5px;
-	color: #7d7d7d;
-	background: white;
+	padding: 10px;
+	color: #222;
+	background: #FCC200;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	border-radius: 4px;
-	border:  1px solid #c9c9c9;
+	/*border-radius: 4px;
+	border:  1px solid #c9c9c9;*/
 	min-width: 30px;
 	font-size: .8rem;
-	font-weight: 550;
+	font-weight: 700;
 	margin-right: 5px;
 	cursor: pointer;
 	transition: .2s ease-out;
+	border: none;
 }
 
 /* Dropdown button on hover & focus */
 .dropbtn:hover, .dropbtn:focus {
-  background-color: #2980B9;
+  background-color: #f4bc00;
 }
 
 /* The container <div> - needed to position the dropdown content */
@@ -748,12 +753,16 @@ input[type="checkbox"] {
 }
 .fontsize-option {
 	padding: 10px 20px;
+	background: #FCC200;
+}
+.fontsize-option:hover {
+	background: #f4bc00;
 }
 .fontsize-option.active {
 	background: #5bb0b5!important;
 }
 .fontsize-option:hover {
-	background: #edfeff;
+	background: #f4bc00;
 	cursor:  pointer;
 }
 
@@ -780,9 +789,11 @@ input[type="checkbox"] {
 }
 .checkbox-line-wrapper {
 	padding: 5px 10px;
+	background: #FCC200;
+	font-size: .8rem;
 }
 .checkbox-line-wrapper:hover {
-	background: #edfeff;
+	background: #f4bc00;
 	cursor:  pointer;
 }
 .coverage-line-inner.hidden {


### PR DESCRIPTION
Makes the butons on the calltree page yellow like the buttons on the report page.

Signed-off-by: AdamKorcz <Adam@adalogics.com>