### PR TITLE
Allow pointing runner to local source directories

### DIFF
--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -75,6 +75,7 @@ def download_full_public_corpus(project_name, target_corpus_dir: None):
 
 def build_project(
     project_name,
+    source_dir = None,
     sanitizer = None,
     to_clean = False
 ):
@@ -86,6 +87,8 @@ def build_project(
     if to_clean:
         cmd.append("--clean")
     cmd.append(project_name)
+    if source_dir is not None:
+        cmd.append(source_dir)
 
     try:
         subprocess.check_call(" ".join(cmd), shell=True)
@@ -371,6 +374,7 @@ def setup_next_corpus_dir(project_name):
 
 def complete_coverage_check(
     project_name: str,
+    source_dir: Optional[str],
     fuzztime: int,
     job_count: int,
     corpus_dir: Optional[str],
@@ -384,14 +388,14 @@ def complete_coverage_check(
             # Apply jvm build patch to include fuzz-introspector logic
             patch_jvm_build(project_build_path)
 
-    build_project(project_name, to_clean=True)
+    build_project(project_name, source_dir, to_clean=True)
 
     if download_public_corpus:
         corpus_dir = setup_next_corpus_dir(project_name)
         download_full_public_corpus(project_name, corpus_dir)
 
     run_all_fuzzers(project_name, fuzztime, job_count, corpus_dir)
-    build_project(project_name, sanitizer="coverage")
+    build_project(project_name, source_dir, sanitizer="coverage")
     percent = get_coverage(project_name, corpus_dir)
 
     return percent
@@ -399,6 +403,7 @@ def complete_coverage_check(
 
 def introspector_run(
     project_name: str,
+    source_dir: Optional[str],
     fuzztime: int,
     job_count: int,
     corpus_dir: Optional[str],
@@ -409,19 +414,20 @@ def introspector_run(
     if collect_coverage:
         complete_coverage_check(
             project_name,
+            source_dir,
             fuzztime,
             job_count,
             corpus_dir,
             download_public_corpus
         )
     else:
-        build_project(project_name, to_clean=True)
+        build_project(project_name, source_dir, to_clean=True)
         setup_next_corpus_dir(project_name)
 
     curr_dir = os.path.abspath(".")
 
     # Build sanitizers with introspector
-    build_project(project_name, sanitizer="introspector")
+    build_project(project_name, source_dir, sanitizer="introspector")
 
     # get the latest corpus
     latest_corpus_dir = get_recent_corpus_dir()
@@ -518,6 +524,12 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         help="if set, will download public corpus",
         default=False
     )
+    coverage_parser.add_argument(
+        "--source-dir",
+        type=str,
+        help="path to source",
+        default=None
+    )
 
     introspector_parser = subparsers.add_parser("introspector")
     introspector_parser.add_argument(
@@ -560,6 +572,12 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         help="Do not run coverage in this case",
         default=False
     )
+    introspector_parser.add_argument(
+        "--source-dir",
+        type=str,
+        help="path to source",
+        default=None
+    )
 
     download_corpus_parser = subparsers.add_parser("download-corpus")
     download_corpus_parser.add_argument(
@@ -579,6 +597,7 @@ if __name__ == "__main__":
         print("  jobs = %d"%(args.jobs))
         complete_coverage_check(
             args.project,
+            args.source_dir,
             args.fuzztime,
             args.jobs,
             args.corpus_dir,
@@ -588,6 +607,7 @@ if __name__ == "__main__":
         print("Running full")
         introspector_run(
             args.project,
+            args.source_dir,
             args.fuzztime,
             args.jobs,
             args.corpus_dir,


### PR DESCRIPTION
There are use cases where it would be desirable to be able to point FI to specific local directories when projects are built. For example systemd can't be built with FI because it links its fuzz targets against shared libraries and any patches getting FI to work are unlikely to be accepted upstream. That shouldn't prevent anyone from using FI with it though as long as their local forks are compatible with FI. Also when fuzz targets and/or code are changed or when PRs are analyzed locally it should be possible to confirm that things have gotten better or at least haven't gotten worse.

It's probably worth mentioning that since `./infra/helper.py` doesn't clean up after itself for this to work build scripts should clean up their build directories themselves using `make clean`, `git clean -dxf`
 `rm ./build` or something like that. That looks like an
`infra/helper.py` bug and should probably be fixed there eventually by switching to ephemeral mounts where whatever is written by build scripts gets deleted once containers are stopped.