### PR TITLE
[Java Integration] Connect oss-fuzz jvm project with fuzz-introspector runner

### DIFF
--- a/oss_fuzz_integration/jvm.patch
+++ b/oss_fuzz_integration/jvm.patch
@@ -37,11 +37,13 @@ class=${class:1}
 cd $OUT
 rm -rf fuzz-introspector
 git clone https://github.com/arthurscchan/fuzz-introspector
+# Require change to "cd fuzz-introspector/frontends/java"
 cd fuzz-introspector/frontends/java/soot
-git checkout coverage-report
 sed -i 's/mvn/$MVN/g' run.sh
 ./run.sh -j $jarfile -c $class -m fuzzerTestOneInput
 cd $OUT
+# Require change to "cp fuzz-introspector/frontends/java/*.data ./"
 cp fuzz-introspector/frontends/java/soot/*.data ./
+# Require change to "cp fuzz-introspector/frontends/java/*.data.yaml ./"
 cp fuzz-introspector/frontends/java/soot/*.data.yaml ./
 rm -rf fuzz-introspector

--- a/oss_fuzz_integration/jvm.patch
+++ b/oss_fuzz_integration/jvm.patch
@@ -1,0 +1,47 @@
+# Packing for fuzz-introspector
+jarfile=
+class=
+
+for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+  stripped_path=$(echo ${fuzzer} | sed 's|^.*src/main/java/\(.*\).java$|\1|');
+  # the .java was stripped by sed
+  if (echo ${stripped_path} | grep ".java$"); then
+    fuzzer_classname=$(basename -s .java $fuzzer);
+  else
+    fuzzer_classname=$(echo ${stripped_path} | sed 's|/|.|g')
+  fi
+  fuzzer_basename=$(basename -s .java $fuzzer)
+
+  cd $OUT
+  if ls $fuzzer_basename*.class 1>/dev/null 2>&1
+  then
+    jar cvf $fuzzer_basename.jar $fuzzer_basename*.class
+    jarfile=$jarfile:$OUT/$fuzzer_basename.jar
+  fi
+  class=$class:$fuzzer_classname
+  cd -
+done
+
+# Add jar dependency
+for jar in $ALL_JARS
+do
+  if [[ -f "$OUT/$jar" ]]
+  then
+    jarfile=$jarfile:$OUT/$jar
+  fi
+done
+
+jarfile=${jarfile:1}
+class=${class:1}
+
+cd $OUT
+rm -rf fuzz-introspector
+git clone https://github.com/arthurscchan/fuzz-introspector
+cd fuzz-introspector/frontends/java/soot
+git checkout coverage-report
+sed -i 's/mvn/$MVN/g' run.sh
+./run.sh -j $jarfile -c $class -m fuzzerTestOneInput
+cd $OUT
+cp fuzz-introspector/frontends/java/soot/*.data ./
+cp fuzz-introspector/frontends/java/soot/*.data.yaml ./
+rm -rf fuzz-introspector

--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -430,15 +430,15 @@ def introspector_run(
             os.path.join(curr_dir, "build", "out", project_name)
         )
 
-        # Clean fuzz-introspector
-        if os.path.isdir(os.path.join(curr_dir, "fuzz-introspector-main")):
-            shutil.rmtree(os.path.join(curr_dir, "fuzz-introspector-main"))
-
         generate_html_report(
             introspector_main_path,
             target_project_path,
             latest_corpus_dir
         )
+
+        # Clean fuzz-introspector
+        if os.path.isdir(os.path.join(curr_dir, "fuzz-introspector-main")):
+            shutil.rmtree(os.path.join(curr_dir, "fuzz-introspector-main"))
 
         server_directory = os.path.abspath(latest_corpus_dir)
     else:


### PR DESCRIPTION
Add logic in fuzz-introspector runner to include all necessary steps (Build, run, generating coverage, generating html report) for oss-fuzz jvm project, thus connecting them to fuzz introspector.

This PR consist of the following steps for JVM project connection:

1. Apply patch for fuzz-introspector logic into the jvm project's build.sh before building the project.
2. Build the project normally, run the fuzzers, rebuild the project with coverage sanitizer to generate coverage report
3. Goto correct build result folder, set the correct permission.
4. Run fuzz-introspector main logic to generate HTML report
5. Launch the python http.server in the directory to showcase the HTML report.

This is related to the last step of issue #536

Signed-off-by: Arthur Chan <arthur.chan@adalogics.com>