### PR TITLE
Skip comments and empty lines when loading coverage data

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -334,7 +334,11 @@ def load_llvm_coverage(
                                     "M", "0000").replace(
                                         ".", ""))
                     except Exception:
-                        hit_times = 0
+                        # Avoid overcounting the code lines by skipping comments and empty lines.
+                        if " 0| " in line:
+                            hit_times = 0
+                        else:
+                            continue
                     # Add source code line and hitcount to coverage map of current function
                     logger.debug(f"reading coverage: {curr_func} "
                                  f"-- {line_number} -- {hit_times}")


### PR DESCRIPTION
In `.covreport` files, empty lines and comments should not be counted as `0` hit lines. Otherwise it skews the overall coverage calculation.

Fixes #523 

Example:

```
  990|     18|    hts_tpool_result *r;
  991|       |
  992|     18|    if (fp->mt) {
  ------------------
  |  Branch (992:9): [True: 0, False: 18]
  ------------------
  993|      0|    again:
  994|      0|        if (fp->mt->hit_eof) {
  ------------------
  |  Branch (994:13): [True: 0, False: 0]
  ------------------
  995|       |            // Further reading at EOF will always return 0
  996|      0|            fp->block_length = 0;
  997|      0|            return 0;
  998|      0|        }
```
lines `991` and `995` does not have any code to be considered for coverage stats, so should be skipped in code coverage load.