### PR TITLE
fix python coverage function url

### DIFF
--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -173,6 +173,27 @@ class MergedProjectProfile:
             unreached_percentage
         )
 
+    def resolve_coverage_report_link(
+        self,
+        coverage_url,
+        function_source_file,
+        lineno,
+        func_name
+    ):
+        if self.target_lang == "python":
+            return self.profiles[0].resolve_coverage_link(
+                coverage_url,
+                function_source_file,
+                lineno,
+                func_name
+            )
+        else:
+            return "%s%s.html#L%d" % (
+                coverage_url,
+                function_source_file,
+                lineno
+            )
+
     @property
     def target_lang(self):
         """Language the fuzzers are written in"""

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -238,10 +238,11 @@ def create_all_function_table(
         except Exception:
             hit_percentage = 0.0
 
-        func_cov_url = "%s%s.html#L%d" % (
+        func_cov_url = proj_profile.resolve_coverage_report_link(
             coverage_url,
             fd.function_source_file,
-            fd.function_linenumber
+            fd.function_linenumber,
+            fd.function_name
         )
 
         if proj_profile.runtime_coverage.is_func_hit(fd.function_name):


### PR DESCRIPTION
The function table provided wrong urls to the coverage reports. This fixes it.

Signed-off-by: David Korczynski <david@adalogics.com>