### PR TITLE
oss-fuzz: refine jvm set up

### DIFF
--- a/oss_fuzz_integration/jvm.patch
+++ b/oss_fuzz_integration/jvm.patch
@@ -36,14 +36,12 @@ class=${class:1}
 
 cd $OUT
 rm -rf fuzz-introspector
-git clone https://github.com/arthurscchan/fuzz-introspector
-# Require change to "cd fuzz-introspector/frontends/java"
-cd fuzz-introspector/frontends/java/soot
+git clone https://github.com/ossf/fuzz-introspector
+
+cd fuzz-introspector/frontends/java/
 sed -i 's/mvn/$MVN/g' run.sh
 ./run.sh -j $jarfile -c $class -m fuzzerTestOneInput
 cd $OUT
-# Require change to "cp fuzz-introspector/frontends/java/*.data ./"
-cp fuzz-introspector/frontends/java/soot/*.data ./
-# Require change to "cp fuzz-introspector/frontends/java/*.data.yaml ./"
-cp fuzz-introspector/frontends/java/soot/*.data.yaml ./
+cp fuzz-introspector/frontends/java/*.data ./
+cp fuzz-introspector/frontends/java/*.data.yaml ./
 rm -rf fuzz-introspector

--- a/oss_fuzz_integration/jvm.patch
+++ b/oss_fuzz_integration/jvm.patch
@@ -1,47 +1,51 @@
-# Packing for fuzz-introspector
-jarfile=
-class=
+if [[ ${SET_FUZZINTRO_JVM:-"unset"} == "unset" ]];
+then
+  # Packing for fuzz-introspector
+  jarfile=
+  class=
 
-for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
-  stripped_path=$(echo ${fuzzer} | sed 's|^.*src/main/java/\(.*\).java$|\1|');
-  # the .java was stripped by sed
-  if (echo ${stripped_path} | grep ".java$"); then
-    fuzzer_classname=$(basename -s .java $fuzzer);
-  else
-    fuzzer_classname=$(echo ${stripped_path} | sed 's|/|.|g')
-  fi
-  fuzzer_basename=$(basename -s .java $fuzzer)
+  for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
+    stripped_path=$(echo ${fuzzer} | sed 's|^.*src/main/java/\(.*\).java$|\1|');
+    # the .java was stripped by sed
+    if (echo ${stripped_path} | grep ".java$"); then
+      fuzzer_classname=$(basename -s .java $fuzzer);
+    else
+      fuzzer_classname=$(echo ${stripped_path} | sed 's|/|.|g')
+    fi
+    fuzzer_basename=$(basename -s .java $fuzzer)
+
+    cd $OUT
+    if ls $fuzzer_basename*.class 1>/dev/null 2>&1
+    then
+      jar cvf $fuzzer_basename.jar $fuzzer_basename*.class
+      jarfile=$jarfile:$OUT/$fuzzer_basename.jar
+    fi
+    class=$class:$fuzzer_classname
+    cd -
+  done
+
+  # Add jar dependency
+  for jar in $ALL_JARS
+  do
+    if [[ -f "$OUT/$jar" ]]
+    then
+      jarfile=$jarfile:$OUT/$jar
+    fi
+  done
+
+  jarfile=${jarfile:1}
+  class=${class:1}
 
   cd $OUT
-  if ls $fuzzer_basename*.class 1>/dev/null 2>&1
-  then
-    jar cvf $fuzzer_basename.jar $fuzzer_basename*.class
-    jarfile=$jarfile:$OUT/$fuzzer_basename.jar
-  fi
-  class=$class:$fuzzer_classname
-  cd -
-done
+  rm -rf fuzz-introspector
+  git clone https://github.com/ossf/fuzz-introspector
 
-# Add jar dependency
-for jar in $ALL_JARS
-do
-  if [[ -f "$OUT/$jar" ]]
-  then
-    jarfile=$jarfile:$OUT/$jar
-  fi
-done
-
-jarfile=${jarfile:1}
-class=${class:1}
-
-cd $OUT
-rm -rf fuzz-introspector
-git clone https://github.com/ossf/fuzz-introspector
-
-cd fuzz-introspector/frontends/java/
-sed -i 's/mvn/$MVN/g' run.sh
-./run.sh -j $jarfile -c $class -m fuzzerTestOneInput
-cd $OUT
-cp fuzz-introspector/frontends/java/*.data ./
-cp fuzz-introspector/frontends/java/*.data.yaml ./
-rm -rf fuzz-introspector
+  cd fuzz-introspector/frontends/java/
+  sed -i 's/mvn/$MVN/g' run.sh
+  ./run.sh -j $jarfile -c $class -m fuzzerTestOneInput
+  cd $OUT
+  cp fuzz-introspector/frontends/java/*.data ./
+  cp fuzz-introspector/frontends/java/*.data.yaml ./
+  rm -rf fuzz-introspector
+  export SET_FUZZINTRO_JVM="SET"
+fi

--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -26,6 +26,7 @@ import requests
 import zipfile
 from typing import Optional
 
+THIS_DIR=os.path.dirname(os.path.abspath(__file__))
 
 def download_public_corpus(
     project_name,
@@ -121,7 +122,7 @@ def patch_jvm_build(project_build_path):
     # Patch build.sh to include fuzz-introspector logic for JVM project
     if os.path.exists(project_build_path):
         content = ''
-        with open('jvm.patch') as file_handle:
+        with open(os.path.join(THIS_DIR, 'jvm.patch')) as file_handle:
             content = file_handle.read()
         with open(project_build_path, 'a+') as file_handle:
             file_handle.write('\n')


### PR DESCRIPTION
- Change the paths where indicated by the `# Require change to "cp fuzz-introspector/frontends/java/*.data ./"
- Modify the `runner.py` to find the `jvm.patch` relative to the `runner.py` file instead of the current working dir
- wrap the `jvm.patch` script in a condition that's only true once, meaning we can run `runner.py` a number of times. This is a quick hack for a temporary situation.
- fix a bug in `runner.py` for correctly identifying fuzz targets.

Signed-off-by: David Korczynski <david@adalogics.com>