### PR TITLE
oss-fuzz/test_projects: add dbus-broker

### DIFF
--- a/oss_fuzz_integration/README.md
+++ b/oss_fuzz_integration/README.md
@@ -94,7 +94,7 @@ directory:
 sudo docker system prune -a
 
 # Rebuild images using local set up
-./build_patched_oss_fuzz.sh
+./build_all_custom_images.sh
 
 # Test fuzz-introspector against various projects
 cd oss-fuzz

--- a/oss_fuzz_integration/test_projects.py
+++ b/oss_fuzz_integration/test_projects.py
@@ -86,7 +86,8 @@ def main_loop():
         "tarantool",
         "fio",
         "wuffs",
-        "c-ares"
+        "c-ares",
+        "dbus-broker",
     ]
 
     build_results = []


### PR DESCRIPTION
to mostly make sure that projects using meson are buildable.

It can also eventually be used to make sure that filenames are normalized consistently but it should be put on hold until https://github.com/ossf/fuzz-introspector/issues/471 is fixed.