### PR TITLE
JVM-issue: Fix multiple append bug

### DIFF
--- a/oss_fuzz_integration/runner.py
+++ b/oss_fuzz_integration/runner.py
@@ -189,8 +189,7 @@ def has_append(project_build_path):
         with open(project_build_path) as file_handle:
             content = file_handle.read()
             for line in content.splitlines():
-                match = re.compile(r'# Packing for fuzz-introspector').match(line)
-                if match:
+                if 'export SET_FUZZINTRO_JVM="SET"' in line:
                     return True
     return False
 


### PR DESCRIPTION
The has_append() checking logic is invalid after the changes of the jvm.patch. This bug will append a fresh version of jvm.patch to the project build file even if it is already appended from last build. Although the appended shell code from jvm.patch contains self-check to ensure single execution, extending the build.sh up with non-used repeating logic is not good.

This PR aims to fix the checking criteria and ensure the append will not done again.

Related to issue #629 

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>