### PR TITLE
[Java Integration] Add CI to execute jvm test cases

### DIFF
--- a/.github/workflows/jvm-test.yml
+++ b/.github/workflows/jvm-test.yml
@@ -1,0 +1,18 @@
+name: JVM-Test
+
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: JVM-Test
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+    - name: Set up OpenJDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '11'
+    - name: JVM-Test
+      run: |
+        cd tests/java && ./buildAll.sh && ./runTest.sh


### PR DESCRIPTION
Add in automatic cI to test jvm test cases on java code.

This is part of the final checking for issue #536 

Signed-off-by: Arthur Chan <arthur.chan@adalogics.com>