### PR TITLE
src: remove individual levels for logging

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -40,7 +40,6 @@ from fuzz_introspector.datatypes import (
 from fuzz_introspector.exceptions import AnalysisError
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class AnalysisInterface(abc.ABC):

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -25,7 +25,6 @@ from typing import (
 from fuzz_introspector import utils
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class CoverageProfile:

--- a/src/fuzz_introspector/data_loader.py
+++ b/src/fuzz_introspector/data_loader.py
@@ -37,7 +37,6 @@ from fuzz_introspector.datatypes import (
 from fuzz_introspector.exceptions import DataLoaderError
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 def read_fuzzer_data_file_to_profile(

--- a/src/fuzz_introspector/datatypes/branch_profile.py
+++ b/src/fuzz_introspector/datatypes/branch_profile.py
@@ -24,7 +24,6 @@ from typing import (
 from fuzz_introspector import utils
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class BranchProfile:

--- a/src/fuzz_introspector/datatypes/bug.py
+++ b/src/fuzz_introspector/datatypes/bug.py
@@ -16,7 +16,6 @@
 import logging
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class Bug:

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -25,7 +25,6 @@ from fuzz_introspector.datatypes import branch_profile
 from fuzz_introspector import utils
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class FunctionProfile:

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -33,7 +33,6 @@ from fuzz_introspector.datatypes import function_profile
 from fuzz_introspector.exceptions import DataLoaderError
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class FuzzerProfile:

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -27,7 +27,6 @@ from fuzz_introspector import utils
 from fuzz_introspector.datatypes import function_profile, fuzzer_profile
 
 logger = logging.getLogger(name=__name__)
-logger.setLevel(logging.INFO)
 
 
 class MergedProjectProfile:


### PR DESCRIPTION
avoid having individual modules setting log level but use the global setting instead.

Signed-off-by: David Korczynski <david@adalogics.com>