### PR TITLE
frontends: python: fix issue

### DIFF
--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -119,7 +119,10 @@ class FuzzerVisitor(ast.NodeVisitor):
                 print("Refining import to %s" % (_import))
 
             # Let's try and see if these are searchable
-            specs = importlib.util.find_spec(_import)
+            try:
+                specs = importlib.util.find_spec(_import)
+            except ModuleNotFoundError:
+                continue
             if specs is not None:
                 print("Spec:")
                 print(specs)


### PR DESCRIPTION
When module is not found we should continue and not crash.

Example issue found in `croniter` with stack trace:
```
Step #6 - "compile-libfuzzer-introspector-x86_64": Spec:
Step #6 - "compile-libfuzzer-introspector-x86_64": ModuleSpec(name='sys', loader=<class '_frozen_importlib.BuiltinImporter'>)
Step #6 - "compile-libfuzzer-introspector-x86_64": Hello
Step #6 - "compile-libfuzzer-introspector-x86_64":   - datetime.datetime
Step #6 - "compile-libfuzzer-introspector-x86_64": Traceback (most recent call last):
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/importlib/util.py", line 96, in find_spec
Step #6 - "compile-libfuzzer-introspector-x86_64":     parent_path = parent.__path__
Step #6 - "compile-libfuzzer-introspector-x86_64": AttributeError: module 'datetime' has no attribute '__path__'
Step #6 - "compile-libfuzzer-introspector-x86_64":
Step #6 - "compile-libfuzzer-introspector-x86_64": The above exception was the direct cause of the following exception:
Step #6 - "compile-libfuzzer-introspector-x86_64":
Step #6 - "compile-libfuzzer-introspector-x86_64": Traceback (most recent call last):
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 167, in <module>
Step #6 - "compile-libfuzzer-introspector-x86_64":     fuzz_packages = get_package_paths(filename)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 156, in get_package_paths
Step #6 - "compile-libfuzzer-introspector-x86_64":     fuzz_visitor.print_specifics()
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 122, in print_specifics
Step #6 - "compile-libfuzzer-introspector-x86_64":     specs = importlib.util.find_spec(_import)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/importlib/util.py", line 98, in find_spec
Step #6 - "compile-libfuzzer-introspector-x86_64":     raise ModuleNotFoundError(
Step #6 - "compile-libfuzzer-introspector-x86_64": ModuleNotFoundError: __path__ attribute not found on 'datetime' while trying to find 'datetime.datetime
```

Ref: https://oss-fuzz-build-logs.storage.googleapis.com/log-2112b514-3916-43f8-8a5e-c0bdb2addb05.txt

Signed-off-by: David Korczynski <david@adalogics.com>