### PR TITLE
More verbose YAML loading

### DIFF
--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -84,8 +84,8 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         with open(filename, 'r') as stream:
             data_dict: Dict[Any, Any] = yaml.safe_load(stream)
             return data_dict
-    except (yaml.YAMLError, UnicodeDecodeError):
-        logger.info("Error loading yaml file")
+    except yaml.YAMLError as e:
+        logger.info("Error loading yaml file: " + str(e))
 
     # Try loading multiple yaml files in the fuzz introspector format
     # We need this because we have different formats for each language.
@@ -94,8 +94,8 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         with open(filename, 'r') as yaml_f:
             data = yaml_f.read()
             docs = yaml.safe_load_all(data)
-    except (yaml.YAMLError, UnicodeDecodeError):
-        logger.info("Failed loading")
+    except yaml.YAMLError as e:
+        logger.info("Failed loading YAML: " + str(e))
         return None
 
     content = dict()
@@ -112,7 +112,8 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
                     content['All functions']['Elements'].extend(
                         doc['All functions']['Elements']
                     )
-    except yaml.YAMLError:
+    except yaml.YAMLError as e:
+        logger.info("Failed loading YAML: " + str(e))        
         return None
     if "Fuzzer filename" not in content:
         return None

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -84,12 +84,14 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         with open(filename, 'r') as stream:
             data_dict: Dict[Any, Any] = yaml.safe_load(stream)
             return data_dict
-    except yaml.YAMLError as e:
-        logger.info("Error loading yaml file: " + str(e))
+    except yaml.YAMLError:
+        # This likely fails as the LLVM frontend now is putting multiple docs in
+        # same yaml file. See commit 737ba72.
+        pass
 
     # Try loading multiple yaml files in the fuzz introspector format
     # We need this because we have different formats for each language.
-    logger.info("Trying to load multiple file formats toget")
+    logger.info("Trying to load multiple file formats together.")
     try:
         with open(filename, 'r') as yaml_f:
             data = yaml_f.read()
@@ -113,7 +115,7 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
                         doc['All functions']['Elements']
                     )
     except yaml.YAMLError as e:
-        logger.info("Failed loading YAML: " + str(e))        
+        logger.info("Failed loading YAML: " + str(e))
         return None
     if "Fuzzer filename" not in content:
         return None


### PR DESCRIPTION
We are seeing a lot of error messages when fuzzer profiles are loading. This PR makes the messages more verbose.


```
INFO:fuzz_introspector.utils:Error loading yaml file
INFO:fuzz_introspector.utils:Trying to load multiple file formats toget
INFO:fuzz_introspector.utils:Error loading yaml file
INFO:fuzz_introspector.utils:Trying to load multiple file formats toget
INFO:fuzz_introspector.utils:Error loading yaml file
```
Signed-off-by: Navidem <navid.emamdoost@gmail.com>