### PR TITLE
Make runner executable

### DIFF
--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2021 Fuzz Introspector Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
to make it possible to just run it directly using `../runner.py` instead of `python3 ../runner.py`. It should make it a bit easier to use the script interactively.