### PR TITLE
oss-fuzz: fix testing set up

### DIFF
--- a/oss_fuzz_integration/project_checker.py
+++ b/oss_fuzz_integration/project_checker.py
@@ -155,7 +155,7 @@ def check_project_html_sanity(html_report):
             url_begin_pos = line.find('"', line_pos)
             url_end_pos = line.find('"', url_begin_pos+1)
             url = line[url_begin_pos+1:url_end_pos]
-            if url.startswith("http"):
+            if url.startswith("http://") or url.startswith("https://"):
                 status = requests.head(url)
                 if status.status_code != 200:
                     print("Faulty URL: %s"%url)

--- a/oss_fuzz_integration/test_projects.py
+++ b/oss_fuzz_integration/test_projects.py
@@ -24,7 +24,7 @@ import project_checker
 SCRIPT_DIR = os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
 
 OSS_FUZZ_HELPER = os.path.realpath(os.getcwd()) + "/infra/helper.py"
-COV_HELPER      = SCRIPT_DIR + "/get_full_coverage.py"
+COV_HELPER      = SCRIPT_DIR + "/runner.py"
 PROJ_CHECK      = SCRIPT_DIR + "/project-checker.py"
 
 # find next test dir
@@ -40,6 +40,7 @@ def run_full_cov(project):
     cmd = []
     cmd.append("python3")
     cmd.append(COV_HELPER)
+    cmd.append("coverage")
     cmd.append(project)
     cmd.append("10") # seconds to run
 


### PR DESCRIPTION
Fixes naming of oss-fuzz runner and also restricts URL checking. The URL checking is necessary to restrict to more precisely describe URLs, as I ran into an issue with the following "`<a href="http`" check from `tarantool`:
```
<a href="http_parser_fuzzer.covreport">
```
which gives the following exception
```
requests.exceptions.MissingSchema: Invalid URL 'http_parser_fuzzer.covreport': No schema supplied. Perhaps you meant http://http_parser_fuzzer.covreport?
```