### PR TITLE
Fix location of main.py for simple test

### DIFF
--- a/tests/build_simple_example.sh
+++ b/tests/build_simple_example.sh
@@ -21,10 +21,10 @@ for PROJ in simple-example-0; do
   rm -rf ./web
 
   ./build_all.sh
-  python3 ${ROOT}/../post-processing/main.py correlate --binaries_dir=./work/
+  python3 ${ROOT}/../src/main.py correlate --binaries_dir=./work/
   #exit 0
   ./build_cov.sh || true
   mkdir web
   cd web
-  python3 ${ROOT}/../post-processing/main.py report --correlation_file=../exe_to_fuzz_introspector_logs.yaml --target_dir=../
+  python3 ${ROOT}/../src/main.py report --correlation_file=../exe_to_fuzz_introspector_logs.yaml --target_dir=../
 done


### PR DESCRIPTION
For this test, the location of main.py is in src instead of post-processing (post-processing doesn't exist in the main branch).

Signed-off-by: Jordy Zomer <jordy@pwning.systems>