### PR TITLE
html_report: add warning box

### DIFF
--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -741,8 +741,8 @@ def create_fuzzer_detailed_section(
 
     if total_hit_functions > reachable_funcs:
         html_string += (
-            "<div class=\"high-level-conclusions-wrapper\">"
-            "<span class=\"high-level-conclusion red-conclusion\">"
+            "<div class=\"warning-box-wrapper\">"
+            "<span class=\"warning-box red-warning\">"
             "<b>Warning:</b> The number of covered functions are larger than the "
             "number of reachable functions. This means that there are more functions covered at "
             "runtime than are extracted using static analysis. This is likely a result "

--- a/src/fuzz_introspector/styling/styles.css
+++ b/src/fuzz_introspector/styling/styles.css
@@ -465,6 +465,37 @@ input[type="checkbox"] {
     background: #eaffd4;
     color: #3b7300;
 }
+
+.warning-box-wrapper {
+	display: flex;
+	flex-direction: column;
+}
+.warning-box-wrapper .line-wrapper {
+    margin-bottom: 23px;
+    position: relative;
+}
+.warning-box {
+	border-radius: 5px;
+  padding: 10px 30px;
+  display: flex;
+  flex-direction: column;
+  max-width: 600px;
+  width: 50%;
+}
+.warning-box.yellow-warning {
+    background: #fffddb;
+    color: #916f00;
+}
+.warning-box.red-warning {
+    background: #ffd7d4;
+    color: #820900;
+}
+.warning-box.green-warning {
+    background: #eaffd4;
+    color: #3b7300;
+}
+
+
 .colormap {
 	width: 100%;
 }


### PR DESCRIPTION
Substitute the use of conclusion box in cases where it is in fact not a
conclusion.

Fixes: https://github.com/ossf/fuzz-introspector/issues/429