### PR TITLE
oss-fuzz: provide patches for jvm integration

### DIFF
--- a/oss_fuzz_integration/build_post_processing.sh
+++ b/oss_fuzz_integration/build_post_processing.sh
@@ -44,4 +44,5 @@ cp -rf ../frontends/ ./oss-fuzz/infra/base-images/base-builder/frontends
 cd oss-fuzz
 docker build -t gcr.io/oss-fuzz-base/base-builder infra/base-images/base-builder
 docker build -t gcr.io/oss-fuzz-base/base-builder-python infra/base-images/base-builder-python
+docker build -t gcr.io/oss-fuzz-base/base-builder-jvm infra/base-images/base-builder-jvm
 docker build -t gcr.io/oss-fuzz-base/base-runner infra/base-images/base-runner

--- a/oss_fuzz_integration/jvm.patch
+++ b/oss_fuzz_integration/jvm.patch
@@ -1,4 +1,4 @@
-if [[ ${SET_FUZZINTRO_JVM:-"unset"} == "unset" ]];
+if [[ ${SANITIZER} == "introspector" && ${SET_FUZZINTRO_JVM:-"unset"} == "unset" ]];
 then
   # Packing for fuzz-introspector
   jarfile=
@@ -44,8 +44,9 @@ then
   sed -i 's/mvn/$MVN/g' run.sh
   ./run.sh -j $jarfile -c $class -m fuzzerTestOneInput
   cd $OUT
