### PR TITLE
frontends: python: scan for sources by default

### DIFF
--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -340,7 +340,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--scan",
-        default=False,
+        default=True,
         help="Set if package should be scanned for sources",
         action="store_true"
     )

--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -353,14 +353,12 @@ def main() -> int:
     parser = get_cmdline_parser()
 
     args = parser.parse_args()
-
-    scan_packge_for_sources = not args.no_scan
-
+    scan_package_for_sources = not args.no_scan
     exit_code = run_fuzz_pass(
         args.fuzzer,
         "/src/pyintro-pack-deps/",
         args.sources,
-        scan_packge_for_sources
+        scan_package_for_sources
     )
     logger.info(f"Done running pass. Exit code: {exit_code}")
 

--- a/frontends/python/main.py
+++ b/frontends/python/main.py
@@ -339,9 +339,9 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         nargs="+"
     )
     parser.add_argument(
-        "--scan",
-        default=True,
-        help="Set if package should be scanned for sources",
+        "--no-scan",
+        default=False,
+        help="Set if package should not be scanned for sources",
         action="store_true"
     )
     return parser
@@ -353,11 +353,14 @@ def main() -> int:
     parser = get_cmdline_parser()
 
     args = parser.parse_args()
+
+    scan_packge_for_sources = not args.no_scan
+
     exit_code = run_fuzz_pass(
         args.fuzzer,
         "/src/pyintro-pack-deps/",
         args.sources,
-        args.scan
+        scan_packge_for_sources
     )
     logger.info(f"Done running pass. Exit code: {exit_code}")
 


### PR DESCRIPTION
This is needed to include the various python sources for analysis. Also means we avoid having to pass the argument from oss-fuzz.