### PR TITLE
add option for Google Analytics

### DIFF
--- a/src/fuzz_introspector/html_helpers.py
+++ b/src/fuzz_introspector/html_helpers.py
@@ -21,6 +21,7 @@ from typing import (
     Tuple,
 )
 
+import os
 from fuzz_introspector import utils
 from fuzz_introspector.datatypes import fuzzer_profile, project_profile
 
@@ -52,8 +53,24 @@ def html_table_add_row(elems: List[Any]) -> str:
 
 def html_get_header(calltree: bool = False,
                     title: str = "Fuzz introspector") -> str:
-    header = """<html>
+    gtag_tracking = ""
+    try:
+        gtag = os.environ['G_ANALYTICS_TAG']
+        gtag_tracking += f"""<!-- Google tag (gtag.js) -->
+                <script async src="https://www.googletagmanager.com/gtag/js?id={gtag}"></script>
+                <script>
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){{dataLayer.push(arguments);}}
+                  gtag('js', new Date());
+
+                  gtag('config', '{gtag}');
+                </script>\n"""
+    except KeyError:
+        gtag_tracking = ""
+
+    header = f"""<html>
     <head>
+        {gtag_tracking}
         <link
             rel='stylesheet'
             href='prism.css'>

--- a/src/test/test_html_generation.py
+++ b/src/test/test_html_generation.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../")
+
+from fuzz_introspector import html_helpers  # noqa: E402
+
+
+def test_gtag():
+    header = html_helpers.html_get_header()
+    assert "<!-- Google tag (gtag.js) -->" not in header
+
+    os.environ["G_ANALYTICS_TAG"] = "FUZZINTRO123"
+
+    header = html_helpers.html_get_header()
+    assert "<!-- Google tag (gtag.js) -->" in header
+    assert "FUZZINTRO123" in header


### PR DESCRIPTION
Adds the option to add Google Analytics tracking by setting the `G_ANALYTICS_TAG` env variable.

Signed-off-by: AdamKorcz <adam@adalogics.com>