### PR TITLE
python coverage: ensure coverage file list is accurate

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -366,7 +366,11 @@ def load_python_json_coverage(
 
     if len(coverage_reports) > 0:
         json_file = coverage_reports[0]
+    else:
+        logger.info("Found not coverage files")
+        return cp
 
+    cp.coverage_files.append(json_file)
     with open(json_file, "r") as f:
         data = json.load(f)
 

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -367,7 +367,7 @@ def load_python_json_coverage(
     if len(coverage_reports) > 0:
         json_file = coverage_reports[0]
     else:
-        logger.info("Found not coverage files")
+        logger.info("Found no coverage files")
         return cp
 
     cp.coverage_files.append(json_file)


### PR DESCRIPTION
Is needed to avoid misrepresenting "no coverage" following https://github.com/ossf/fuzz-introspector/pull/528

Signed-off-by: David Korczynski <david@adalogics.com>