### PR TITLE
Avoid adding extra / to functionSourceFile

### DIFF
--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -531,7 +531,6 @@ std::string FuzzIntrospector::getFunctionFilename(Function *F) {
   StringRef Dir;
   StringRef Res;
 
-  int Found = 0;
   for (auto &I : instructions(*F)) {
     const llvm::DebugLoc &DebugInfo = I.getDebugLoc();
     if (DebugInfo) {
@@ -541,16 +540,16 @@ std::string FuzzIntrospector::getFunctionFilename(Function *F) {
       // errs() << "Line number: " << debugInfo.getLine() << "\n";
       Dir = Scope->getDirectory();
       Res = Scope->getFilename();
-      Found = 1;
       break;
     }
   }
 
   SmallString<256> *CurrentDir = new SmallString<256>();
-  if (Found)
+  if (Dir.size()) {
     CurrentDir->append(Dir);
-  CurrentDir->append("/");
-  if (Found)
+    CurrentDir->append("/");
+  }
+  if (Res.size())
     CurrentDir->append(Res);
 
   StringRef s4 = CurrentDir->str();

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -85,7 +85,7 @@ class Analysis(analysis.AnalysisInterface):
             ct_idx_str = self.create_str_node_ctx_idx(str(node.cov_ct_idx))
 
             # Only display [function] link if we have, otherwhise show no [function] text.
-            if node.dst_function_source_file.replace(" ", "") != "/":
+            if node.dst_function_source_file.replace(" ", "") != "":
                 func_href = f"""<a href="{link}">[function]</a>"""
             else:
                 func_href = ""

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -224,7 +224,7 @@ class MergedProjectProfile:
         """
         all_strs = []
         for f in self.all_functions.values():
-            if f.function_source_file == "/":
+            if f.function_source_file == "":
                 continue
             if "/usr/include/" in f.function_source_file:
                 continue


### PR DESCRIPTION
As a result of this, if LLVM pass cannot find source info, functionSourceFile will be empty string instead of "/".
The changes have been made to handle such cases.
Fixes #362 