### PR TITLE
Java-Issue: Fix method naming logic error

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -165,20 +165,16 @@ class CustomSenceTransformer extends SceneTransformer {
           continue;
         }
 
-        if (m.getName().equals(this.entryMethodStr) && c.getName().equals(this.entryClassStr)) {
-          this.entryMethod = m;
-        }
-
         // Discover method related information
         FunctionElement element = new FunctionElement();
         Map<String, Integer> functionLineMap = new HashMap<String, Integer>();
 
-        // Unable to retrieve from Soot
-        // element.setLinkageType("???");
-        // element.setConstantsTouched([]);
-        // element.setArgNames();
-
-        element.setFunctionName(m.getSubSignature().split(" ")[1]);
+        if (m.getName().equals(this.entryMethodStr) && c.getName().equals(this.entryClassStr)) {
+          this.entryMethod = m;
+          element.setFunctionName(m.getSubSignature().split(" ")[1]);
+        } else {
+          element.setFunctionName("[" + c.getFilePath() + "]." + m.getSubSignature().split(" ")[1]);
+        }
         element.setFunctionSourceFile(c.getFilePath());
         element.setFunctionLinenumber(m.getJavaSourceStartLineNumber());
         element.setReturnType(m.getReturnType().toString());
@@ -190,7 +186,7 @@ class CustomSenceTransformer extends SceneTransformer {
 
         // Identify in / out edges of each method.
         int methodEdges = 0;
-        Iterator<Edge> outEdges = callGraph.edgesOutOf(m);
+        Iterator<Edge> outEdges = this.mergePolymorphism(callGraph, callGraph.edgesOutOf(m));
         Iterator<Edge> inEdges = callGraph.edgesInto(m);
         while (inEdges.hasNext()) {
           methodEdges++;
@@ -200,12 +196,32 @@ class CustomSenceTransformer extends SceneTransformer {
         methodEdges = 0;
         for (; outEdges.hasNext(); methodEdges++) {
           Edge edge = outEdges.next();
-          SootMethod tgt = (SootMethod) edge.getTgt();
+          SootMethod tgt = edge.tgt();
           if (this.excludeMethodList.contains(tgt.getName())) {
             methodEdges--;
             continue;
           }
-          element.addFunctionsReached(tgt.getSubSignature().split(" ")[1]);
+          String callerClass = edge.src().getDeclaringClass().getName();
+          String className = "";
+          Set<String> classNameSet =
+              this.edgeClassMap.getOrDefault(
+                  callerClass
+                  + ":"
+                  + tgt.getName() + ":"
+                  + ((edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber()),
+                  Collections.emptySet());
+          className = this.mergeClassName(classNameSet);
+          boolean merged = false;
+          for (String name : className.split(":")) {
+            if (name.equals(tgt.getDeclaringClass().getName())) {
+              merged = true;
+              break;
+            }
+          }
+          if (!merged) {
+            className = tgt.getDeclaringClass().getName();
+          }
+		  element.addFunctionsReached("[" + className + "]." + tgt.getSubSignature().split(" ")[1]);
           functionLineMap.put(
               tgt.getSubSignature().split(" ")[1], edge.srcStmt().getJavaSourceStartLineNumber());
         }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -206,9 +206,12 @@ class CustomSenceTransformer extends SceneTransformer {
           Set<String> classNameSet =
               this.edgeClassMap.getOrDefault(
                   callerClass
-                  + ":"
-                  + tgt.getName() + ":"
-                  + ((edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber()),
+                      + ":"
+                      + tgt.getName()
+                      + ":"
+                      + ((edge.srcStmt() == null)
+                          ? -1
+                          : edge.srcStmt().getJavaSourceStartLineNumber()),
                   Collections.emptySet());
           className = this.mergeClassName(classNameSet);
           boolean merged = false;
@@ -221,7 +224,7 @@ class CustomSenceTransformer extends SceneTransformer {
           if (!merged) {
             className = tgt.getDeclaringClass().getName();
           }
-		  element.addFunctionsReached("[" + className + "]." + tgt.getSubSignature().split(" ")[1]);
+          element.addFunctionsReached("[" + className + "]." + tgt.getSubSignature().split(" ")[1]);
           functionLineMap.put(
               tgt.getSubSignature().split(" ")[1], edge.srcStmt().getJavaSourceStartLineNumber());
         }


### PR DESCRIPTION
Java method from different classes are allowed to have a same signature. This logic does not work well with fuzz-introspector which identify unique function only by function name. In order to accommodate fuzz-introspector analysing logic, changes has been made on the Soot static analysis code to include also the class name as part of the function identifiers. This PR provide a fix to the soot generation logic to include class name in the resulting .data and .data.yaml file to allow fuzz-introspector correctly handle and analyse methods from different class but with the exact same signature.

Example:
toString() methods coming from java.io.File and java.io.FileInputStream have the exact same signature, making the method name as java.io.File.toString() and java.io.FileInputStream.toString() can uniquely identify them.

Related to Issue #629 

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>