### PR TITLE
[Java Integration]: Fix jvm data bug

### DIFF
--- a/frontends/java/soot/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/soot/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -217,7 +217,7 @@ class CustomSenceTransformer extends SceneTransformer {
           element.setBBCount(0);
           element.setiCount(0);
           element.setCyclomaticComplexity(0);
-          // methodList.addFunctionElement(element);
+          methodList.addFunctionElement(element);
           System.err.println("Source code for " + m + " not found.");
           continue;
         }
@@ -357,8 +357,7 @@ class CustomSenceTransformer extends SceneTransformer {
 
     String className = "";
     if (callerClass != null) {
-      Set<String> classNameSet =
-          this.edgeClassMap.getOrDefault(
+      Set<String> classNameSet = this.edgeClassMap.getOrDefault(
               callerClass + ":" + method.getName() + ":" + line, Collections.emptySet());
       className = this.mergeClassName(classNameSet);
       boolean merged = false;

--- a/frontends/java/soot/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/soot/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -177,7 +177,7 @@ class CustomSenceTransformer extends SceneTransformer {
         // element.setConstantsTouched([]);
         // element.setArgNames();
 
-        element.setFunctionName(m.getName());
+        element.setFunctionName(m.getSubSignature().split(" ")[1]);
         element.setFunctionSourceFile(c.getFilePath());
         element.setFunctionLinenumber(m.getJavaSourceStartLineNumber());
         element.setReturnType(m.getReturnType().toString());
@@ -200,12 +200,12 @@ class CustomSenceTransformer extends SceneTransformer {
         for (; outEdges.hasNext(); methodEdges++) {
           Edge edge = outEdges.next();
           SootMethod tgt = (SootMethod) edge.getTgt();
-          if (this.excludeMethodList.contains(m.getName())) {
+          if (this.excludeMethodList.contains(tgt.getName())) {
             methodEdges--;
             continue;
           }
           element.addFunctionsReached(
-              tgt.toString() + "; Line: " + edge.srcStmt().getJavaSourceStartLineNumber());
+                  tgt.getSubSignature().split(" ")[1] + "; Line: " + edge.srcStmt().getJavaSourceStartLineNumber());
         }
         element.setEdgeCount(methodEdges);
 
@@ -375,7 +375,8 @@ class CustomSenceTransformer extends SceneTransformer {
     }
 
     callTree.append(StringUtils.leftPad("", depth * 2));
-    callTree.append(method.getName() + " " + className + " linenumber=" + line + "\n");
+    callTree.append(
+            method.getSubSignature().split(" ")[1] + " " + className + " linenumber=" + line + "\n");
 
     boolean excluded = false;
     checkExclusionLoop:

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -86,7 +86,9 @@ class FuzzerProfile:
         elif self.target_lang == "python":
             return self.entrypoint_fun
         elif self.target_lang == "jvm":
-            return "fuzzerTestOneInput"
+            return "fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)"
+        else:
+            return None
 
     @property
     def identifier(self):
@@ -107,15 +109,13 @@ class FuzzerProfile:
     def has_entry_point(self) -> bool:
         """Returns whether an entrypoint is identified"""
         if self.target_lang == "c-cpp":
-            if "LLVMFuzzerTestOneInput" in self.all_class_functions:
-                return True
+            return self.entrypoint_function in self.all_class_functions
 
         elif self.target_lang == "python":
             return self.entrypoint_function is not None
 
         elif self.target_lang == "jvm":
-            if "fuzzerTestOneInput" in self.all_class_functions:
-                return True
+            return self.entrypoint_function in self.all_class_functions
 
         return False
 
@@ -389,9 +389,9 @@ class FuzzerProfile:
         """
         # Find C/CPP entry point
         if self._target_lang == "c-cpp":
-            if "LLVMFuzzerTestOneInput" in self.all_class_functions:
+            if self.entrypoint_function in self.all_class_functions:
                 self.functions_reached_by_fuzzer = (
-                    self.all_class_functions["LLVMFuzzerTestOneInput"].functions_reached
+                    self.all_class_functions[self.entrypoint_function].functions_reached
                 )
                 return
 
@@ -404,9 +404,9 @@ class FuzzerProfile:
 
         # Find JVM entrypoint
         elif self._target_lang == "jvm":
-            if "fuzzerTestOneInput" in self.all_class_functions:
+            if self.entrypoint_function in self.all_class_functions:
                 self.functions_reached_by_fuzzer = (
-                    self.all_class_functions["fuzzerTestOneInput"].functions_reached
+                    self.all_class_functions[self.entrypoint_function].functions_reached
                 )
                 return
 

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -100,7 +100,7 @@ class FuzzerProfile:
 
         elif self._target_lang == "jvm":
             # TODO Handle jvm fuzzer source file
-            logger.info("TODO Handle jvm fuzzer source file")
+            pass
 
         return self.fuzzer_source_file
 
@@ -151,7 +151,7 @@ class FuzzerProfile:
             )
         elif self.target_lang == "jvm":
             # TODO Add coverage report for JVM
-            logger.info("TODO: No coverage report for JVM yet")
+            pass
         else:
             logger.info("Could not find any html_status.json file")
         return "#"
@@ -441,7 +441,6 @@ class FuzzerProfile:
                 )
         elif self.target_lang == "jvm":
             # TODO Add JVM coverage loading support
-            logger.info("TODO Add coverage loading support for jvm")
             self.coverage = code_coverage.load_llvm_coverage(
                 target_folder,
                 self.identifier


### PR DESCRIPTION
Fix the bug that some method and data are missing from the report. 
Also, now the call tree are displaying method arguments, to distinguish same name method with different argument for unique identification purpose.

Related to issue #536 
Aim to fix bug for PR #604 