### PR TITLE
analysis plugins: add metadata plugin

### DIFF
--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -1,0 +1,105 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis for showing metadata"""
+
+import os
+import logging
+
+from typing import (
+    List,
+    Tuple,
+)
+
+from fuzz_introspector import analysis
+from fuzz_introspector import html_helpers
+from fuzz_introspector.datatypes import (
+    project_profile,
+    fuzzer_profile,
+)
+
+logger = logging.getLogger(name=__name__)
+
+
+class Analysis(analysis.AnalysisInterface):
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def get_name():
+        return "MetadataAnalysis"
+
+    def analysis_func(
+        self,
+        toc_list: List[Tuple[str, str, int]],
+        tables: List[str],
+        project_profile: project_profile.MergedProjectProfile,
+        profiles: List[fuzzer_profile.FuzzerProfile],
+        basefolder: str,
+        coverage_url: str,
+        conclusions: List[html_helpers.HTMLConclusion]
+    ) -> str:
+        logger.info(f" - Running analysis {Analysis.get_name()}")
+
+        html_string = ""
+        html_string += "<div class=\"report-box\">"
+        html_string += html_helpers.html_add_header_with_link(
+            "Metadata section",
+            1,
+            toc_list
+        )
+        html_string += "<div class=\"collapsible\">"
+        html_string += """<p>This sections shows the raw data that is used
+        to produce this report. This is mainly used for further processing
+        and developer debugging.</p>
+        """
+        html_string += "<p>"
+        tables.append(f"myTable{len(tables)}")
+        html_string += html_helpers.html_create_table_head(
+            tables[-1],
+            [
+                ("Fuzzer", ""),
+                ("Calltree file", ""),
+                ("Program data file", ""),
+                ("Coverage file", "")
+            ]
+        )
+        for profile in profiles:
+            base_datafile = os.path.basename(profile.introspector_data_file)
+            base_yamlfile = os.path.basename(profile.introspector_data_file + ".yaml")
+            coverage_file_link_str = ""
+            for idx in range(len(profile.coverage.coverage_files)):
+                cov_prof = profile.coverage.coverage_files[idx]
+                cov_prof = os.path.basename(cov_prof)
+                coverage_file_link_str += f"<a href=\"{cov_prof}\">{cov_prof}</a>"
+                if idx < len(profile.coverage.coverage_files)-1:
+                    coverage_file_link_str += ","
+                
+
+            html_string += html_helpers.html_table_add_row(
+                [
+                    profile.identifier,
+                    f"<a href=\"{base_datafile}\">{base_datafile}</a>",
+                    f"<a href=\"{base_yamlfile}\">{base_yamlfile}</a>",
+                    f"{coverage_file_link_str}"
+                ]
+            )
+
+        html_string += "</p>"
+
+        html_string += "</div>"  # .collapsible
+        html_string += "</div>"  # report-box
+
+        logger.info(f" - Completed analysis {Analysis.get_name()}")
+
+        return html_string

--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -75,6 +75,8 @@ class Analysis(analysis.AnalysisInterface):
             ]
         )
         for profile in profiles:
+            if profile.coverage is None:
+                continue
             base_datafile = os.path.basename(profile.introspector_data_file)
             base_yamlfile = os.path.basename(profile.introspector_data_file + ".yaml")
             coverage_file_link_str = ""
@@ -82,9 +84,8 @@ class Analysis(analysis.AnalysisInterface):
                 cov_prof = profile.coverage.coverage_files[idx]
                 cov_prof = os.path.basename(cov_prof)
                 coverage_file_link_str += f"<a href=\"{cov_prof}\">{cov_prof}</a>"
-                if idx < len(profile.coverage.coverage_files)-1:
+                if idx < len(profile.coverage.coverage_files) - 1:
                     coverage_file_link_str += ","
-                
 
             html_string += html_helpers.html_table_add_row(
                 [

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -129,7 +129,8 @@ def get_all_analyses() -> List[Type[AnalysisInterface]]:
         runtime_coverage_analysis,
         bug_digestor,
         filepath_analyser,
-        function_call_analyser
+        function_call_analyser,
+        metadata
     )
 
     analysis_array = [
@@ -139,7 +140,8 @@ def get_all_analyses() -> List[Type[AnalysisInterface]]:
         driver_synthesizer.Analysis,
         bug_digestor.Analysis,
         filepath_analyser.Analysis,
-        function_call_analyser.Analysis
+        function_call_analyser.Analysis,
+        metadata.Analysis
     ]
     return analysis_array
 

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -51,6 +51,7 @@ class CoverageProfile:
         self.file_map: Dict[str, List[Tuple[int, int]]] = dict()
         self.branch_cov_map: Dict[str, Tuple[int, int]] = dict()
         self._cov_type = ""
+        self.coverage_files = []
 
     def set_type(self, cov_type: str) -> None:
         self._cov_type = cov_type
@@ -242,6 +243,7 @@ def load_llvm_coverage(
         if found_name is not None and found_name not in profile_file:
             continue
 
+        cp.coverage_files.append(profile_file)
         logger.info(f"Reading coverage report: {profile_file}")
         with open(profile_file, 'rb') as pf:
             curr_func = None

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -51,7 +51,7 @@ class CoverageProfile:
         self.file_map: Dict[str, List[Tuple[int, int]]] = dict()
         self.branch_cov_map: Dict[str, Tuple[int, int]] = dict()
         self._cov_type = ""
-        self.coverage_files = []
+        self.coverage_files: List[str] = []
 
     def set_type(self, cov_type: str) -> None:
         self._cov_type = cov_type

--- a/src/main.py
+++ b/src/main.py
@@ -52,7 +52,8 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
             "OptimalTargets",
             "RuntimeCoverageAnalysis",
             "FuzzEngineInputAnalysis",
-            "FilePathAnalyser"
+            "FilePathAnalyser",
+            "MetadataAnalysis"
         ],
         help="""
             Analyses to run. Available options:


### PR DESCRIPTION
Display the data used for constructing the fuzzing report.

Includes links to .covreport, .data, .data.yaml

Ref: https://github.com/ossf/fuzz-introspector/issues/485

Build logs will come at a later stage.