### PR TITLE
docs: specify the config file does not apply to coverage reports

### DIFF
--- a/doc/Config.md
+++ b/doc/Config.md
@@ -32,7 +32,7 @@ Fuzz-introspector already excludes several functions by default, including many
 standard C++ library functions.
 
 ## Limitations
-The configuration file will only apply to data that in the Fuzz-introspector HTML
+The configuration file will only apply to data that is in the Fuzz-introspector HTML
 reports. In particular, this means:
 - The code coverage reports will still show all the files that in the coverage report which
   was used as input to Fuzz-introspector. In order to exclude certain files from the

--- a/doc/Config.md
+++ b/doc/Config.md
@@ -30,3 +30,10 @@ and also all files that have `libxml2` in the file path.
 
 Fuzz-introspector already excludes several functions by default, including many
 standard C++ library functions.
+
+## Limitations
+The configuration file will only apply to data that in the Fuzz-introspector HTML
+reports. In particular, this means:
+- The code coverage reports will still show all the files that in the coverage report which
+  was used as input to Fuzz-introspector. In order to exclude certain files from the
+  code coverage reports, it's needed to avoid instrumenting these files entirely.

--- a/doc/Config.md
+++ b/doc/Config.md
@@ -34,6 +34,7 @@ standard C++ library functions.
 ## Limitations
 The configuration file will only apply to data that is in the Fuzz-introspector HTML
 reports. In particular, this means:
-- The code coverage reports will still show all the files that in the coverage report which
-  was used as input to Fuzz-introspector. In order to exclude certain files from the
-  code coverage reports, it's needed to avoid instrumenting these files entirely.
+- The code coverage reports linked to by Fuzz-introspector will still show all the
+  files that are in the coverage report which was used as input to Fuzz-introspector.
+  In order to exclude certain files from the code coverage reports, it's needed to
+  avoid instrumenting these files entirely.


### PR DESCRIPTION
Closes: https://github.com/ossf/fuzz-introspector/issues/580

Signed-off-by: David Korczynski <david@adalogics.com>