### PR TITLE
Unit Testing: Add test case for resolving coverage link

### DIFF
--- a/src/test/test_fuzzer_profile.py
+++ b/src/test/test_fuzzer_profile.py
@@ -57,24 +57,6 @@ def base_cpp_profile(tmpdir, sample_cfg1, fake_yaml_func_elem):
     return fp
 
 
-def test_coverage_url(tmpdir, sample_cfg1):
-    """Basic test for coverage URL"""
-    fp = base_cpp_profile(tmpdir, sample_cfg1, [])
-
-    cov_link = fp.resolve_coverage_link(
-        "https://coverage-url.com/",
-        "fuzzlib/fuzzlib.c",
-        13,
-        "function_name"
-    )
-
-    # Explicitly ensure the coverage URL is set
-    assert cov_link != "#"
-
-    # Ensure the coverage URL is correct
-    assert "https://coverage-url.com/fuzzlib/fuzzlib.c.html#L13" == cov_link
-
-
 def test_reaches_file(tmpdir, sample_cfg1):
     """Basic test for reaches file"""
     fp = base_cpp_profile(tmpdir, sample_cfg1, [])

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -91,3 +91,154 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
     os.environ['FUZZ_INTROSPECTOR'] = "1"
     assert utils.get_target_coverage_url(coverage_url, fuzz_target, lang) == res
     del os.environ['FUZZ_INTROSPECTOR']
+
+@pytest.mark.parametrize(
+    ('cov_url', 'source_file', 'lineno', 'function_name', 'target_lang', 'temp_file', 'expect'),
+    [
+        (
+            'https://coverage-url.com/',
+            'fuzzlib/fuzzlib.c',
+            '13',
+            'name',
+            'c-cpp',
+            None,
+            'https://coverage-url.com/fuzzlib/fuzzlib.c.html#L13'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Class',
+            '13',
+            'name',
+            'python',
+            None,
+            '#'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Class',
+            '13',
+            'name',
+            'python',
+            '''{
+                 "format":2,
+                 "version":"6.5.0",
+                 "globals":"Test",
+                 "files":{
+                     "Test":{
+                         "hash":"Test",
+                         "index":{
+                             "relative_filename":"/src/fuzz_parse.py"
+                         }
+                     }
+                 }
+            }''',
+            '#'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Class',
+            '13',
+            'fuzz_parse',
+            'python',
+            '''{
+                 "format":2,
+                 "version":"6.5.0",
+                 "globals":"Test",
+                 "files":{
+                     "Test":{
+                         "hash":"Test",
+                         "index":{
+                             "relative_filename":"/src/fuzz_parse.py"
+                         }
+                     }
+                 }
+            }''',
+            'https://coverage-url.com//Test.html#t13'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Class',
+            '13',
+            'abc.def.fuzz_parse',
+            'python',
+            '''{
+                 "format":2,
+                 "version":"6.5.0",
+                 "globals":"Test",
+                 "files":{
+                     "Test":{
+                         "hash":"Test",
+                         "index":{
+                             "relative_filename":"/src/abc/def.py"
+                         }
+                     }
+                 }
+            }''',
+            'https://coverage-url.com//Test.html#t13'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Class',
+            '13',
+            'name',
+            'jvm',
+            None,
+            'https://coverage-url.com//default/Class.java.html#L13'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Package.Class$Subclass',
+            '13',
+            'name',
+            'jvm',
+            None,
+            'https://coverage-url.com//Package/Class.java.html#L13'
+        ),
+        (
+            'https://coverage-url.com/',
+            'Test.Package.Class',
+            '13',
+            'name',
+            'jvm',
+            None,
+            'https://coverage-url.com//Test.Package/Class.java.html#L13'
+        ),
+        (
+            'https://coverage-url.com/',
+            'fuzzlib/fuzzlib.c',
+            '13',
+            'name',
+            'abcde',
+            None,
+            '#'
+        )
+    ]
+)
+def test_resolve_coverage_link(
+    cov_url: str,
+    source_file: str,
+    lineno: int,
+    function_name: str,
+    target_lang: str,
+    temp_file: str,
+    expect: str
+):
+    """Basic test of coverage URL for all lang"""
+    if (temp_file is not None):
+        # Create temp html_status.json for python coverage link
+        with open('temp_html_status.json', 'w+') as f:
+            f.write(temp_file)
+
+    actual = utils.resolve_coverage_link(
+        cov_url,
+        source_file,
+        lineno,
+        function_name,
+        target_lang
+    )
+    assert expect == actual
+
+    if (temp_file is not None):
+        # Remove temp html_status.json file
+        os.remove('temp_html_status.json')
+

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -154,7 +154,7 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
                      }
                  }
             }''',
-            'https://coverage-url.com//Test.html#t13'
+            'https://coverage-url.com/Test.html#t13'
         ),
         (
             'https://coverage-url.com/',
@@ -175,7 +175,7 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
                      }
                  }
             }''',
-            'https://coverage-url.com//Test.html#t13'
+            'https://coverage-url.com/Test.html#t13'
         ),
         (
             'https://coverage-url.com/',
@@ -184,7 +184,7 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
             'name',
             'jvm',
             None,
-            'https://coverage-url.com//default/Class.java.html#L13'
+            'https://coverage-url.com/default/Class.java.html#L13'
         ),
         (
             'https://coverage-url.com/',
@@ -193,7 +193,7 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
             'name',
             'jvm',
             None,
-            'https://coverage-url.com//Package/Class.java.html#L13'
+            'https://coverage-url.com/Package/Class.java.html#L13'
         ),
         (
             'https://coverage-url.com/',
@@ -202,7 +202,7 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
             'name',
             'jvm',
             None,
-            'https://coverage-url.com//Test.Package/Class.java.html#L13'
+            'https://coverage-url.com/Test.Package/Class.java.html#L13'
         ),
         (
             'https://coverage-url.com/',

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -92,6 +92,7 @@ def test_get_target_coverage_url(coverage_url: str, fuzz_target: str, res: str, 
     assert utils.get_target_coverage_url(coverage_url, fuzz_target, lang) == res
     del os.environ['FUZZ_INTROSPECTOR']
 
+
 @pytest.mark.parametrize(
     ('cov_url', 'source_file', 'lineno', 'function_name', 'target_lang', 'temp_file', 'expect'),
     [
@@ -241,4 +242,3 @@ def test_resolve_coverage_link(
     if (temp_file is not None):
         # Remove temp html_status.json file
         os.remove('temp_html_status.json')
-


### PR DESCRIPTION
This PR aims to create unit test cases for resolving coverage link function in utils for all language, since the resolve coverage link code is moved from fuzzer_profile to utils and generalised for all supported languages.

Issue #630 

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>