### PR TITLE
Branch Profiles Change: Fix format change for yaml branch profile

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -253,7 +253,6 @@ class CustomSenceTransformer extends SceneTransformer {
             if (unit instanceof JIfStmt) {
               // Handle branch profile
               BranchProfile branchProfile = new BranchProfile();
-              BranchSide branchSide = new BranchSide();
 
               Map<String, Integer> trueBlockLine =
                   getBlockStartEndLineWithLineNumber(
@@ -271,23 +270,26 @@ class CustomSenceTransformer extends SceneTransformer {
               if (!trueBlockLine.isEmpty()) {
                 Integer start = trueBlockLine.get("start");
                 Integer end = trueBlockLine.get("end");
-                branchSide.setTrueSides(c.getName() + ":" + start);
-                branchSide.setTrueSidesFuncs(
+                BranchSide branchSide = new BranchSide();
+                branchSide.setBranchSideStr(c.getName() + ":" + start);
+                branchSide.setBranchSideFuncs(
                     getFunctionCallInTargetLine(functionLineMap, start, end));
+                branchProfile.addBranchSides(branchSide);
               }
 
               // False branch
               if (!falseBlockLine.isEmpty()) {
                 Integer start = falseBlockLine.get("start");
                 Integer end = falseBlockLine.get("end");
-                branchSide.setFalseSides(c.getName() + ":" + (start - 1));
-                branchSide.setFalseSidesFuncs(
+                BranchSide branchSide = new BranchSide();
+                branchSide.setBranchSideStr(c.getName() + ":" + (start - 1));
+                branchSide.setBranchSideFuncs(
                     getFunctionCallInTargetLine(functionLineMap, start, end));
+                branchProfile.addBranchSides(branchSide);
               }
 
               branchProfile.setBranchString(
                   c.getName() + ":" + unit.getJavaSourceStartLineNumber());
-              branchProfile.setBranchSides(branchSide);
               element.addBranchProfile(branchProfile);
             }
             iCount++;

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/BranchProfile.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/BranchProfile.java
@@ -16,10 +16,16 @@
 package ossf.fuzz.introspector.soot.yaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
 
 public class BranchProfile {
   private String branchString;
-  private BranchSide branchSides;
+  private List<BranchSide> branchSides;
+
+  public BranchProfile() {
+    this.branchSides = new ArrayList<BranchSide>();
+  }
 
   @JsonProperty("Branch String")
   public String getBranchString() {
@@ -31,11 +37,15 @@ public class BranchProfile {
   }
 
   @JsonProperty("Branch Sides")
-  public BranchSide getBranchSides() {
+  public List<BranchSide> getBranchSides() {
     return branchSides;
   }
 
-  public void setBranchSides(BranchSide branchSides) {
+  public void addBranchSides(BranchSide branchSide) {
+    this.branchSides.add(branchSide);
+  }
+
+  public void setBranchSides(List<BranchSide> branchSides) {
     this.branchSides = branchSides;
   }
 }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/BranchSide.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/BranchSide.java
@@ -20,57 +20,32 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BranchSide {
-  private String trueSides;
-  private List<String> trueSidesFuncs;
-  private String falseSides;
-  private List<String> falseSidesFuncs;
+  private String branchSideStr;
+  private List<String> branchSidesFuncs;
 
   public BranchSide() {
-    this.trueSidesFuncs = new ArrayList<String>();
-    this.falseSidesFuncs = new ArrayList<String>();
+    this.branchSidesFuncs = new ArrayList<String>();
   }
 
-  @JsonProperty("TrueSide")
-  public String getTrueSides() {
-    return trueSides;
+  @JsonProperty("BranchSide")
+  public String getBranchSideStr() {
+    return branchSideStr;
   }
 
-  public void setTrueSides(String trueSides) {
-    this.trueSides = trueSides;
+  public void setBranchSideStr(String branchSideStr) {
+    this.branchSideStr = branchSideStr;
   }
 
-  @JsonProperty("TrueSideFuncs")
-  public List<String> getTrueSidesFuncs() {
-    return trueSidesFuncs;
+  @JsonProperty("BranchSideFuncs")
+  public List<String> getBranchSideFuncs() {
+    return branchSidesFuncs;
   }
 
-  public void addTrueSidesFuncs(String trueSidesFunc) {
-    this.trueSidesFuncs.add(trueSidesFunc);
+  public void addBranchSideFuncs(String branchSidesFunc) {
+    this.branchSidesFuncs.add(branchSidesFunc);
   }
 
-  public void setTrueSidesFuncs(List<String> trueSidesFuncs) {
-    this.trueSidesFuncs = trueSidesFuncs;
-  }
-
-  @JsonProperty("FalseSide")
-  public String getFalseSides() {
-    return falseSides;
-  }
-
-  public void setFalseSides(String falseSides) {
-    this.falseSides = falseSides;
-  }
-
-  @JsonProperty("FalseSideFuncs")
-  public List<String> getFalseSidesFuncs() {
-    return falseSidesFuncs;
-  }
-
-  public void addFalseSidesFuncs(String falseSidesFunc) {
-    this.falseSidesFuncs.add(falseSidesFunc);
-  }
-
-  public void setFalseSidesFuncs(List<String> falseSidesFuncs) {
-    this.falseSidesFuncs = falseSidesFuncs;
+  public void setBranchSideFuncs(List<String> branchSidesFuncs) {
+    this.branchSidesFuncs = branchSidesFuncs;
   }
 }


### PR DESCRIPTION
Branch Profiles has been generalised in PR #657. This change makes old yaml invalid, and will crash the running for JVM implementation of fuzz-introspector. This PR aim to fix the Soot CG and yaml generation logic to meet the new generalised format of the branch profiles to avoid errors in generating JVM report.

Issue #629 #630

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>