### PR TITLE
oss-fuzz: exclude llvm-symbolizer

### DIFF
--- a/oss_fuzz_integration/get_full_coverage.py
+++ b/oss_fuzz_integration/get_full_coverage.py
@@ -56,11 +56,15 @@ def get_fuzzers(project_name):
     execs = []
     for l in os.listdir("build/out/%s"%(project_name)):
         print("Checking %s"%(l))
+        if l in {'llvm-symbolizer', 'sanitizer_with_fuzzer.so'}:
+            continue
+        if l.startswith('jazzer_'):
+            continue
         complete_path = os.path.join("build/out/%s"%(project_name), l)
         executable = (os.path.isfile(complete_path) and os.access(complete_path, os.X_OK))
         if executable:
             execs.append(l)
-    print("Executable files: %s"%(str(execs)))
+    print("Fuzz targets: %s"%(str(execs)))
     return execs
 
 


### PR DESCRIPTION
to prevent the script from running it as a fuzz target and getting
```
Running llvm-symbolizer
...
/out/llvm-symbolizer -rss_limit_mb=2560 -timeout=25 -max_total_time=20 -detect_leaks=0 /tmp/llvm-symbolizer_corpus < /dev/null^M
error: unknown argument '-r'^M
error: unknown argument '-_'^M
error: unknown argument '-l'^M
error: unknown argument '-m'^M
...
Executing finished with exception
```