### PR TITLE
runner.py: create links to public corpora like CIFuzz does

### DIFF
--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -29,8 +29,15 @@ def download_public_corpus(
     fuzzer_name,
     target_zip
 ):
-    OSS_FUZZ_PUBLIC_CORPUS = "https://storage.googleapis.com/%s-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/%s_%s/public.zip"
-    download_url = OSS_FUZZ_PUBLIC_CORPUS % (project_name, project_name, fuzzer_name)
+    OSS_FUZZ_PUBLIC_CORPUS = "https://storage.googleapis.com/%s-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/%s/public.zip"
+
+    # There is a special case where the names of projects aren't added to links to public
+    # corpora if the names of fuzz targets already start with their project's name + "_":
+    # https://github.com/google/oss-fuzz/blob/7797279c274d10197d62841dc43834238fd483a1/infra/cifuzz/clusterfuzz_deployment.py#L295-L298
+    if fuzzer_name.startswith(f"{project_name}_"):
+        download_url = OSS_FUZZ_PUBLIC_CORPUS % (project_name, fuzzer_name)
+    else:
+        download_url = OSS_FUZZ_PUBLIC_CORPUS % (project_name, f"{project_name}_{fuzzer_name}")
 
     cmd = f"wget {download_url}"
     if target_zip:


### PR DESCRIPTION
There is a special case where the names of projects aren't added to links to public corpora if the names of fuzz targets already start with their project's name + "_": https://github.com/google/oss-fuzz/blob/7797279c274d10197d62841dc43834238fd483a1/infra/cifuzz/clusterfuzz_deployment.py#L295-L298

It should make it possible to use the script with projects like avahi
```
--2022-11-22 17:54:14--  https://storage.googleapis.com/avahi-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/avahi_avahi_packet_consume_record_fuzzer/public.zip
Resolving storage.googleapis.com (storage.googleapis.com)... 173.194.222.128, 173.194.73.128, 74.125.131.128, ...
Connecting to storage.googleapis.com (storage.googleapis.com)|173.194.222.128|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2022-11-22 17:54:17 ERROR 403: Forbidden.
```