### PR TITLE
html-report: fix python coverage link

### DIFF
--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -24,6 +24,7 @@ from typing import (
 
 from fuzz_introspector import code_coverage
 from fuzz_introspector import utils
+from fuzz_introspector import exceptions
 from fuzz_introspector.datatypes import function_profile, fuzzer_profile
 
 logger = logging.getLogger(name=__name__)
@@ -171,6 +172,18 @@ class MergedProjectProfile:
             reached_percentage,
             unreached_percentage
         )
+
+    @property
+    def target_lang(self):
+        """Language the fuzzers are written in"""
+        set_of_targets = set()
+        for profile in self.profiles:
+            set_of_targets.add(profile.target_lang)
+        if len(set_of_targets) > 1:
+            raise exceptions.AnalysisError(
+                "Project has fuzzers with multiple targets"
+            )
+        return set_of_targets.pop()
 
     def get_profiles_coverage_files(self) -> List[str]:
         all_coverage_files_used = list()

--- a/src/fuzz_introspector/html_helpers.py
+++ b/src/fuzz_introspector/html_helpers.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 from fuzz_introspector import utils
-from fuzz_introspector.datatypes import fuzzer_profile
+from fuzz_introspector.datatypes import fuzzer_profile, project_profile
 
 
 class HTMLConclusion:
@@ -143,8 +143,14 @@ def create_pfc_button(
 def html_get_table_of_contents(
         toc_list: List[Tuple[str, str, int]],
         coverage_url: str,
-        profiles: List[fuzzer_profile.FuzzerProfile]) -> str:
+        profiles: List[fuzzer_profile.FuzzerProfile],
+        proj_profile: project_profile.MergedProjectProfile) -> str:
     per_fuzzer_coverage_button = create_pfc_button(profiles, coverage_url)
+
+    if proj_profile.target_lang == "python":
+        cov_index = "index.html"
+    else:
+        cov_index = "report.html"
     html_toc_string = ""
     html_toc_string += f"""<div class="left-sidebar">\
                             <div class="left-sidebar-content-box"
@@ -152,14 +158,17 @@ def html_get_table_of_contents(
                                  padding: 0 20px; margin-top: 30px">
                                 <div class="yellow-button-wrapper"
                                     style="position: relative; margin: 30px 0 5px 0">
-                                    <a href="{coverage_url}/report.html">
+                                    <a href="{coverage_url}/{cov_index}">
                                         <div class="yellow-button">
                                             Project coverage
                                         </div>
                                     </a>
                                 </div>
-                                {per_fuzzer_coverage_button}
-                            </div>
+                        """
+    if proj_profile.target_lang != "python":
+        html_toc_string += f"{per_fuzzer_coverage_button}"
+
+    html_toc_string += f"""</div>
                             <div class="left-sidebar-content-box">\
                                 <h2 style="margin-top:0px">Table of contents</h2>"""
     for k, v, d in toc_list:

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -1044,7 +1044,12 @@ def create_html_report(
     ###########################
     # Fix up table of contents.
     ###########################
-    html_toc_string = html_helpers.html_get_table_of_contents(toc_list, coverage_url, profiles)
+    html_toc_string = html_helpers.html_get_table_of_contents(
+        toc_list,
+        coverage_url,
+        profiles,
+        proj_profile
+    )
 
     # Assemble the final HTML report and write it to a file.
     html_full_doc = (html_header


### PR DESCRIPTION
The link to python coverage is different to that of c-cpp files. This fixes it.

Signed-off-by: David Korczynski <david@adalogics.com>