### PR TITLE
Fix bug for python coverage

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -273,11 +273,11 @@ class CoverageProfile:
 
                 # Create the covmap
                 for exec_line in self.dual_file_map[filename]['executed_lines']:
-                    if exec_line > fstart and exec_line < fend:
+                    if exec_line > fstart and (exec_line < fend or fend == -1):
                         logger.debug(f"E: {exec_line}")
                         self.covmap[fname].append((exec_line, 1000))
                 for non_exec_line in self.dual_file_map[filename]['missing_lines']:
-                    if non_exec_line > fstart and non_exec_line < fend:
+                    if non_exec_line > fstart and (non_exec_line < fend or fend == -1):
                         logger.debug(f"N: {non_exec_line}")
                         self.covmap[fname].append((non_exec_line, 0))
         return


### PR DESCRIPTION
_fend_ will be -1 when the function is the last in the source file. And thus, for the last function in each source file, _fend_ will always be less than _exec_line_ or _non_exec_line_ making the last function of each source file will never be processed.