### PR TITLE
JVM implementation bug: Fix jvm link with missing package name

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -103,7 +103,7 @@ class Analysis(analysis.AnalysisInterface):
             node = nodes[i]
 
             if (profile.target_lang == "jvm"):
-                demangled_name = "[%s].%s" % (
+                demangled_name = utils.demangle_jvm_func(
                     node.dst_function_source_file, node.dst_function_name)
             else:
                 demangled_name = utils.demangle_cpp_func(node.dst_function_name)

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -272,16 +272,14 @@ def get_parent_callsite_link(node, callstack, profile, target_coverage_url):
     """Gets the coverage callsite link of a given node."""
     if callstack_has_parent(node, callstack):
         parent_fname = callstack_get_parent(node, callstack)
-        parent_source = node.parent_calltree_callsite.dst_function_source_file
         dst_options = [
             parent_fname,
-            utils.demangle_cpp_func(parent_fname),
-            utils.demangle_jvm_func(parent_source, parent_fname)
+            utils.demangle_cpp_func(parent_fname)
         ]
         for dst in dst_options:
             for fd_k, fd in profile.all_class_functions.items():
                 if (
-                    fd.function_name == dst
+                    utils.demangle_jvm_func(fd.function_source_file, fd.function_name) == dst
                     or utils.normalise_str(fd.function_name) == utils.normalise_str(dst)
                 ):
                     callsite_link = profile.resolve_coverage_link(

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -250,7 +250,8 @@ def get_url_to_cov_report(profile, node, target_coverage_url):
     """ Get URL to coverage report for the node. """
     dst_options = [
         node.dst_function_name,
-        utils.demangle_cpp_func(node.dst_function_name)
+        utils.demangle_cpp_func(node.dst_function_name),
+        utils.demangle_jvm_func(node.dst_function_source_file, node.dst_function_name)
     ]
     for dst in dst_options:
         for fd_k, fd in profile.all_class_functions.items():
@@ -271,9 +272,11 @@ def get_parent_callsite_link(node, callstack, profile, target_coverage_url):
     """Gets the coverage callsite link of a given node."""
     if callstack_has_parent(node, callstack):
         parent_fname = callstack_get_parent(node, callstack)
+        parent_source = node.parent_calltree_callsite
         dst_options = [
             parent_fname,
-            utils.demangle_cpp_func(parent_fname)
+            utils.demangle_cpp_func(parent_fname),
+            utils.demangle_jvm_func(parent_source, parent_fname)
         ]
         for dst in dst_options:
             for fd_k, fd in profile.all_class_functions.items():

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -272,7 +272,7 @@ def get_parent_callsite_link(node, callstack, profile, target_coverage_url):
     """Gets the coverage callsite link of a given node."""
     if callstack_has_parent(node, callstack):
         parent_fname = callstack_get_parent(node, callstack)
-        parent_source = node.parent_calltree_callsite
+        parent_source = node.parent_calltree_callsite.dst_function_source_file
         dst_options = [
             parent_fname,
             utils.demangle_cpp_func(parent_fname),
@@ -326,7 +326,11 @@ def overlay_calltree_with_coverage(
         node.cov_ct_idx = ct_idx
         ct_idx += 1
 
-        demangled_name = utils.demangle_cpp_func(node.dst_function_name)
+        if profile.target_lang == "jvm":
+            demangled_name = utils.demangle_jvm_func(
+                node.dst_function_source_file, node.dst_function_name)
+        else:
+            demangled_name = utils.demangle_cpp_func(node.dst_function_name)
 
         # Add to callstack
         callstack_set_curr_node(node, demangled_name, callstack)

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -132,6 +132,10 @@ def demangle_cpp_func(funcname: str) -> str:
         return funcname
 
 
+def demangle_jvm_func(package: str, funcname: str) -> str:
+    return "[%s].%s" % (package, funcname)
+
+
 def scan_executables_for_fuzz_introspector_logs(
     exec_dir: str
 ) -> List[Dict[str, str]]:


### PR DESCRIPTION
Fix a bug that the jvm coverage links are missing because of wrong comparison and generation of java package name.