### PR TITLE
frontend: python: improve automation of package finding

### DIFF
--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -79,7 +79,15 @@ def run_fuzz_pass(
     scanned_sources = []
     if scan:
         for root, dirs, files in os.walk(package):
+            # avoid test directories. We're not interested in exploring this code.
+            to_include = True
+            for rdir in os.path.split(root):
+                if rdir == "test" or rdir == "tests":
+                    to_include = False
+            if not to_include:
+                continue
             for filename in files:
+                logger.debug("Iterating %s ---- %s"%(root, filename))
                 fpath = os.path.join(root, filename)
                 if not fpath.endswith(".py"):
                     continue
@@ -91,10 +99,14 @@ def run_fuzz_pass(
     logger.info(
         f"Running analysis with arguments: {{fuzzer: {fuzzer}, package: {package} }}"
     )
+    sources_to_analyze = [fuzzer] + sources + scanned_sources
+    logger.info("Sources to analyze:")
+    for srz in sources_to_analyze:
+        logger.info("- %s"%(srz))
     cg = CallGraphGenerator(
         [fuzzer] + sources + scanned_sources,
         package,
-        -1,
+        1000,
         CALL_GRAPH_OP
     )
     cg.analyze()

--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -87,7 +87,7 @@ def run_fuzz_pass(
             if not to_include:
                 continue
             for filename in files:
-                logger.debug("Iterating %s ---- %s"%(root, filename))
+                logger.debug("Iterating %s ---- %s" % (root, filename))
                 fpath = os.path.join(root, filename)
                 if not fpath.endswith(".py"):
                     continue
@@ -102,7 +102,7 @@ def run_fuzz_pass(
     sources_to_analyze = [fuzzer] + sources + scanned_sources
     logger.info("Sources to analyze:")
     for srz in sources_to_analyze:
-        logger.info("- %s"%(srz))
+        logger.info("- %s" % (srz))
     cg = CallGraphGenerator(
         [fuzzer] + sources + scanned_sources,
         package,

--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -112,9 +112,9 @@ class FuzzerVisitor(ast.NodeVisitor):
             print("  - %s" % (_import))
             if _import.count(".") > 1:
                 _import = _import.split(".")[0]
-                print("Refining import to %s"%(_import))
+                print("Refining import to %s" % (_import))
+
             # Let's try and see if these are searchable
-            #try:
             specs = importlib.util.find_spec(_import)
             if specs is not None:
                 print("Spec:")

--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -110,14 +110,20 @@ class FuzzerVisitor(ast.NodeVisitor):
         print("- Fuzzer imports:")
         for _import in self.fuzzer_imports:
             print("  - %s" % (_import))
+            if _import.count(".") > 1:
+                _import = _import.split(".")[0]
+                print("Refining import to %s"%(_import))
             # Let's try and see if these are searchable
-            try:
-                specs = importlib.util.find_spec(_import)
-                if specs is not None:
-                    print("Spec:")
-                    print(specs)
-                    avoid = ['atheris', 'sys', 'os']
-                    if _import not in avoid:
+            #try:
+            specs = importlib.util.find_spec(_import)
+            if specs is not None:
+                print("Spec:")
+                print(specs)
+                avoid = ['atheris', 'sys', 'os']
+                print("Hello")
+                if _import not in avoid:
+                    print("hello to")
+                    if specs.submodule_search_locations:
                         for elem in specs.submodule_search_locations:
                             print("Checking --- %s" % (elem))
                             if (
@@ -125,11 +131,12 @@ class FuzzerVisitor(ast.NodeVisitor):
                                 and "site-packages" not in elem
                             ):
                                 # skip packages that are builtin packacges
+                                # Check if we can refine
+                                if elem.count(".") > 1:
+                                    print("Has such a count")
                                 continue
                             print("Adding --- %s" % (elem))
                             self.fuzzer_packages.append(elem)
-            except:  # noqa: E722
-                pass
         print("Iterating")
         for pkg in self.fuzzer_packages:
             print("package: %s" % (pkg))


### PR DESCRIPTION
This is a follow-up to https://github.com/ossf/fuzz-introspector/pull/586 and hopefully a nail in the coffin or close to.

When we the static analysis is run on python a scan is done for the files to include. This worked well for imports e.g. `import pkg; pkg.a()` but not for `from pkg import a; a()`. The reason was the logic for scanning for python code searched for `.../pkg/a.py` instead of `.../pkg`, which is what we need to include all relevant files. This caused `/src/pyintro-pack-deps` to be lacking files, which is the folder we treat as the "global package" when doing analysis.

This fixes it in that it refines how scanning is done. Now, `pkg` is included as a whole.

I have tested this on e.g. `glom`, `idna`, `pyyaml`, `g-api-*` projects and it's working well.

Signed-off-by: David Korczynski <david@adalogics.com>