### PR TITLE
html_report: fix link to callsite node from main page

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -179,7 +179,7 @@ class Analysis(analysis.AnalysisInterface):
             profile,
             [],
             "",
-            fuzz_blockers = fuzz_blockers
+            fuzz_blockers=fuzz_blockers
         )
         if fuzz_blocker_table is not None:
             complete_html_string += "<div class=\"report-box\">"

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -175,7 +175,12 @@ class Analysis(analysis.AnalysisInterface):
             max_blockers_to_extract=12
         )
 
-        fuzz_blocker_table = self.create_fuzz_blocker_table(profile, [], "", fuzz_blockers)
+        fuzz_blocker_table = self.create_fuzz_blocker_table(
+            profile,
+            [],
+            "",
+            fuzz_blockers = fuzz_blockers
+        )
         if fuzz_blocker_table is not None:
             complete_html_string += "<div class=\"report-box\">"
             complete_html_string += "<h1>Fuzz blockers</h1>"
@@ -241,7 +246,8 @@ class Analysis(analysis.AnalysisInterface):
         profile: fuzzer_profile.FuzzerProfile,
         tables: List[str],
         calltree_file_name: str,
-        fuzz_blockers: Optional[List[cfg_load.CalltreeCallsite]] = None
+        fuzz_blockers: Optional[List[cfg_load.CalltreeCallsite]] = None,
+        file_link: Optional[str] = None
     ) -> Optional[str]:
         """
         Creates HTML string for table showing fuzz blockers.
@@ -282,12 +288,23 @@ class Analysis(analysis.AnalysisInterface):
         for node in fuzz_blockers:
             link_prefix = "0" * (5 - len(str(node.cov_ct_idx)))
             node_id = "%s%s" % (link_prefix, node.cov_ct_idx)
+            if file_link is not None:
+                cs_link = (
+                    "<span class=\"text-link\">"
+                    f"<a href=\"{file_link}?scrollToNode={node_id}\">call site"
+                    "</a></span>"
+                )
+            else:
+                cs_link = (
+                    "<span class=\"text-link\" "
+                    f"onclick=\" scrollToNodeInCT('{node_id}')\">"
+                    "call site</span>"
+                )
             html_table_string += html_helpers.html_table_add_row([
                 str(node.cov_forward_reds),
                 str(node.cov_ct_idx),
                 node.cov_parent,
-                f"""<span class=\"text-link\"
-                 onclick=\"scrollToNodeInCT('{node_id}')\">call site</span>""",
+                cs_link,
                 node.cov_largest_blocked_func
             ])
         html_table_string += "</table>"

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -601,7 +601,7 @@ def create_fuzzer_detailed_section(
         profile,
         tables,
         calltree_file_name,
-        file_link = calltree_file_name
+        file_link=calltree_file_name
     )
     if html_fuzz_blocker_table is not None:
         html_string += html_helpers.html_add_header_with_link(

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -600,7 +600,8 @@ def create_fuzzer_detailed_section(
     html_fuzz_blocker_table = calltree_analysis.create_fuzz_blocker_table(
         profile,
         tables,
-        calltree_file_name
+        calltree_file_name,
+        file_link = calltree_file_name
     )
     if html_fuzz_blocker_table is not None:
         html_string += html_helpers.html_add_header_with_link(

--- a/src/fuzz_introspector/styling/calltree.js
+++ b/src/fuzz_introspector/styling/calltree.js
@@ -69,12 +69,13 @@ $( document ).ready(function() {
     }, false);
   }
   
-  // if "scrollToNode" was passed to the URL, scroll:
-  scrollOnLoad();
-
   tabLineHover();
 
   addImageOverview();
+
+  // if "scrollToNode" was passed to the URL, scroll:
+  // This should be in the last bit to ensure all loading is done beforehand.
+  scrollOnLoad();
 });
 
 function addImageOverview() {
@@ -106,9 +107,8 @@ function scrollOnLoad() {
     if(elementToScrollTo===null) {
       return
     }
-    var offset = elementToScrollTo.getBoundingClientRect();
     elementToScrollTo.style.background = "#ffe08c";
-    document.querySelector(".calltree-content-section").scrollTop = offset.top-500;
+    elementToScrollTo.scrollIntoView({behavior: "smooth", block: "center"})
   }
 }
 


### PR DESCRIPTION
Loading a specific callsite is done by way of URL parameters from a page
different than calltree.html.

Fixes: https://github.com/ossf/fuzz-introspector/issues/430