### PR TITLE
Fix coverage URL in calltree regressions.

### DIFF
--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -89,14 +89,14 @@ class FuzzerProfile:
     ) -> str:
         """Resolves a link to a coverage report."""
         if self.target_lang == "c-cpp":
-            self._resolve_c_cpp_coverage_link(
+            return self._resolve_c_cpp_coverage_link(
                 cov_url,
                 source_file,
                 lineno,
                 function_name
             )
         elif self.target_lang == "python":
-            self._resolve_python_coverage_link(
+            return self._resolve_python_coverage_link(
                 cov_url,
                 source_file,
                 lineno,

--- a/src/test/test_fuzzer_profile.py
+++ b/src/test/test_fuzzer_profile.py
@@ -1,0 +1,69 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test datatypes/fuzzer_profile.py"""
+
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../")
+
+from fuzz_introspector.datatypes import fuzzer_profile
+
+
+@pytest.fixture
+def sample_cfg1():
+    """Fixture for a sample (shortened paths) calltree"""
+    cfg_str = """Call tree
+LLVMFuzzerTestOneInput /src/wuffs/fuzz/c/fuzzlib/fuzzlib.c linenumber=-1
+  llvmFuzzerTestOneInput /src/wuffs/fuzz/c/../fuzzlib/fuzzlib.c linenumber=93
+    jenkins_hash_u32 /src/wuffs/fuzz/c/std/../fuzzlib/fuzzlib.c linenumber=67
+    jenkins_hash_u32 /src/wuffs/fuzz/c/std/../fuzzlib/fuzzlib.c linenumber=68
+    wuffs_base__ptr_u8__reader /src/wuffs/fuzz/...-snapshot.c linenumber=72
+    fuzz /src/wuffs/fuzz/c/std/bmp_fuzzer.c linenumber=74"""
+    return cfg_str
+
+
+def test_coverage_url(tmpdir, sample_cfg1):
+    """Basic test for coverage URL"""
+    # Write the CFG
+    cfg_path = os.path.join(tmpdir, "test_file.data")
+    with open(cfg_path, "w") as f:
+        f.write(sample_cfg1)
+
+    fake_frontend_yaml = {
+        "Fuzzer filename" : "/src/wuffs/fuzz/c/fuzzlib/fuzzlib.c",
+        "All functions" : {
+            "Elements" : []
+        }
+    }
+
+    fp = fuzzer_profile.FuzzerProfile(
+        os.path.join(tmpdir, "test_file.data"),
+        fake_frontend_yaml,
+        "c-cpp"
+    )
+
+    cov_link = fp.resolve_coverage_link(
+        "https://coverage-url.com/",
+        "fuzzlib/fuzzlib.c",
+        13,
+        "function_name"
+    )
+
+    # Explicitly ensure the coverage URL is set
+    assert cov_link != "#"
+
+    # Ensure the coverage URL is correct
+    assert "https://coverage-url.com/fuzzlib/fuzzlib.c.html#L13" == cov_link


### PR DESCRIPTION
Fixes regression in coverage url extraction which caused all coverage URLs in calltree to be "#". Adds a unit test to catch the regression.