### PR TITLE
Incorporate unique function complexity to rank branch blockers

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -16,6 +16,8 @@
 import os
 import logging
 import json
+import random
+import string
 
 from typing import (
     Dict,
@@ -33,6 +35,8 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 
 # For pretty printing the html code:
 from bs4 import BeautifulSoup as bs
+
+from fuzz_introspector.html_report import create_collapsible_element
 
 logger = logging.getLogger(name=__name__)
 
@@ -379,6 +383,9 @@ class Analysis(analysis.AnalysisInterface):
         if len(branch_blockers) == 0:
             return None
 
+        random_suffix = '_' + ''.join(
+            random.choices(string.ascii_lowercase + string.ascii_uppercase, k=7))
+
         blockers_node_map = self.collect_calltree_nodes(branch_blockers,
                                                         profile.function_call_depths)
 
@@ -388,9 +395,12 @@ class Analysis(analysis.AnalysisInterface):
         html_table_string += html_helpers.html_create_table_head(
             tables[-1],
             [
-                ("Blocked Complexity",
+                ("Unique Blocked Complexity", "Cyclomatic Complexity of the not-yet-covered functions reachable by the blocked branch side."),
+                ("Unique Reachable Complexities", "Cyclomatic Complexity of the functions reachable by the blocked branch side."),
+                ("Unique Reachable Functions", "List of functions that only the blocked branch side can reach."),
+                ("All Blocked Complexity",
                  "Cyclomatic Complexity that is not covered because of blockage."),
-                ("Reachable Complexity",
+                ("All Reachable Complexity",
                  "Cyclomatic Complexity that the blocked branch-side can reach."),
                 ("Function Name",
                  "Function containing the blocked branch."),
@@ -420,8 +430,18 @@ class Analysis(analysis.AnalysisInterface):
                     f"onclick=\" scrollToNodeInCT('{node_id}')\">"
                     "call site</span>"
                 )
-
+            collapsible_id = entry.source_file + entry.blocked_side_line_numder + random_suffix
+            func_num = len(entry.blocked_unique_funcs)
+            if func_num > 0:
+                collapsible_string = create_collapsible_element(func_num, 
+                                                                entry.blocked_unique_funcs,
+                                                                collapsible_id)
+            else:
+                collapsible_string = "None"
             html_table_string += html_helpers.html_table_add_row([
+                str(entry.blocked_unique_not_covered_complexity),
+                str(entry.blocked_unique_reachable_complexity),
+                collapsible_string,
                 str(entry.blocked_not_covered_complexity),
                 str(entry.blocked_reachable_complexity),
                 utils.demangle_cpp_func(entry.function_name),

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -395,10 +395,14 @@ class Analysis(analysis.AnalysisInterface):
         html_table_string += html_helpers.html_create_table_head(
             tables[-1],
             [
-                ("Unique Blocked Complexity", "Cyclomatic Complexity of the not-yet-covered functions reachable by the blocked branch side."),
-                ("Unique Reachable Complexities", "Cyclomatic Complexity of the functions reachable by the blocked branch side."),
-                ("Unique Reachable Functions", "List of functions that only the blocked branch side can reach."),
-                ("All Blocked Complexity",
+                ("Unique non-covered Complexity",
+                 "Cyclomatic Complexity of not-yet-covered functions reachable "
+                 "by the blocked branch side."),
+                ("Unique Reachable Complexities",
+                 "Cyclomatic Complexity of the functions reachable by the blocked branch side."),
+                ("Unique Reachable Functions",
+                 "List of functions that only the blocked branch side can reach."),
+                ("All non-covered Complexity",
                  "Cyclomatic Complexity that is not covered because of blockage."),
                 ("All Reachable Complexity",
                  "Cyclomatic Complexity that the blocked branch-side can reach."),
@@ -433,7 +437,7 @@ class Analysis(analysis.AnalysisInterface):
             collapsible_id = entry.source_file + entry.blocked_side_line_numder + random_suffix
             func_num = len(entry.blocked_unique_funcs)
             if func_num > 0:
-                collapsible_string = create_collapsible_element(func_num, 
+                collapsible_string = create_collapsible_element(str(func_num),
                                                                 entry.blocked_unique_funcs,
                                                                 collapsible_id)
             else:

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -469,7 +469,7 @@ def detect_branch_level_blockers(
             side_line = llvm_branch.branch_true_side_pos
             side_line_number = side_line.split(':')[1].split(',')[0]
             blocked_unique_funcs = list(
-                llvm_branch.get_side_unique_reachable_funcnames(bp.BranchSide.TRUE))
+                llvm_branch.get_side_unique_reachable_funcnames(blocked_side))
         elif true_hitcount != 0 and false_hitcount == 0:
             blocked_side = bp.BranchSide.FALSE
             blocked_unique_not_covered_com = (
@@ -480,7 +480,7 @@ def detect_branch_level_blockers(
             side_line = llvm_branch.branch_false_side_pos
             side_line_number = side_line.split(':')[1].split(',')[0]
             blocked_unique_funcs = list(
-                llvm_branch.get_side_unique_reachable_funcnames(bp.BranchSide.FALSE))
+                llvm_branch.get_side_unique_reachable_funcnames(blocked_side))
 
         if blocked_side:
             # Sanity check on line numbers: anomaly can happen because of debug info inaccuracy

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -470,7 +470,7 @@ def detect_branch_level_blockers(
             blocked_not_covered_com = llvm_branch.branch_true_side_not_covered_complexity
             side_line = llvm_branch.branch_true_side_pos
             side_line_number = side_line.split(':')[1].split(',')[0]
-            blocked_unique_funcs = (
+            blocked_unique_funcs = list(
                 llvm_branch.get_side_unique_reachable_funcnames(bp.BranchSide.TRUE))
         elif true_hitcount != 0 and false_hitcount == 0:
             blocked_side = bp.BranchSide.FALSE
@@ -481,7 +481,7 @@ def detect_branch_level_blockers(
             blocked_not_covered_com = llvm_branch.branch_false_side_not_covered_complexity
             side_line = llvm_branch.branch_false_side_pos
             side_line_number = side_line.split(':')[1].split(',')[0]
-            blocked_unique_funcs = (
+            blocked_unique_funcs = list(
                 llvm_branch.get_side_unique_reachable_funcnames(bp.BranchSide.FALSE))
 
         if blocked_side:

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -19,7 +19,6 @@ import logging
 import os
 import re
 
-from enum import Enum
 
 from typing import (
     Dict,
@@ -36,7 +35,8 @@ from fuzz_introspector import html_helpers
 from fuzz_introspector.datatypes import (
     project_profile,
     fuzzer_profile,
-    function_profile
+    function_profile,
+    branch_profile as bp
 )
 from fuzz_introspector.exceptions import AnalysisError
 
@@ -103,15 +103,14 @@ def instantiate_analysis_interface(cls: Type[AnalysisInterface]):
     return cls()
 
 
-class BlockedSide(Enum):
-    TRUE = 1
-    FALSE = 2
-
-
 class FuzzBranchBlocker:
-    def __init__(self, side, not_cov_comp, reach_comp, hitcount_diff, filename, b_line, s_line,
-                 fname, link) -> None:
+    def __init__(self, side, unique_not_cov_comp, unique_reach_comp, unique_funcs,
+                 not_cov_comp, reach_comp, hitcount_diff, filename, b_line, s_line, fname,
+                 link) -> None:
         self.blocked_side = side
+        self.blocked_unique_not_covered_complexity = unique_not_cov_comp
+        self.blocked_unique_reachable_complexity = unique_reach_comp
+        self.blocked_unique_funcs = unique_funcs
         self.blocked_not_covered_complexity = not_cov_comp
         self.blocked_reachable_complexity = reach_comp
         self.sides_hitcount_diff = hitcount_diff
@@ -353,17 +352,20 @@ def overlay_calltree_with_coverage(
                                                            target_coverage_url)
     logger.info(f"[+] found {len(profile.branch_blockers)} branch blockers.")
     branch_blockers_list = []
-    for br_blocker in profile.branch_blockers:
+    for blk in profile.branch_blockers:
         branch_blockers_list.append(
             {
-                'blocked_side': repr(br_blocker.blocked_side),
-                'blocked_not_covered_complexity': br_blocker.blocked_not_covered_complexity,
-                'blocked_reachable_complexity': br_blocker.blocked_reachable_complexity,
-                'sides_hitcount_diff': br_blocker.sides_hitcount_diff,
-                'source_file': br_blocker.source_file,
-                'branch_line_number': br_blocker.branch_line_number,
-                'blocked_side_line_numder': br_blocker.blocked_side_line_numder,
-                'function_name': br_blocker.function_name
+                'blocked_side': repr(blk.blocked_side),
+                'blocked_unique_not_covered_complexity': blk.blocked_unique_not_covered_complexity,
+                'blocked_unique_reachable_complexity': blk.blocked_unique_reachable_complexity,
+                'blocked_unique_functions': blk.blocked_unique_funcs,
+                'blocked_not_covered_complexity': blk.blocked_not_covered_complexity,
+                'blocked_reachable_complexity': blk.blocked_reachable_complexity,
+                'sides_hitcount_diff': blk.sides_hitcount_diff,
+                'source_file': blk.source_file,
+                'branch_line_number': blk.branch_line_number,
+                'blocked_side_line_numder': blk.blocked_side_line_numder,
+                'function_name': blk.function_name
             }
         )
     utils.write_to_summary_file(profile.identifier, 'branch_blockers', branch_blockers_list)
@@ -377,27 +379,41 @@ def update_branch_complexities(all_functions: Dict[str, function_profile.Functio
     """
     for func_k, func in all_functions.items():
         for branch_k, branch in func.branch_profiles.items():
+            branch.branch_false_side_unique_not_covered_complexity = 0
+            branch.branch_false_side_unique_reachable_complexity = 0
+            branch.branch_true_side_unique_not_covered_complexity = 0
+            branch.branch_true_side_unique_reachable_complexity = 0
             branch.branch_false_side_reachable_complexity = 0
             branch.branch_true_side_reachable_complexity = 0
             branch.branch_false_side_not_covered_complexity = 0
             branch.branch_true_side_not_covered_complexity = 0
+            false_side_funcs = branch.get_side_unique_reachable_funcnames(bp.BranchSide.FALSE)
+            true_side_funcs = branch.get_side_unique_reachable_funcnames(bp.BranchSide.TRUE)
+            # Iterate over the list of funcs instead of set, because we want to account
+            # for the complexity of repeating functions.
             for fn in branch.branch_false_side_funcs:
                 if fn not in all_functions or BLOCKLISTED_COMPLEXITY_FUNCS.match(fn):
                     continue
-                branch.branch_false_side_reachable_complexity += (
-                    all_functions[fn].total_cyclomatic_complexity)
+                new_comp = all_functions[fn].total_cyclomatic_complexity
+                branch.branch_false_side_reachable_complexity += new_comp
+                if fn in false_side_funcs:
+                    branch.branch_false_side_unique_reachable_complexity += new_comp
                 if coverage.is_func_hit(fn) is False:
-                    branch.branch_false_side_not_covered_complexity += (
-                        all_functions[fn].total_cyclomatic_complexity)
+                    branch.branch_false_side_not_covered_complexity += new_comp
+                    if fn in false_side_funcs:
+                        branch.branch_false_side_unique_not_covered_complexity += new_comp
 
             for fn in branch.branch_true_side_funcs:
                 if fn not in all_functions or BLOCKLISTED_COMPLEXITY_FUNCS.match(fn):
                     continue
-                branch.branch_true_side_reachable_complexity += (
-                    all_functions[fn].total_cyclomatic_complexity)
+                new_comp = all_functions[fn].total_cyclomatic_complexity
+                branch.branch_true_side_reachable_complexity += new_comp
+                if fn in true_side_funcs:
+                    branch.branch_true_side_unique_reachable_complexity += new_comp
                 if coverage.is_func_hit(fn) is False:
-                    branch.branch_true_side_not_covered_complexity += (
-                        all_functions[fn].total_cyclomatic_complexity)
+                    branch.branch_true_side_not_covered_complexity += new_comp
+                    if fn in true_side_funcs:
+                        branch.branch_true_side_unique_not_covered_complexity += new_comp
 
 
 def detect_branch_level_blockers(
@@ -446,17 +462,27 @@ def detect_branch_level_blockers(
         # it may become interesting to report less-taken side: like
         # the side that is taken less than 20% of the times
         if true_hitcount == 0 and false_hitcount != 0:
-            blocked_side = BlockedSide.TRUE
-            blocked_reachable_complexity = llvm_branch.branch_true_side_reachable_complexity
-            blocked_not_covered_complexity = llvm_branch.branch_true_side_not_covered_complexity
+            blocked_side = bp.BranchSide.TRUE
+            blocked_unique_not_covered_com = (
+                llvm_branch.branch_true_side_unique_not_covered_complexity)
+            blocked_unique_reachable_com = llvm_branch.branch_true_side_unique_reachable_complexity
+            blocked_reachable_com = llvm_branch.branch_true_side_reachable_complexity
+            blocked_not_covered_com = llvm_branch.branch_true_side_not_covered_complexity
             side_line = llvm_branch.branch_true_side_pos
             side_line_number = side_line.split(':')[1].split(',')[0]
+            blocked_unique_funcs = (
+                llvm_branch.get_side_unique_reachable_funcnames(bp.BranchSide.TRUE))
         elif true_hitcount != 0 and false_hitcount == 0:
-            blocked_side = BlockedSide.FALSE
-            blocked_reachable_complexity = llvm_branch.branch_false_side_reachable_complexity
-            blocked_not_covered_complexity = llvm_branch.branch_false_side_not_covered_complexity
+            blocked_side = bp.BranchSide.FALSE
+            blocked_unique_not_covered_com = (
+                llvm_branch.branch_false_side_unique_not_covered_complexity)
+            blocked_unique_reachable_com = llvm_branch.branch_false_side_unique_reachable_complexity
+            blocked_reachable_com = llvm_branch.branch_false_side_reachable_complexity
+            blocked_not_covered_com = llvm_branch.branch_false_side_not_covered_complexity
             side_line = llvm_branch.branch_false_side_pos
             side_line_number = side_line.split(':')[1].split(',')[0]
+            blocked_unique_funcs = (
+                llvm_branch.get_side_unique_reachable_funcnames(bp.BranchSide.FALSE))
 
         if blocked_side:
             # Sanity check on line numbers: anomaly can happen because of debug info inaccuracy
@@ -484,10 +510,15 @@ def detect_branch_level_blockers(
                 int(line_number),
                 function_name
             )
-            fuzz_blockers.append(FuzzBranchBlocker(blocked_side, blocked_not_covered_complexity,
-                                 blocked_reachable_complexity, hitcount_diff, source_file_path,
-                                 line_number, side_line_number, function_name, link))
+            new_blk = FuzzBranchBlocker(blocked_side, blocked_unique_not_covered_com,
+                                        blocked_unique_reachable_com, blocked_unique_funcs,
+                                        blocked_not_covered_com, blocked_reachable_com,
+                                        hitcount_diff, source_file_path, line_number,
+                                        side_line_number, function_name, link)
+            fuzz_blockers.append(new_blk)
 
-    fuzz_blockers.sort(key=lambda x: [x.blocked_not_covered_complexity,
+    fuzz_blockers.sort(key=lambda x: [x.blocked_unique_not_covered_complexity,
+                                      x.blocked_unique_reachable_complexity,
+                                      x.blocked_not_covered_complexity,
                                       x.blocked_reachable_complexity], reverse=True)
     return fuzz_blockers

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -17,7 +17,6 @@
 import abc
 import logging
 import os
-import re
 
 
 from typing import (
@@ -40,7 +39,6 @@ from fuzz_introspector.datatypes import (
 )
 from fuzz_introspector.exceptions import AnalysisError
 
-BLOCKLISTED_COMPLEXITY_FUNCS = re.compile(r'^__sanitizer|^llvm\.')
 
 logger = logging.getLogger(name=__name__)
 
@@ -392,7 +390,7 @@ def update_branch_complexities(all_functions: Dict[str, function_profile.Functio
             # Iterate over the list of funcs instead of set, because we want to account
             # for the complexity of repeating functions.
             for fn in branch.branch_false_side_funcs:
-                if fn not in all_functions or BLOCKLISTED_COMPLEXITY_FUNCS.match(fn):
+                if fn not in all_functions:
                     continue
                 new_comp = all_functions[fn].total_cyclomatic_complexity
                 branch.branch_false_side_reachable_complexity += new_comp
@@ -404,7 +402,7 @@ def update_branch_complexities(all_functions: Dict[str, function_profile.Functio
                         branch.branch_false_side_unique_not_covered_complexity += new_comp
 
             for fn in branch.branch_true_side_funcs:
-                if fn not in all_functions or BLOCKLISTED_COMPLEXITY_FUNCS.match(fn):
+                if fn not in all_functions:
                     continue
                 new_comp = all_functions[fn].total_cyclomatic_complexity
                 branch.branch_true_side_reachable_complexity += new_comp

--- a/src/fuzz_introspector/constants.py
+++ b/src/fuzz_introspector/constants.py
@@ -41,4 +41,4 @@ COLOR_CONSTANTS = [
     (50, 1000000000000, "lawngreen", "#7cfc00")
 ]
 
-BLOCKLISTED_COMPLEXITY_FUNCS = re.compile(r'^__sanitizer|^llvm\.')
+BLOCKLISTED_FUNCTION_NAMES = re.compile(r'^__sanitizer|^llvm\.')

--- a/src/fuzz_introspector/constants.py
+++ b/src/fuzz_introspector/constants.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 GIT_REPO = "https://github.com/ossf/fuzz-introspector"
 GIT_BRANCH_URL = f"{GIT_REPO}/blob/main"
 
@@ -38,3 +40,5 @@ COLOR_CONSTANTS = [
     (30, 50, "greenyellow", "#adff2f"),
     (50, 1000000000000, "lawngreen", "#7cfc00")
 ]
+
+BLOCKLISTED_COMPLEXITY_FUNCS = re.compile(r'^__sanitizer|^llvm\.')

--- a/src/fuzz_introspector/datatypes/branch_profile.py
+++ b/src/fuzz_introspector/datatypes/branch_profile.py
@@ -14,16 +14,22 @@
 """Branch profiler"""
 
 import logging
-
+from enum import Enum
 from typing import (
     Any,
     Dict,
     List,
+    Set,
 )
 
 from fuzz_introspector import utils
 
 logger = logging.getLogger(name=__name__)
+
+
+class BranchSide(Enum):
+    TRUE = 1
+    FALSE = 2
 
 
 class BranchProfile:
@@ -34,6 +40,10 @@ class BranchProfile:
         self.branch_pos = str()
         self.branch_true_side_pos = str()
         self.branch_false_side_pos = str()
+        self.branch_true_side_unique_not_covered_complexity = -1
+        self.branch_false_side_unique_not_covered_complexity = -1
+        self.branch_true_side_unique_reachable_complexity = -1
+        self.branch_false_side_unique_reachable_complexity = -1
         self.branch_true_side_reachable_complexity = -1
         self.branch_false_side_reachable_complexity = -1
         self.branch_true_side_not_covered_complexity = -1
@@ -54,6 +64,14 @@ class BranchProfile:
     def assign_from_coverage(self, true_count: str, false_count: str) -> None:
         self.branch_true_side_hitcount = int(true_count)
         self.branch_false_side_hitcount = int(false_count)
+
+    def get_side_unique_reachable_funcnames(self, branch_side: BranchSide) -> Set[str]:
+        """Returns the set of unique functions reachable from the specified branch side"""
+        true_side_funcs_set = set(self.branch_true_side_funcs)
+        false_side_funcs_set = set(self.branch_false_side_funcs)
+        if branch_side == BranchSide.TRUE:
+            return true_side_funcs_set.difference(false_side_funcs_set)
+        return false_side_funcs_set.difference(true_side_funcs_set)
 
     def dump(self) -> None:
         """

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -223,5 +223,7 @@ def load_func_names(input_list: List[str]) -> List[str]:
     """
     loaded = []
     for reached in input_list:
+        if constants.BLOCKLISTED_COMPLEXITY_FUNCS.match(reached):
+            continue
         loaded.append(demangle_cpp_func(reached))
     return loaded

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -223,7 +223,7 @@ def load_func_names(input_list: List[str]) -> List[str]:
     """
     loaded = []
     for reached in input_list:
-        if constants.BLOCKLISTED_COMPLEXITY_FUNCS.match(reached):
+        if constants.BLOCKLISTED_FUNCTION_NAMES.match(reached):
             continue
         loaded.append(demangle_cpp_func(reached))
     return loaded


### PR DESCRIPTION
Similar to the logic in https://github.com/ossf/fuzz-introspector/pull/336#issue-1272902626, this PR goes one step further by differentiating uniquely reachable functions by each branch side.
For example in the following control flow consisting basic blocks A, B, C, D, and function calls to u, v, w, x, y; assume the edge A -> C is blocking, here we collect the complexity of functions `v, w` separate from `v, w, x, y` and mark if they are covered or not-covered. 
Then the branch blockers first are ranked based on `[unique_not_covered_funcs_complexity, unique_reachable_funcs_complexity]` and then the rest of reachable/covered functions compelxity.

```mermaid
graph TD;
    A-->B:u;
    A-.->C:v,w;
    B:u -->D:x,y;
    C:v,w -.->D:x,y;
```

Signed-off-by: Navid Emamdoost <navid.emamdoost@gmail.com>