### PR TITLE
Update contact for the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+conduct@openssf.org.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Replace the placeholder text with the correct email address as confirmed via the OpenSSF Slack.

Signed-off-by: Caleb Brown <github@calebbrown.id.au>