### PR TITLE
function profile: quick fix

### DIFF
--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -52,7 +52,10 @@ class FunctionProfile:
         self.branch_profiles = self.load_func_branch_profiles(elem['BranchProfiles'])
 
         # Saving callsites for this function
-        self.callsite = self.load_func_callsites(elem['Callsites'])
+        try:
+            self.callsite = self.load_func_callsites(elem['Callsites'])
+        except Exception:
+            self.callsite = []
 
         # These are set later.
         self.hitcount: int = 0

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -55,7 +55,7 @@ class FunctionProfile:
         try:
             self.callsite = self.load_func_callsites(elem['Callsites'])
         except Exception:
-            self.callsite = []
+            self.callsite = dict()
 
         # These are set later.
         self.hitcount: int = 0


### PR DESCRIPTION
Fixes: https://github.com/ossf/fuzz-introspector/issues/476

The issue happens when the underlying clang is out of sync with the post
processing part, because the "Callsites" element is not available in the
older clang frontend. We should, however, support a more safe loading
anyways.