### PR TITLE
abstract entrypoint identification to fuzzer profile

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -180,18 +180,13 @@ def get_node_coverage_hitcount(
 
     node_hitcount: int = 0
     if is_first:
-        # The first node is always the entry of LLVMFuzzerTestOneInput
-        # LLVMFuzzerTestOneInput will never have a parent in the calltree. As such, we
-        # check here if the function has been hit, and if so, make it green. We avoid
-        # hardcoding LLVMFuzzerTestOneInput to be green because some fuzzers may not
-        # have a single seed, and in this specific case LLVMFuzzerTestOneInput
-        # will be red.
-        if demangled_name != "LLVMFuzzerTestOneInput" and "TestOneInput" not in demangled_name:
-            logger.info("Unexpected first node in the calltree.")
-            logger.info(f"Found: {demangled_name}")
+        # As this is the first node ensure it is indeed the entrypoint.
+        # The difference is this node has node "parent" or prior nodes.
+        if not profile.func_is_entrypoint(demangled_name):
             raise AnalysisError(
                 "First node in calltree seems to be non-fuzzer function"
             )
+
         coverage_data = profile.coverage.get_hit_details("LLVMFuzzerTestOneInput")
         if len(coverage_data) == 0:
             logger.error("There is no coverage data (not even all negative).")

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -73,12 +73,30 @@ class FuzzerProfile:
         return self._target_lang
 
     @property
+    def entrypoint_function(self):
+        """The name of the fuzzer entrypoint"""
+        if self.target_lang == "c-cpp":
+            return "LLVMFuzzerTestOneInput"
+        if self.target_lang == "python":
+            # TODO: fix this to be actual logic that determines
+            # the entrypoint
+            return "TestOneInput"
+
+    @property
     def identifier(self):
         """Fuzzer identifier"""
         if self.binary_executable != "":
             return os.path.basename(self.binary_executable)
 
         return self.fuzzer_source_file
+
+    def func_is_entrypoint(self, demangled_func_name: str) -> bool:
+        if (
+            demangled_func_name != self.entrypoint_function and
+            self.entrypoint_function not in demangled_func_name
+        ):
+            return False
+        return True
 
     def resolve_coverage_link(
         self,

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -92,8 +92,8 @@ class FuzzerProfile:
 
     def func_is_entrypoint(self, demangled_func_name: str) -> bool:
         if (
-            demangled_func_name != self.entrypoint_function and
-            self.entrypoint_function not in demangled_func_name
+            demangled_func_name != self.entrypoint_function
+            and self.entrypoint_function not in demangled_func_name
         ):
             return False
         return True


### PR DESCRIPTION
This is to make it easier to have more complex logic when matching function names with a fuzzer's
entrypoint.

Ref: https://github.com/ossf/fuzz-introspector/issues/517

Signed-off-by: David Korczynski <david@adalogics.com>