-  cp fuzz-introspector/frontends/java/*.data ./
-  cp fuzz-introspector/frontends/java/*.data.yaml ./
+  mkdir -p $SRC/my-fi-data
+  cp fuzz-introspector/frontends/java/*.data $SRC/my-fi-data/
+  cp fuzz-introspector/frontends/java/*.data.yaml $SRC/my-fi-data/
   rm -rf fuzz-introspector
   export SET_FUZZINTRO_JVM="SET"
 fi

--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -1,8 +1,8 @@
 diff --git a/infra/base-images/base-builder/Dockerfile b/infra/base-images/base-builder/Dockerfile
-index aa954a17..c033e1c4 100644
+index 12c08499..9808589b 100644
 --- a/infra/base-images/base-builder/Dockerfile
 +++ b/infra/base-images/base-builder/Dockerfile
-@@ -160,5 +160,9 @@ COPY cargo compile compile_afl compile_libfuzzer compile_honggfuzz \
+@@ -162,5 +162,9 @@ COPY cargo compile compile_afl compile_libfuzzer compile_honggfuzz \
  COPY llvmsymbol.diff $SRC
  COPY detect_repo.py /opt/cifuzz/
  COPY bazel.bazelrc /root/.bazelrc
@@ -12,8 +12,48 @@ index aa954a17..c033e1c4 100644
 +COPY frontends /fuzz-introspector/frontends
  
  CMD ["compile"]
+diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
+index e82b8153..b0e3688e 100755
+--- a/infra/base-images/base-builder/compile
++++ b/infra/base-images/base-builder/compile
+@@ -16,7 +16,7 @@
+ ################################################################################
+ 
+ echo "---------------------------------------------------------------"
+-
++echo "Checking with sanitizer $SANITIZER"
+ # This is a temporary fix: fall back to LLVM14's old pass manager
+ if [ -n "${OLD_LLVMPASS-}" ]; then
+   export SANITIZER_FLAGS_introspector=$(echo $SANITIZER_FLAGS_introspector | sed -r 's/-O0/-flegacy-pass-manager/')
+@@ -27,8 +27,9 @@ if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
+     echo "ERROR: JVM projects can be fuzzed with libFuzzer or tested with wycheproof engines only."
+     exit 1
+   fi
+-  if [ "$SANITIZER" != "address" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "none" ]; then
+-    echo "ERROR: JVM projects can be fuzzed with AddressSanitizer or UndefinedBehaviorSanitizer only."
++  if [ "$SANITIZER" != "address" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "none" ] && [ "$SANITIZER" != "introspector" ]; then
++    echo "$SANITIZER"
++    echo "ERROR: JVM projects can be fuzzed with AddressSanitizer or UndefinedBehaviorSanitizer or introspector only."
+     exit 1
+   fi
+   if [ "$ARCHITECTURE" != "x86_64" ]; then
+@@ -251,6 +252,14 @@ if [ "$SANITIZER" = "introspector" ]; then
+     REPORT_ARGS="$REPORT_ARGS --language=python"
+     python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
+     cp -rf $SRC/inspector $OUT/inspector
++  elif [ "$FUZZING_LANGUAGE" = "jvm" ]; then
++    echo "GOING jvm route"
++    set -x
++    find $OUT/ -name "jacoco.xml" -exec cp {} $SRC/inspector/ \;
++    REPORT_ARGS="$REPORT_ARGS --target_dir=$SRC/inspector"
++    REPORT_ARGS="$REPORT_ARGS --language=jvm"
++    python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
++    cp -rf $SRC/inspector $OUT/inspector
+   else
+     # C/C++
+ 
 diff --git a/infra/base-images/base-clang/Dockerfile b/infra/base-images/base-clang/Dockerfile
-index 964a10a0..1c3d686d 100644
+index a4e23350..d734662f 100644
 --- a/infra/base-images/base-clang/Dockerfile
 +++ b/infra/base-images/base-clang/Dockerfile
 @@ -45,6 +45,8 @@ RUN apt-get update && apt-get install -y git && \
@@ -48,7 +88,7 @@ index bc034e19..929e3499 100755
  # Copy the binaries needed for code coverage and crash symbolization.
  COPY --from=base-clang /usr/local/bin/llvm-cov \
 diff --git a/projects/jackson-databind/build.sh b/projects/jackson-databind/build.sh
-index b5ea5b01..fa0001ba 100755
+index 7dd6f09b..b304a3c4 100755
 --- a/projects/jackson-databind/build.sh
 +++ b/projects/jackson-databind/build.sh
 @@ -55,6 +55,9 @@ BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
@@ -95,3 +135,16 @@ index b5ea5b01..fa0001ba 100755
 +cd $OUT
 +cp fuzz-introspector/frontends/java/soot/*.result ./
 +rm -rf fuzz-introspector
+diff --git a/projects/javassist/build.sh b/projects/javassist/build.sh
+index b4890d06..5c5e7fc7 100644
+--- a/projects/javassist/build.sh
++++ b/projects/javassist/build.sh
+@@ -23,7 +23,7 @@ mv ./src/test ./src/java
+ mkdir ./src/test
+ mv ./src/java ./src/test/java
+ 
+-MAVEN_ARGS="-Djavac.src.version=15 -Djavac.target.version=15 -DskipTests"
++MAVEN_ARGS="-Djavac.src.version=15 -Djavac.target.version=15 -DskipTests --quiet"
+ $MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
+ CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+  -Dexpression=project.version -q -DforceStdout)

--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -73,30 +73,6 @@ def download_full_public_corpus(project_name, target_corpus_dir: None):
         subprocess.check_call(f"unzip {target_zip} -d {target_fuzzer_dir}/", shell=True)
 
 
-def prepare_introspector(curr_dir):
-    # Download and introspector and return its main.py path
-    try:
-        if os.path.isdir(os.path.join(curr_dir, "fuzz-introspector-main")):
-            shutil.rmtree(os.path.join(curr_dir, "fuzz-introspector-main"))
-
-        URL = "https://github.com/ossf/fuzz-introspector/archive/refs/heads/main.zip"
-        response = requests.get(URL)
-        with open("introspector.zip", "wb") as file_handle:
-            file_handle.write(response.content)
-
-        with zipfile.ZipFile("introspector.zip", "r") as file_handle:
-            file_handle.extractall(".")
-
-        os.remove("introspector.zip")
-
-        return os.path.abspath(
-            os.path.join(curr_dir, "fuzz-introspector-main", "src", "main.py")
-        )
-    except:
-        print("Introspector fail.")
-        exit(1)
-
-
 def build_project(
     project_name,
     sanitizer = None,
@@ -124,8 +100,6 @@ def patch_jvm_build(project_build_path):
         content = ''
         with open(os.path.join(THIS_DIR, 'jvm.patch')) as file_handle:
             content = file_handle.read()
-        if "SET_FUZZINTRO_JVM" in content:
-            return
         with open(project_build_path, 'a+') as file_handle:
             file_handle.write('\n')
             file_handle.write(content)
@@ -347,39 +321,6 @@ def get_coverage(project_name, corpus_dir):
     print("Finished")
 
 
-def generate_html_report(
-    introspector_main_path,
-    target_project_path,
-    corpus_dir
-):
-    # Switch to corpus directory
-    curr_dir = os.getcwd()
-    os.chdir(corpus_dir)
-
-    # Execute introspector to generate html report
-    cmd = [
-        "python3",
-        introspector_main_path,
-        "report",
-        "--target_dir",
-        target_project_path,
-        "--language",
-        "jvm",
-        "--coverage_url",
-        "/report/linux"
-    ]
-    try:
-        subprocess.check_call(
-            " ".join(cmd),
-            shell=True
-        )
-    except:
-        print("Could not generate html reports")
-    finally:
-        # Switch back to working dir
-        os.chdir(curr_dir)
-
-
 def setup_next_corpus_dir(project_name):
     fuzzer_names = get_fuzzers(project_name)
     corpus_dir = get_next_corpus_dir()
@@ -440,64 +381,37 @@ def introspector_run(
 
     curr_dir = os.path.abspath(".")
 
-    if get_project_lang(project_name) == 'jvm-old':
-        # For JVM project, execute fuzz-introspector manually
+    # Build sanitizers with introspector
+    build_project(project_name, sanitizer="introspector")
 
+    # get the latest corpus
+    latest_corpus_dir = get_recent_corpus_dir()
 
-        # Prepare fuzz-introspector
-        introspector_main_path = prepare_introspector(curr_dir)
+    # copy over inpsoector and coverage reports
 
-        # get the latest corpus
-        latest_corpus_dir = get_recent_corpus_dir()
+    # copy over reports:
+    # - introspector
+    # - project coverage
+    # - per-fuzzer coverage
+    if os.path.isdir(os.path.join(latest_corpus_dir, "inspector-report")):
+        shutil.rmtree(os.path.join(latest_corpus_dir, "inspector-report"))
 
-        # get target project path
-        target_project_path = os.path.abspath(
-            os.path.join(curr_dir, "build", "out", project_name)
-        )
-
-        generate_html_report(
-            introspector_main_path,
-            target_project_path,
-            latest_corpus_dir
-        )
-
-        # Clean fuzz-introspector
-        if os.path.isdir(os.path.join(curr_dir, "fuzz-introspector-main")):
-            shutil.rmtree(os.path.join(curr_dir, "fuzz-introspector-main"))
-
-        server_directory = os.path.abspath(latest_corpus_dir)
-    else:
-        # Build sanitizers with introspector
-        build_project(project_name, sanitizer="introspector")
-
-        # get the latest corpus
-        latest_corpus_dir = get_recent_corpus_dir()
-
-        # copy over inpsoector and coverage reports
-
-        # copy over reports:
-        # - introspector
-        # - project coverage
-        # - per-fuzzer coverage
-        if os.path.isdir(os.path.join(latest_corpus_dir, "inspector-report")):
-            shutil.rmtree(os.path.join(latest_corpus_dir, "inspector-report"))
-
+    shutil.copytree(
+        os.path.join(curr_dir, "build", "out", project_name, "inspector"),
+        os.path.join(latest_corpus_dir, "inspector-report")
+    )
+    if collect_coverage:
         shutil.copytree(
-            os.path.join(curr_dir, "build", "out", project_name, "inspector"),
-            os.path.join(latest_corpus_dir, "inspector-report")
+            os.path.join(latest_corpus_dir, "report"),
+            os.path.join(latest_corpus_dir, "inspector-report", "covreport")
         )
-        if collect_coverage:
-            shutil.copytree(
-                os.path.join(latest_corpus_dir, "report"),
-                os.path.join(latest_corpus_dir, "inspector-report", "covreport")
-            )
 
-            for target_coverage_dir in os.listdir(os.path.join(latest_corpus_dir, "report_target")):
-                shutil.copytree(
-                    os.path.join(latest_corpus_dir, "report_target", target_coverage_dir),
-                    os.path.join(latest_corpus_dir, "inspector-report", "covreport", target_coverage_dir)
-                )
-        server_directory = os.path.join(latest_corpus_dir, "inspector-report")
+        for target_coverage_dir in os.listdir(os.path.join(latest_corpus_dir, "report_target")):
+            shutil.copytree(
+                os.path.join(latest_corpus_dir, "report_target", target_coverage_dir),
+                os.path.join(latest_corpus_dir, "inspector-report", "covreport", target_coverage_dir)
+            )
+    server_directory = os.path.join(latest_corpus_dir, "inspector-report")
 
     # start webserver
     cmd = "python3 -m http.server %d --directory %s" % (port, server_directory)

--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -124,6 +124,8 @@ def patch_jvm_build(project_build_path):
         content = ''
         with open(os.path.join(THIS_DIR, 'jvm.patch')) as file_handle:
             content = file_handle.read()
+        if "SET_FUZZINTRO_JVM" in content:
+            return
         with open(project_build_path, 'a+') as file_handle:
             file_handle.write('\n')
             file_handle.write(content)
@@ -438,7 +440,7 @@ def introspector_run(
 
     curr_dir = os.path.abspath(".")
 
-    if get_project_lang(project_name) == 'jvm':
+    if get_project_lang(project_name) == 'jvm-old':
         # For JVM project, execute fuzz-introspector manually
 
 


### PR DESCRIPTION
Provides patches for oss-fuzz that modifies the infrastructure to handle introspector runs for jvm targets. We only needed some minor changes in `infra/base-images/base-builder/compile` and some updates in `jvm.patch`. Also cleans up some of the jvm-specific logic from `runner.py` introduced in https://github.com/ossf/fuzz-introspector/pull/621