### PR TITLE
fix mismatching of python calltree/coverage

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -332,11 +332,11 @@ def overlay_calltree_with_coverage(
     # ensure the entrypoint is covered.
     all_nodes = cfg_load.extract_all_callsites(profile.function_call_depths)
     if len(all_nodes) > 0:
-        has_hits = False
         for node in cfg_load.extract_all_callsites(profile.function_call_depths)[1:]:
             if node.cov_hitcount > 0:
                 all_nodes[0].cov_hitcount = 200
                 all_nodes[0].cov_color = get_hit_count_color(200)
+                break
 
     # Extract data about which nodes unlocks data
     all_callsites = cfg_load.extract_all_callsites(profile.function_call_depths)

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -187,7 +187,7 @@ def get_node_coverage_hitcount(
                 "First node in calltree seems to be non-fuzzer function"
             )
 
-        coverage_data = profile.coverage.get_hit_details("LLVMFuzzerTestOneInput")
+        coverage_data = profile.coverage.get_hit_details(demangled_name)
         if len(coverage_data) == 0:
             logger.error("There is no coverage data (not even all negative).")
         node.cov_parent = "EP"
@@ -328,6 +328,15 @@ def overlay_calltree_with_coverage(
             profile,
             target_coverage_url
         )
+    # For python, do a hack where we check if any node is covered, and, if so,
+    # ensure the entrypoint is covered.
+    all_nodes = cfg_load.extract_all_callsites(profile.function_call_depths)
+    if len(all_nodes) > 0:
+        has_hits = False
+        for node in cfg_load.extract_all_callsites(profile.function_call_depths)[1:]:
+            if node.cov_hitcount > 0:
+                all_nodes[0].cov_hitcount = 200
+                all_nodes[0].cov_color = get_hit_count_color(200)
 
     # Extract data about which nodes unlocks data
     all_callsites = cfg_load.extract_all_callsites(profile.function_call_depths)

--- a/src/fuzz_introspector/cfg_load.py
+++ b/src/fuzz_introspector/cfg_load.py
@@ -117,17 +117,24 @@ def data_file_read_calltree(filename: str) -> Optional[CalltreeCallsite]:
                 # Parse the line
                 # Type: {spacing depth} {target filename} {line count}
                 if len(stripped_line) == 3:
+                    target_func = stripped_line[0]
                     filename = stripped_line[1]
                     linenumber = int(stripped_line[2].replace("linenumber=", ""))
                 else:
+                    target_func = stripped_line[0]
                     filename = ""
                     linenumber = 0
+
+                if "......" in filename or "......" in target_func:
+                    filename = filename.replace("......", "")
+                    target_func = target_func.replace("......", "")
+
                 space_count = len(line) - len(line.lstrip(' '))
                 depth = int(space_count / 2)
 
                 # Create a callsite nide
                 ctcs = CalltreeCallsite(
-                    stripped_line[0],
+                    target_func,
                     filename,
                     depth,
                     linenumber,

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -129,7 +129,7 @@ class CoverageProfile:
         if "fuzz" in target_key:
             logger.info("Checking adjustment")
             # 11 in the below code reflects the size of the coverage stub added here:
-            # https://github.com/google/oss-fuzz/blob/360b484fa0f026c0dea44c62897519c6c99127cc/infra/base-images/base-builder/compile_python_fuzzer#L29-L40
+            # https://github.com/google/oss-fuzz/blob/360b484fa0f026c0dea44c62897519c6c99127cc/infra/base-images/base-builder/compile_python_fuzzer#L29-L40  # noqa: E501
             if lineno + 11 in self.file_map[target_key]:
                 logger.info("Success with line number adjustment")
                 return True

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -125,6 +125,15 @@ class CoverageProfile:
             logger.info("Success")
             return True
 
+        # Check if "fuzz" is in the filename. This is a hack in python coverage
+        if "fuzz" in target_key:
+            logger.info("Checking adjustment")
+            # 11 in the below code reflects the size of the coverage stub added here:
+            # https://github.com/google/oss-fuzz/blob/360b484fa0f026c0dea44c62897519c6c99127cc/infra/base-images/base-builder/compile_python_fuzzer#L29-L40
+            if lineno + 11 in self.file_map[target_key]:
+                logger.info("Success with line number adjustment")
+                return True
+
         return False
 
     def is_func_hit(self, funcname: str) -> bool:
@@ -147,6 +156,7 @@ class CoverageProfile:
             linenumber and the second element is the amount of times that line
             was covered.
         """
+        logger.debug(f"Getting coverage of {funcname}")
         fuzz_key = None
         if funcname in self.covmap:
             fuzz_key = funcname


### PR DESCRIPTION
The calltree generation by way of the AST uses different filepaths than the coverage extraction utility. The AST ones can be a bit weird, e.g. including "......" in the path. This fixes it.

Fixes: https://github.com/ossf/fuzz-introspector/issues/517

Signed-off-by: David Korczynski <david@adalogics.com>