### PR TITLE
llvm: write all functions without storing all in memory and delay function reachability for each function to post processing

### DIFF
--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -270,7 +270,7 @@ struct FuzzIntrospector : public ModulePass {
                               std::set<StringRef> *);
   void extractFuzzerReachabilityGraph(Module &M);
   int extractCalltree(Function *F, CalltreeNode *callTree,
-                      std::vector<CalltreeNode *> *allNodes);
+                      std::vector<CalltreeNode *> *allNodes, int toRecurse);
   void logCalltree(struct CalltreeNode *calltree, std::ofstream *, int Depth);
   FuzzerFunctionWrapper wrapFunction(Function *func);
   void extractAllFunctionDetailsToYaml(std::string nextYamlName, Module &M);
@@ -974,7 +974,7 @@ bool FuzzIntrospector::shouldAvoidFunction(Function *Func) {
 // indirect calls.
 int FuzzIntrospector::extractCalltree(
     Function *F, CalltreeNode *Calltree,
-    std::vector<CalltreeNode *> *allNodesInTree) {
+    std::vector<CalltreeNode *> *allNodesInTree, int toRecurse) {
   std::vector<CalltreeNode *> OutgoingEdges;
   resolveOutgoingEdges(F, &OutgoingEdges);
 
@@ -988,9 +988,11 @@ int FuzzIntrospector::extractCalltree(
     if (Calltree != nullptr) {
       Calltree->Outgoings.push_back(OutEdge);
     }
-    int OutEdgeDepth =
-        1 + extractCalltree(OutEdge->CallsiteDst, OutEdge, allNodesInTree);
-    MaxDepthOfEdges = std::max(MaxDepthOfEdges, OutEdgeDepth);
+    if (toRecurse) {
+      int OutEdgeDepth =
+          1 + extractCalltree(OutEdge->CallsiteDst, OutEdge, allNodesInTree, toRecurse);
+      MaxDepthOfEdges = std::max(MaxDepthOfEdges, OutEdgeDepth);
+    }
   }
   return MaxDepthOfEdges;
 }
@@ -1260,7 +1262,7 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
   // Rather, we should cache a lot of the analysis we do in extractCalltree
   // because a top-level function would capture all the data we need for the
   // full program.
-  FuncWrap.FunctionDepth = extractCalltree(F, nullptr, &Nodes);
+  FuncWrap.FunctionDepth = extractCalltree(F, nullptr, &Nodes, 0);
   getFunctionsInAllNodes(&Nodes, &FuncReaches);
   std::copy(FuncReaches.begin(), FuncReaches.end(),
             std::back_inserter(FuncWrap.FunctionsReached));
@@ -1333,7 +1335,7 @@ void FuzzIntrospector::extractFuzzerReachabilityGraph(Module &M) {
   FuzzerCalltree.LineNumber = -1;
 
   std::vector<CalltreeNode *> Nodes;
-  extractCalltree(FuzzEntryFunc, &FuzzerCalltree, &Nodes);
+  extractCalltree(FuzzEntryFunc, &FuzzerCalltree, &Nodes, 1);
 
   // TODO: handle LLVMFuzzerInitialize as this function may also
   // reach target code, and should be considered another fuzzer entrypoint.

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -225,10 +225,39 @@ class FuzzerProfile:
 
         return self.fuzzer_source_file
 
+    def _propagate_functions_reached(self) -> None:
+        """Accummulates all functions reached by a given fuzzer. This is
+        achieved by iterating the outgoing edges of each function recursively
+        """
+        for func in self.all_class_functions:
+            worklist = []
+            max_depth = 0
+            for func_reached in self.all_class_functions[func].functions_reached:
+                worklist.append((func_reached, 0))
+            visited = set()
+
+            while len(worklist) > 0:
+                elem, depth = worklist.pop()
+                if depth > max_depth:
+                    max_depth = depth
+
+                if elem in visited:
+                    continue
+                visited.add(elem)
+
+                if elem in self.all_class_functions:
+                    for func_reached2 in self.all_class_functions[elem].functions_reached:
+                        worklist.append((func_reached2, depth+1))
+
+            self.all_class_functions[func].functions_reached = list(visited)
+            self.all_class_functions[func].function_depth = max_depth
+
+
     def accummulate_profile(self, target_folder: str) -> None:
         """Triggers various analyses on the data of the fuzzer. This is used
         after a profile has been initialised to generate more interesting data.
         """
+        self._propagate_functions_reached()
         self._set_all_reached_functions()
         self._set_all_unreached_functions()
         self._load_coverage(target_folder)

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -247,11 +247,10 @@ class FuzzerProfile:
 
                 if elem in self.all_class_functions:
                     for func_reached2 in self.all_class_functions[elem].functions_reached:
-                        worklist.append((func_reached2, depth+1))
+                        worklist.append((func_reached2, depth + 1))
 
             self.all_class_functions[func].functions_reached = list(visited)
             self.all_class_functions[func].function_depth = max_depth
-
 
     def accummulate_profile(self, target_folder: str) -> None:
         """Triggers various analyses on the data of the fuzzer. This is used

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -86,7 +86,36 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
             data_dict: Dict[Any, Any] = yaml.safe_load(stream)
             return data_dict
         except (yaml.YAMLError, UnicodeDecodeError):
-            return None
+            logger.info("Error loading yaml file")
+
+    # Try loading multiple yaml files in the fuzz introspector format
+    # We need this because we have different formats for each language.
+    logger.info("Trying to load multiple file formats toget")
+    combined_dict = dict()
+    with open(filename, 'r') as yaml_f:
+        data = yaml_f.read()
+    try:
+        docs = yaml.safe_load_all(data)
+    except (yaml.YAMLError, UnicodeDecodeError):
+        logger.info("Failed loading")
+        return None
+
+    content = dict()
+    for doc in docs:
+        if "Fuzzer filename" in doc and "Fuzzer filename" not in content:
+            content["Fuzzer filename"] = doc["Fuzzer filename"]
+        if "All functions" in doc:
+            if "All functions" not in content:
+                content['All functions'] = doc['All functions']
+            else:
+                content['All functions']['Elements'].append(
+                    doc['All functions']['Elements'][0]
+                )
+    if "Fuzzer filename" not in content:
+        return None
+    if "All functions" not in content:
+        return None
+    return content
 
 
 def demangle_cpp_func(funcname: str) -> str:

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -91,7 +91,6 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
     # Try loading multiple yaml files in the fuzz introspector format
     # We need this because we have different formats for each language.
     logger.info("Trying to load multiple file formats toget")
-    combined_dict = dict()
     with open(filename, 'r') as yaml_f:
         data = yaml_f.read()
     try:


### PR DESCRIPTION
This is in contrast to keeping it all in memory during the compilation. This will avoid significant memory overhead for some projects. Also avoid iterating the calltree for each function in the llvm module since we only use this to capture the functions reachable as well as function calldepth. Instead, we just capture outgoing edges for each function, and then propagate this in the python logic. This reduces the overhead of fuzz introspector because the llvm operations are resource heavy. Memory footprint is reduced a lot so we should be able to see more builds compile (e.g. the ones that are killed in the referenced issue), plus, it will speed up compilation by a lot.

Ref: https://github.com/ossf/fuzz-introspector/issues/195

Signed-off-by: David Korczynski <david@adalogics.com>