### PR TITLE
fuzzer_profile: enable correct identification of python entrypoint

### DIFF
--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -99,6 +99,7 @@ def run_fuzz_pass(
     cg.analyze()
     formatter = formats.Fuzz(cg)
     cg_extended = formatter.generate()
+    logger.info("The entrypoints: %s"%(cg_extended['entrypoints']))
 
     if should_debug():
         logger.info("Printing extended cg")
@@ -181,6 +182,11 @@ def convert_cg_to_introspector_data(cg_extended, fuzzer_filename):
     new_dict['All functions'] = dict()
     new_dict['All functions']['Function list name'] = "All functions"
     new_dict['All functions']['Elements'] = []
+
+    if "ep" in cg_extended:
+        new_dict['ep'] = dict()
+        new_dict['ep']['func_name'] = cg_extended['ep']['name']
+        new_dict['ep']['module'] = cg_extended['ep']['mod']
 
     # TODO: do the implementation necessary to carry these out.
     for elem in cg_extended['cg']:

--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -99,7 +99,6 @@ def run_fuzz_pass(
     cg.analyze()
     formatter = formats.Fuzz(cg)
     cg_extended = formatter.generate()
-    logger.info("The entrypoints: %s"%(cg_extended['entrypoints']))
 
     if should_debug():
         logger.info("Printing extended cg")

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -65,6 +65,12 @@ class FuzzerProfile:
             self.fuzzer_source_file: str = frontend_yaml['Fuzzer filename']
         except KeyError:
             raise DataLoaderError("Fuzzer filename not in loaded yaml")
+
+        # Read entrypoint of fuzzer if this is a Python module
+        if target_lang == "python":
+            self.entrypoint_fun = frontend_yaml['ep']['func_name']
+            self.entrypoint_mod = frontend_yaml['ep']['module']
+
         self._set_function_list(frontend_yaml)
 
     @property
@@ -78,9 +84,8 @@ class FuzzerProfile:
         if self.target_lang == "c-cpp":
             return "LLVMFuzzerTestOneInput"
         if self.target_lang == "python":
-            # TODO: fix this to be actual logic that determines
-            # the entrypoint
-            return "TestOneInput"
+            logger.info("Returning: %s"%(self.entrypoint_fun))
+            return self.entrypoint_fun
 
     @property
     def identifier(self):
@@ -334,14 +339,16 @@ class FuzzerProfile:
             return
 
         # Find Python entrypoint
-        for func_name in self.all_class_functions:
-            if "TestOneInput" in func_name:
-                reached = self.all_class_functions[func_name].functions_reached
-                self.functions_reached_by_fuzzer = reached
-                return
+        if self._target_lang == "python":
+            ep_key = "%s.%s"%(
+                self.entrypoint_mod,
+                self.entrypoint_fun
+            )
+            reached = self.all_class_functions[ep_key].functions_reached
+            self.functions_reached_by_fuzzer = reached
+            return
 
-        # TODO: make fuzz-introspector exceptions
-        raise Exception
+        raise exceptions.DataLoaderError("Can not identify entrypoint")
 
     def _set_all_unreached_functions(self) -> None:
         """Sets self.functions_unreached_by_fuzzer to all functions that are

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -84,7 +84,6 @@ class FuzzerProfile:
         if self.target_lang == "c-cpp":
             return "LLVMFuzzerTestOneInput"
         if self.target_lang == "python":
-            logger.info("Returning: %s"%(self.entrypoint_fun))
             return self.entrypoint_fun
 
     @property
@@ -340,15 +339,12 @@ class FuzzerProfile:
 
         # Find Python entrypoint
         if self._target_lang == "python":
-            ep_key = "%s.%s"%(
-                self.entrypoint_mod,
-                self.entrypoint_fun
-            )
+            ep_key = f"{self.entrypoint_mod}.{self.entrypoint_fun}"
             reached = self.all_class_functions[ep_key].functions_reached
             self.functions_reached_by_fuzzer = reached
             return
 
-        raise exceptions.DataLoaderError("Can not identify entrypoint")
+        raise DataLoaderError("Can not identify entrypoint")
 
     def _set_all_unreached_functions(self) -> None:
         """Sets self.functions_unreached_by_fuzzer to all functions that are


### PR DESCRIPTION
Previously we hardcoded this but this didnt allow fuzzers to have arbitrary function names for entrypoints, which indeed is allowed when developing python fuzzers.

Signed-off-by: David Korczynski <david@adalogics.com>