### PR TITLE
Correctly load per-fuzzer coverage

### DIFF
--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -58,10 +58,6 @@ def run_analysis_on_dir(
     input_bugs = data_loader.try_load_input_bugs()
     logger.info(f"[+] Loaded {len(input_bugs)} bugs")
 
-    logger.info("[+] Accummulating profiles")
-    for profile in profiles:
-        profile.accummulate_profile(target_folder)
-
     logger.info("[+] Correlating executables to Fuzz introspector reports")
     correlation_dict = utils.data_file_read_yaml(correlation_file)
     if correlation_dict is not None and "pairings" in correlation_dict:
@@ -69,6 +65,10 @@ def run_analysis_on_dir(
             profile.correlate_executable_name(correlation_dict)
     else:
         logger.info("- Nothing to correlate")
+
+    logger.info("[+] Accummulating profiles")
+    for profile in profiles:
+        profile.accummulate_profile(target_folder)
 
     logger.info("[+] Creating project profile")
     proj_profile = project_profile.MergedProjectProfile(profiles)

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -343,7 +343,7 @@ class FuzzerProfile:
         if self.target_lang == "c-cpp":
             self.coverage = code_coverage.load_llvm_coverage(
                 target_folder,
-                self._get_target_fuzzer_filename()
+                self.identifier
             )
         elif self.target_lang == "python":
             self.coverage = code_coverage.load_python_json_coverage(
@@ -355,7 +355,8 @@ class FuzzerProfile:
             )
 
     def _get_target_fuzzer_filename(self) -> str:
-        return self.fuzzer_source_file.split("/")[-1].replace(".cpp", "").replace(".c", "")
+        return (os.path.basename(self.fuzzer_source_file).replace(".cpp", "")
+                .replace(".cc", "").replace(".c", ""))
 
     def _set_file_targets(self) -> None:
         """Sets self.file_targets to be a dictionarty of string to string.


### PR DESCRIPTION
Fixes #424 

@DavidKorczynski I noticed you were doing the correlation, just had to do it before accumulating fuzzer, so the executable name is set and used correctly via `profile.identifier`.