### PR TITLE
oss-fuzz: allow setting ports explicitly

### DIFF
--- a/oss_fuzz_integration/run_both.sh
+++ b/oss_fuzz_integration/run_both.sh
@@ -19,6 +19,8 @@
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 PROJ=$1
+PORT=${FUZZ_INTROSPECTOR_PORT:-8008}
+
 # Pass all arguments to get_full_coverage.py
 python3 ${SCRIPT_DIR}/get_full_coverage.py $@
 python3 ./infra/helper.py build_fuzzers --sanitizer=introspector $PROJ
@@ -31,7 +33,7 @@ cp -rf ./corpus-$LATEST_CORPUS_DIR/report/ ./corpus-$LATEST_CORPUS_DIR/inspector
 # We need to allow the following to fail because it will do so for Python projects
 cp -rf ./corpus-$LATEST_CORPUS_DIR/report_target/* ./corpus-$LATEST_CORPUS_DIR/inspector-report/covreport/ || true
 
-echo "If all worked, then you should be able to start a webserver at port 8008 in ./corpus-${LATEST_CORPUS_DIR}/inspector-report/"
+echo "If all worked, then you should be able to start a webserver at port $PORT in ./corpus-${LATEST_CORPUS_DIR}/inspector-report/"
 cd ./corpus-${LATEST_CORPUS_DIR}/inspector-report/
-python3 -m http.server 8008
-echo "Use the following command to initialize a webserver in the directory: cd ./corpus-${LATEST_CORPUS_DIR}/inspector-report/ && python3 -m http.server 8008"
+python3 -m http.server "$PORT"
+echo "Use the following command to initialize a webserver in the directory: cd ./corpus-${LATEST_CORPUS_DIR}/inspector-report/ && python3 -m http.server $PORT"

--- a/oss_fuzz_integration/run_both.sh
+++ b/oss_fuzz_integration/run_both.sh
@@ -33,7 +33,6 @@ cp -rf ./corpus-$LATEST_CORPUS_DIR/report/ ./corpus-$LATEST_CORPUS_DIR/inspector
 # We need to allow the following to fail because it will do so for Python projects
 cp -rf ./corpus-$LATEST_CORPUS_DIR/report_target/* ./corpus-$LATEST_CORPUS_DIR/inspector-report/covreport/ || true
 
-echo "If all worked, then you should be able to start a webserver at port $PORT in ./corpus-${LATEST_CORPUS_DIR}/inspector-report/"
+echo "The following command is about to be run to start a webserver: cd ./corpus-${LATEST_CORPUS_DIR}/inspector-report/ && python3 -m http.server $PORT"
 cd ./corpus-${LATEST_CORPUS_DIR}/inspector-report/
 python3 -m http.server "$PORT"
-echo "Use the following command to initialize a webserver in the directory: cd ./corpus-${LATEST_CORPUS_DIR}/inspector-report/ && python3 -m http.server $PORT"


### PR DESCRIPTION
to avoid collisions in general and make it easier to run the script in VMs/containers where only certain ports are forwarded.

I went with the environment variable because I wasn't sure how to keep the script working with `project time --jobs=...`.

I also dropped a redundant command. It isn't run anyway because the server is either interrupted with Ctrl-C
or fails with something like "OSError: [Errno 98] Address already in
use".