### PR TITLE
[Java-Integration]: Fix bug

### DIFF
--- a/frontends/java/soot/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/soot/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -1,4 +1,3 @@
-
 // Copyright 2022 Fuzz Introspector Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -149,7 +148,7 @@ class CustomSenceTransformer extends SceneTransformer {
 						c.getName().equals(this.entryClassStr)) {
 					this.entryMethod = m;
 				}
-        
+
 				// Discover method related information
 				FunctionElement element= new FunctionElement();
 
@@ -241,14 +240,6 @@ class CustomSenceTransformer extends SceneTransformer {
 						blockGraph.getHeads(), 0));
 
 				methodConfig.addFunctionElement(element);
-
-				// Only methods in the entry class or method reachable
-				// from the entry method in the entry class are included
-				// in the call graph result.
-				if (c.getName().equals(this.entryClass) ||
-						element.getFunctionUses() > 0) {
-					methodMap.put(c.getName() + "#" + m.getName(), m);
-				}
 			}
 			classConfig.setFunctionConfig(methodConfig);
 			classYaml.add(classConfig);
@@ -265,7 +256,6 @@ class CustomSenceTransformer extends SceneTransformer {
 			}
 		}
 	}
-
 
 	private Integer calculateDepth(CallGraph cg, SootMethod method) {
 		int depth = 0;
@@ -355,4 +345,3 @@ class CustomSenceTransformer extends SceneTransformer {
 		return excludeList;
 	}
 }
-


### PR DESCRIPTION
Fix two bugs for Issue #536 Step 3~4:
1. Old code forget to remove.
2. Logic of call graph extraction and method depth calculation does not consider looping or recursive code. These kind of code will generate circular edge in the callgraph which will cause infinitely loop when the visitor trace the code following those circular edges. This will end with StackOverflowError and fail the execution. New logic fixed that by recording method that has already been handled to avoid infinitely loop.

Signed-off-by: Arthur Chan <arthur.chan@adalogics.com>