### PR TITLE
Sink coverage report: Commit new flow for retrieving sink coverage from analyser

### DIFF
--- a/src/fuzz_introspector/analyses/bug_digestor.py
+++ b/src/fuzz_introspector/analyses/bug_digestor.py
@@ -48,7 +48,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         """Digests and creates HTML about bugs found by the fuzzers."""
         logger.info(f" - Running analysis {Analysis.get_name()}")
@@ -92,4 +93,8 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</table>"
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
+
+        if json_report:
+            return "[]"
+
         return html_string

--- a/src/fuzz_introspector/analyses/bug_digestor.py
+++ b/src/fuzz_introspector/analyses/bug_digestor.py
@@ -33,12 +33,19 @@ class Analysis(analysis.AnalysisInterface):
     and fuzzer focus functions in libFuzzer. The analysis outputs this either
     in .json format or as HTML string that can be embedded in the HTML report.
     """
+    name: str = "BugDigestorAnalysis"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         self.display_html = False
 
     @staticmethod
     def get_name():
-        return "BugDigestorAnalysis"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -48,8 +55,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         """Digests and creates HTML about bugs found by the fuzzers."""
         logger.info(f" - Running analysis {Analysis.get_name()}")
@@ -93,8 +99,5 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</table>"
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
-
-        if json_report:
-            return "[]"
 
         return html_string

--- a/src/fuzz_introspector/analyses/bug_digestor.py
+++ b/src/fuzz_introspector/analyses/bug_digestor.py
@@ -39,13 +39,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         self.display_html = False
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -56,12 +56,16 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         """
         Creates the HTML of the calltree. Returns the HTML as a string.
         """
         logger.info("Not implemented")
+
+        if json_report:
+            return "[]"
         return ""
 
     def _get_span_row(

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -47,13 +47,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         logger.info("Creating FuzzCalltreeAnalysis")
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -41,12 +41,19 @@ logger = logging.getLogger(name=__name__)
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "FuzzCalltreeAnalysis"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         logger.info("Creating FuzzCalltreeAnalysis")
 
     @staticmethod
     def get_name():
-        return "FuzzCalltreeAnalysis"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -56,16 +63,13 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         """
         Creates the HTML of the calltree. Returns the HTML as a string.
         """
         logger.info("Not implemented")
 
-        if json_report:
-            return "[]"
         return ""
 
     def _get_span_row(

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -40,12 +40,19 @@ class DriverContents:
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "FuzzDriverSynthesizerAnalysis"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "FuzzDriverSynthesizerAnalysis"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -56,7 +63,6 @@ class Analysis(analysis.AnalysisInterface):
         basefolder: str,
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False,
         fuzz_targets=None
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
@@ -179,6 +185,4 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # report-box
         logger.info(f" - Completed analysis {Analysis.get_name()}")
 
-        if json_report:
-            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -46,13 +46,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -56,6 +56,7 @@ class Analysis(analysis.AnalysisInterface):
         basefolder: str,
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False,
         fuzz_targets=None
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
@@ -177,4 +178,7 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
         logger.info(f" - Completed analysis {Analysis.get_name()}")
+
+        if json_report:
+            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -42,13 +42,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         self.display_html = False
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -51,7 +51,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -98,6 +99,8 @@ class Analysis(analysis.AnalysisInterface):
         if not self.display_html:
             html_string = ""
 
+        if json_report:
+            return "[]"
         return html_string
 
     def get_dictionary(self, profile: fuzzer_profile.FuzzerProfile) -> str:

--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -36,12 +36,19 @@ logger = logging.getLogger(name=__name__)
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "FuzzEngineInputAnalysis"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         self.display_html = False
 
     @staticmethod
     def get_name():
-        return "FuzzEngineInputAnalysis"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -51,8 +58,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -99,8 +105,6 @@ class Analysis(analysis.AnalysisInterface):
         if not self.display_html:
             html_string = ""
 
-        if json_report:
-            return "[]"
         return html_string
 
     def get_dictionary(self, profile: fuzzer_profile.FuzzerProfile) -> str:

--- a/src/fuzz_introspector/analyses/filepath_analyser.py
+++ b/src/fuzz_introspector/analyses/filepath_analyser.py
@@ -30,12 +30,19 @@ logger = logging.getLogger(name=__name__)
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "FilePathAnalyser"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "FilePathAnalyser"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def all_files_targeted(
         self,
@@ -55,8 +62,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -146,6 +152,4 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        if json_report:
-            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/filepath_analyser.py
+++ b/src/fuzz_introspector/analyses/filepath_analyser.py
@@ -36,13 +36,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def all_files_targeted(
         self,

--- a/src/fuzz_introspector/analyses/filepath_analyser.py
+++ b/src/fuzz_introspector/analyses/filepath_analyser.py
@@ -55,7 +55,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -144,4 +145,7 @@ class Analysis(analysis.AnalysisInterface):
 
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
+
+        if json_report:
+            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/function_call_analyser.py
+++ b/src/fuzz_introspector/analyses/function_call_analyser.py
@@ -168,7 +168,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         """
         Performs an analysis for all third party API call in the target project.
@@ -309,4 +310,7 @@ class Analysis(analysis.AnalysisInterface):
 
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
+
+        if json_report:
+            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/function_call_analyser.py
+++ b/src/fuzz_introspector/analyses/function_call_analyser.py
@@ -45,13 +45,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def get_source_file(self, callsite) -> str:
         """This function aims to dig up the callsitecalltree of a function

--- a/src/fuzz_introspector/analyses/function_call_analyser.py
+++ b/src/fuzz_introspector/analyses/function_call_analyser.py
@@ -39,13 +39,19 @@ class Analysis(analysis.AnalysisInterface):
     to show all occurence of third party function call within the target
     project and if those calls are statically reached or dynamically covered.
     """
+    name: str = "ThirdPartyAPICoverageAnalyser"
+    json_string_result: str = "[]"
 
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "ThirdPartyAPICoverageAnalyser"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def get_source_file(self, callsite) -> str:
         """This function aims to dig up the callsitecalltree of a function
@@ -168,8 +174,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         """
         Performs an analysis for all third party API call in the target project.
@@ -311,6 +316,4 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        if json_report:
-            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -38,13 +38,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -32,12 +32,19 @@ logger = logging.getLogger(name=__name__)
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "MetadataAnalysis"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "MetadataAnalysis"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -47,8 +54,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -104,6 +110,4 @@ class Analysis(analysis.AnalysisInterface):
 
         logger.info(f" - Completed analysis {Analysis.get_name()}")
 
-        if json_report:
-            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -47,7 +47,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -103,4 +104,6 @@ class Analysis(analysis.AnalysisInterface):
 
         logger.info(f" - Completed analysis {Analysis.get_name()}")
 
+        if json_report:
+            return "[]"
         return html_string

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -54,6 +54,7 @@ class Analysis(analysis.AnalysisInterface):
         basefolder: str,
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False,
         should_synthetise: bool = False
     ) -> str:
         """
@@ -102,6 +103,9 @@ class Analysis(analysis.AnalysisInterface):
 
         logger.info(f" - Completed analysis {Analysis.get_name()}")
         html_string += "</div>"  # .collapsible
+
+        if json_report:
+            return "[]"
         return html_string
 
     def qualifies_as_optimal_target(self, fd: function_profile.FunctionProfile) -> bool:

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -38,12 +38,19 @@ logger = logging.getLogger(name=__name__)
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "OptimalTargets"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "OptimalTargets"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -54,7 +61,6 @@ class Analysis(analysis.AnalysisInterface):
         basefolder: str,
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False,
         should_synthetise: bool = False
     ) -> str:
         """
@@ -104,8 +110,6 @@ class Analysis(analysis.AnalysisInterface):
         logger.info(f" - Completed analysis {Analysis.get_name()}")
         html_string += "</div>"  # .collapsible
 
-        if json_report:
-            return "[]"
         return html_string
 
     def qualifies_as_optimal_target(self, fd: function_profile.FunctionProfile) -> bool:

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -44,13 +44,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
+++ b/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
@@ -45,7 +45,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool = False
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -113,6 +114,9 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # report-box
 
         logger.info(f" - Completed analysis {Analysis.get_name()}")
+
+        if json_report:
+            return "[]"
         return html_string
 
     def get_low_cov_high_line_funcs(

--- a/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
+++ b/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
@@ -36,13 +36,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
+++ b/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
@@ -30,12 +30,19 @@ logger = logging.getLogger(name=__name__)
 
 
 class Analysis(analysis.AnalysisInterface):
+    name: str = "RuntimeCoverageAnalysis"
+    json_string_result: str = "[]"
+
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "RuntimeCoverageAnalysis"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def analysis_func(
         self,
@@ -45,8 +52,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
@@ -115,8 +121,6 @@ class Analysis(analysis.AnalysisInterface):
 
         logger.info(f" - Completed analysis {Analysis.get_name()}")
 
-        if json_report:
-            return "[]"
         return html_string
 
     def get_low_cov_high_line_funcs(

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -277,7 +277,7 @@ class Analysis(analysis.AnalysisInterface):
         functions: List[function_profile.FunctionProfile],
         target_lang: str,
         func_callsites: Dict[str, List[str]],
-        coverage: code_coverage.CoverageProfile(),
+        coverage: code_coverage.CoverageProfile,
         reachable_function_list: List[str]
     ) -> Tuple[str, str]:
         """
@@ -291,7 +291,7 @@ class Analysis(analysis.AnalysisInterface):
 
         for fd in self._filter_function_list(functions, target_lang):
             # Loop through the list of calledlocation for this function
-            for called_location in function_callsite_dict[fd.function_name]:
+            for called_location in func_callsites[fd.function_name]:
                 # Determine if this called location is covered by any fuzzers
                 fuzzer_hit = False
                 for parent_func in fd.incoming_references:
@@ -311,7 +311,7 @@ class Analysis(analysis.AnalysisInterface):
                     f"{str(list_of_fuzzer_covered)}"
                 ])
 
-                json_dict = dict()
+                json_dict = dict[str, Any]
                 json_dict['func_name'] = fd.function_name
                 json_dict['call_loc'] = called_location
                 json_dict['static_reach'] = f"{called_location in reachable_function_list}"

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from typing import (
+    Any,
     List,
     Tuple,
     Dict
@@ -311,7 +312,7 @@ class Analysis(analysis.AnalysisInterface):
                     f"{str(list_of_fuzzer_covered)}"
                 ])
 
-                json_dict = dict[str, Any]
+                json_dict: Dict[str, Any] = {}
                 json_dict['func_name'] = fd.function_name
                 json_dict['call_loc'] = called_location
                 json_dict['static_reach'] = f"{called_location in reachable_function_list}"
@@ -368,7 +369,7 @@ class Analysis(analysis.AnalysisInterface):
             function_callsite_dict,
             proj_profile.runtime_coverage,
             reachable_function_list
-       )
+        )
 
         # Check if html string or json string is needed
         if return_json_string:

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Analysis plugin for introspection sinks of interest"""
 
+import json
 import logging
 
 from typing import (
@@ -149,7 +150,7 @@ class Analysis(analysis.AnalysisInterface):
 
         return func_file
 
-    def retrieve_data_list(
+    def _retrieve_data_list(
         self,
         proj_profile: project_profile.MergedProjectProfile,
         profiles: List[fuzzer_profile.FuzzerProfile]
@@ -177,7 +178,7 @@ class Analysis(analysis.AnalysisInterface):
 
         return (callsite_list, function_list)
 
-    def map_function_callsite(
+    def _map_function_callsite(
         self,
         functions: List[function_profile.FunctionProfile],
         callsites: List[cfg_load.CalltreeCallsite]
@@ -211,7 +212,7 @@ class Analysis(analysis.AnalysisInterface):
 
         return callsite_dict
 
-    def retrieve_reachable_functions(
+    def _retrieve_reachable_functions(
         self,
         functions: List[function_profile.FunctionProfile],
         function_callsites: Dict[str, List[str]]
@@ -234,7 +235,7 @@ class Analysis(analysis.AnalysisInterface):
 
         return function_list
 
-    def filter_function_list(
+    def _filter_function_list(
         self,
         functions: List[function_profile.FunctionProfile],
         target_lang: str
@@ -247,7 +248,7 @@ class Analysis(analysis.AnalysisInterface):
         function_list = []
 
         # Loop through the all function list for a project
-        for fd in functions:
+        forfd in functions:
             # Separate handling for different target language
             if target_lang == "c-cpp":
                 func_name = utils.demangle_cpp_func(fd.function_name)
@@ -270,6 +271,52 @@ class Analysis(analysis.AnalysisInterface):
 
         return function_list
 
+    def _retrieve_content_rows(
+        self,
+        functions: List[function_profile.FunctionProfile],
+        target_lang: str
+    ) -> Tuple[str, str]:
+        """
+        This method aims to retrieve the table content for this analyser
+        in two formats. One in normal html table rows string and the other
+        is a json string for generating separate json report for sink
+        coverage that could be readable by external analyser.
+        """
+        html_string = ""
+        json_list = List[]
+
+        for fd in self._filter_function_list(function_list, profiles[0].target_lang):
+            # Loop through the list of calledlocation for this function
+            for called_location in function_callsite_dict[fd.function_name]:
+                # Determine if this called location is covered by any fuzzers
+                fuzzer_hit = False
+                coverage = proj_profile.runtime_coverage
+                for parent_func in fd.incoming_references:
+                    try:
+                        lineno = int(called_location.split(":")[1])
+                    except ValueError:
+                        continue
+                    if coverage.is_func_lineno_hit(parent_func, lineno):
+                        fuzzer_hit = True
+                        break
+                list_of_fuzzer_covered = fd.reached_by_fuzzers if fuzzer_hit else [""]
+
+                html_string += html_helpers.html_table_add_row([
+                    f"{fd.function_name}",
+                    f"{called_location}",
+                    f"{called_location in reachable_function_list}",
+                    f"{str(list_of_fuzzer_covered)}"
+                ])
+
+                json_dict = dict()
+                json_dict['func_name'] = fd.function_name
+                json_dict['call_loc'] = called_location
+                json_dict['static_reach'] = f"{called_location in reachable_function_list}"
+                json_dict['fuzzer_reach'] = list_of_fuzzer_covered
+                json_list.append(json_dict)
+
+        return (html_string, json.dumps(json_list))
+
     def analysis_func(
         self,
         toc_list: List[Tuple[str, str, int]],
@@ -278,7 +325,8 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        return_json_string: bool = False
     ) -> str:
         """
         Show all used sensitive sink functions / methods in the project and display
@@ -294,20 +342,28 @@ class Analysis(analysis.AnalysisInterface):
            sink functions / methods has been dynamically coveed by any of the fuzzers
         5) Provide additional entry point to increase the chance of dynamically covering
            those sink functions / methods.
+        Remark: json report will be generated instead of html report if tables is None
         """
         logger.info(f" - Running analysis {Analysis.get_name()}")
 
         # Get full function /  callsite list for all fuzzer's profiles
-        callsite_list, function_list = self.retrieve_data_list(proj_profile, profiles)
+        callsite_list, function_list = self._retrieve_data_list(proj_profile, profiles)
 
         # Map callsites to each function
-        function_callsite_dict = self.map_function_callsite(function_list, callsite_list)
+        function_callsite_dict = self._map_function_callsite(function_list, callsite_list)
 
         # Discover reachable function calls
-        reachable_function_list = self.retrieve_reachable_functions(
+        reachable_function_list = self._retrieve_reachable_functions(
             function_list,
             function_callsite_dict
         )
+
+        # Retrieve table content rows
+        html_rows, json_string = _retrieve_content_rows(function_list, profiles[0].target_lang)
+
+        # Check if html string or json string is needed
+        if return_json_string:
+            return json_string
 
         html_string = ""
         html_string += "<div class=\"report-box\">"
@@ -363,28 +419,8 @@ class Analysis(analysis.AnalysisInterface):
             ]
         )
 
-        for fd in self.filter_function_list(function_list, profiles[0].target_lang):
-            # Loop through the list of calledlocation for this function
-            for called_location in function_callsite_dict[fd.function_name]:
-                # Determine if this called location is covered by any fuzzers
-                fuzzer_hit = False
-                coverage = proj_profile.runtime_coverage
-                for parent_func in fd.incoming_references:
-                    try:
-                        lineno = int(called_location.split(":")[1])
-                    except ValueError:
-                        continue
-                    if coverage.is_func_lineno_hit(parent_func, lineno):
-                        fuzzer_hit = True
-                        break
-                list_of_fuzzer_covered = fd.reached_by_fuzzers if fuzzer_hit else [""]
+        html_string += html_rows
 
-                html_string += html_helpers.html_table_add_row([
-                    f"{fd.function_name}",
-                    f"{called_location}",
-                    f"{called_location in reachable_function_list}",
-                    f"{str(list_of_fuzzer_covered)}"
-                ])
         html_string += "</table>"
 
         html_string += "</div>"  # .collapsible

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -118,13 +118,19 @@ class Analysis(analysis.AnalysisInterface):
     covered those sensitive sink fnctions / method in aid to discover possible
     code / command injection through though fuzzing on sink functions / methods..
     """
+    name: str = "SinkCoverageAnalyser"
+    json_string_result: str = "[]"
 
     def __init__(self) -> None:
         pass
 
     @staticmethod
     def get_name():
-        return "SinkCoverageAnalyser"
+        return name
+
+    @staticmethod
+    def get_json_string_result():
+        return json_string_result
 
     def _get_source_file(self, callsite) -> str:
         """This function aims to dig up the callsitecalltree of a function
@@ -329,8 +335,7 @@ class Analysis(analysis.AnalysisInterface):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool = False
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         """
         Show all used sensitive sink functions / methods in the project and display
@@ -363,17 +368,13 @@ class Analysis(analysis.AnalysisInterface):
         )
 
         # Retrieve table content rows
-        html_rows, json_string = self._retrieve_content_rows(
+        html_rows, json_string_result = self._retrieve_content_rows(
             function_list,
             profiles[0].target_lang,
             function_callsite_dict,
             proj_profile.runtime_coverage,
             reachable_function_list
         )
-
-        # Check if html string or json string is needed
-        if json_report:
-            return json_string
 
         html_string = ""
         html_string += "<div class=\"report-box\">"

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -124,13 +124,17 @@ class Analysis(analysis.AnalysisInterface):
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def get_name():
-        return name
+    @classmethod
+    def get_name(cls):
+        return cls.name
 
-    @staticmethod
-    def get_json_string_result():
-        return json_string_result
+    @classmethod
+    def get_json_string_result(cls):
+        return cls.json_string_result
+
+    @classmethod
+    def set_json_string_result(cls, json_string):
+        cls.json_string_result = json_string
 
     def _get_source_file(self, callsite) -> str:
         """This function aims to dig up the callsitecalltree of a function
@@ -368,13 +372,15 @@ class Analysis(analysis.AnalysisInterface):
         )
 
         # Retrieve table content rows
-        html_rows, json_string_result = self._retrieve_content_rows(
+        html_rows, json_row = self._retrieve_content_rows(
             function_list,
             profiles[0].target_lang,
             function_callsite_dict,
             proj_profile.runtime_coverage,
             reachable_function_list
         )
+
+        Analysis.set_json_string_result(json_row)
 
         html_string = ""
         html_string += "<div class=\"report-box\">"

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -330,7 +330,7 @@ class Analysis(analysis.AnalysisInterface):
         basefolder: str,
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion],
-        return_json_string: bool = False
+        json_report: bool = False
     ) -> str:
         """
         Show all used sensitive sink functions / methods in the project and display
@@ -372,7 +372,7 @@ class Analysis(analysis.AnalysisInterface):
         )
 
         # Check if html string or json string is needed
-        if return_json_string:
+        if json_report:
             return json_string
 
         html_string = ""

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -43,7 +43,8 @@ logger = logging.getLogger(name=__name__)
 
 
 class AnalysisInterface(abc.ABC):
-    name: str
+    name: str = ""
+    json_string_result: str = ""
 
     @abc.abstractmethod
     def analysis_func(
@@ -54,8 +55,7 @@ class AnalysisInterface(abc.ABC):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion],
-        json_report: bool
+        conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         """Entrypoint for analysis instance. This function can have side effects
         on many of the arguments passed to it.
@@ -83,15 +83,9 @@ class AnalysisInterface(abc.ABC):
                            be shown at the top of the report page.
         :type conclusions: List[html_helpers.HTMLConclusion]
 
-        :param json_report: A bool value to declare if the ouput is json string for
-                            the json report (True) or html string for html
-                            report (False)
-        :type json_report: bool
-
         :rtype: str
         :returns:  A string that corresponds to HTML that can be embedded in the
-                   html report or the JSON Object that can be embedded into json
-                   report, determine by the json_report parameter.
+                   html report.
         """
         pass
 
@@ -99,6 +93,12 @@ class AnalysisInterface(abc.ABC):
     @abc.abstractmethod
     def get_name():
         """Return name of analysis"""
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_json_string_result():
+        """Return json_string_result"""
         pass
 
 

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -54,7 +54,8 @@ class AnalysisInterface(abc.ABC):
         profiles: List[fuzzer_profile.FuzzerProfile],
         basefolder: str,
         coverage_url: str,
-        conclusions: List[html_helpers.HTMLConclusion]
+        conclusions: List[html_helpers.HTMLConclusion],
+        json_report: bool
     ) -> str:
         """Entrypoint for analysis instance. This function can have side effects
         on many of the arguments passed to it.
@@ -82,9 +83,15 @@ class AnalysisInterface(abc.ABC):
                            be shown at the top of the report page.
         :type conclusions: List[html_helpers.HTMLConclusion]
 
+        :param json_report: A bool value to declare if the ouput is json string for
+                            the json report (True) or html string for html
+                            report (False)
+        :type json_report: bool
+
         :rtype: str
         :returns:  A string that corresponds to HTML that can be embedded in the
-                   report.
+                   html report or the JSON Object that can be embedded into json
+                   report, determine by the json_report parameter.
         """
         pass
 

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -89,15 +89,21 @@ class AnalysisInterface(abc.ABC):
         """
         pass
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
-    def get_name():
+    def get_name(cls):
         """Return name of analysis"""
         pass
 
-    @staticmethod
+    @classmethod
     @abc.abstractmethod
-    def get_json_string_result():
+    def get_json_string_result(cls):
+        """Return json_string_result"""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def set_json_string_result(cls, string):
         """Return json_string_result"""
         pass
 

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -21,6 +21,7 @@ from fuzz_introspector import analysis
 from fuzz_introspector import constants
 from fuzz_introspector import data_loader
 from fuzz_introspector import html_report
+from fuzz_introspector import json_report
 from fuzz_introspector import utils
 from fuzz_introspector.datatypes import project_profile
 
@@ -43,6 +44,7 @@ def run_analysis_on_dir(
     enable_all_analyses: bool,
     report_name: str,
     language: str,
+    sink_coverage_report: bool,
     parallelise: bool = True
 ) -> int:
     if enable_all_analyses:
@@ -98,6 +100,9 @@ def run_analysis_on_dir(
 
     logger.info(f"Analyses to run: {str(analyses_to_run)}")
 
+    if sink_coverage_report:
+        analyses_to_run.append("SinkCoverageAnalyser")
+
     logger.info("[+] Creating HTML report")
     html_report.create_html_report(
         profiles,
@@ -107,4 +112,13 @@ def run_analysis_on_dir(
         proj_profile.basefolder,
         report_name
     )
+
+    logger.info("[+] Creating JSON report for injection sink coveage")
+    json_report.create_json_report(
+        profiles,
+        proj_profile,
+        coverage_url,
+        proj_profile.basefolder
+    )
+
     return constants.APP_EXIT_SUCCESS

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -44,7 +44,7 @@ def run_analysis_on_dir(
     enable_all_analyses: bool,
     report_name: str,
     language: str,
-    sink_coverage_report: bool = False,
+    analyses_with_json: List[str],
     parallelise: bool = True
 ) -> int:
     if enable_all_analyses:
@@ -99,10 +99,6 @@ def run_analysis_on_dir(
         )
 
     logger.info(f"Analyses to run: {str(analyses_to_run)}")
-
-    if sink_coverage_report:
-        analyses_to_run.append("SinkCoverageAnalyser")
-
     logger.info("[+] Creating HTML report")
     html_report.create_html_report(
         profiles,
@@ -113,11 +109,13 @@ def run_analysis_on_dir(
         report_name
     )
 
-    if sink_coverage_report:
-        logger.info("[+] Creating JSON report for injection sink coveage")
+    logger.info(f"Analyses with json output: {str(analyses_to_run)}")
+    if len(analyses_with_json) > 0:
+        logger.info("[+] Creating JSON report")
         json_report.create_json_report(
             profiles,
             proj_profile,
+            analyses_with_json,
             coverage_url
         )
 

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -113,7 +113,7 @@ def run_analysis_on_dir(
         report_name
     )
 
-    if sink_coverage_rport:
+    if sink_coverage_report:
         logger.info("[+] Creating JSON report for injection sink coveage")
         json_report.create_json_report(
             profiles,

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -44,7 +44,7 @@ def run_analysis_on_dir(
     enable_all_analyses: bool,
     report_name: str,
     language: str,
-    sink_coverage_report: bool,
+    sink_coverage_report: bool = False,
     parallelise: bool = True
 ) -> int:
     if enable_all_analyses:
@@ -113,11 +113,12 @@ def run_analysis_on_dir(
         report_name
     )
 
-    logger.info("[+] Creating JSON report for injection sink coveage")
-    json_report.create_json_report(
-        profiles,
-        proj_profile,
-        coverage_url
-    )
+    if sink_coverage_rport:
+        logger.info("[+] Creating JSON report for injection sink coveage")
+        json_report.create_json_report(
+            profiles,
+            proj_profile,
+            coverage_url
+        )
 
     return constants.APP_EXIT_SUCCESS

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -44,7 +44,7 @@ def run_analysis_on_dir(
     enable_all_analyses: bool,
     report_name: str,
     language: str,
-    analyses_with_json: List[str] = [],
+    output_json: List[str] = [],
     parallelise: bool = True
 ) -> int:
     if enable_all_analyses:
@@ -104,18 +104,19 @@ def run_analysis_on_dir(
         profiles,
         proj_profile,
         analyses_to_run,
+        output_json,
         coverage_url,
         proj_profile.basefolder,
         report_name
     )
 
     logger.info(f"Analyses with json output: {str(analyses_to_run)}")
-    if len(analyses_with_json) > 0:
+    if len(output_json) > 0:
         logger.info("[+] Creating JSON report")
         json_report.create_json_report(
             profiles,
             proj_profile,
-            analyses_with_json,
+            output_json,
             coverage_url
         )
 

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -44,7 +44,7 @@ def run_analysis_on_dir(
     enable_all_analyses: bool,
     report_name: str,
     language: str,
-    analyses_with_json: List[str],
+    analyses_with_json: List[str] = [],
     parallelise: bool = True
 ) -> int:
     if enable_all_analyses:

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -117,8 +117,7 @@ def run_analysis_on_dir(
     json_report.create_json_report(
         profiles,
         proj_profile,
-        coverage_url,
-        proj_profile.basefolder
+        coverage_url
     )
 
     return constants.APP_EXIT_SUCCESS

--- a/src/fuzz_introspector/constants.py
+++ b/src/fuzz_introspector/constants.py
@@ -25,6 +25,8 @@ APP_EXIT_SUCCESS = 0
 
 INPUT_BUG_FILE = "input_bugs.json"
 
+JSON_REPORT_FILE = "fuzz-introspector.json"
+
 # Color constants used for call trees. Composed of tuples,
 # (min, max, color) where
 # min and max construct an interval [min: max) (max non-inclusive)

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -818,6 +818,7 @@ def create_html_report(
     profiles: List[fuzzer_profile.FuzzerProfile],
     proj_profile: project_profile.MergedProjectProfile,
     analyses_to_run: List[str],
+    output_json: List[str],
     coverage_url: str,
     basefolder: str,
     report_name: str
@@ -984,13 +985,18 @@ def create_html_report(
     )
     html_report_core += "<div class=\"collapsible\">"
 
+    # Combine and distinguish analyser requires output in html or both (html and json)
+    combined_analyses = analyses_to_run
+    for analyses in output_json:
+        if analyses not in analyses_to_run:
+            combined_analyses.append(analyses)
     analysis_array = analysis.get_all_analyses()
     for analysis_interface in analysis_array:
-        if analysis_interface.get_name() in analyses_to_run:
+        if analysis_interface.get_name() in combined_analyses:
             analysis_instance = analysis.instantiate_analysis_interface(
                 analysis_interface
             )
-            html_report_core += analysis_instance.analysis_func(
+            html_string = analysis_instance.analysis_func(
                 toc_list,
                 tables,
                 proj_profile,
@@ -999,6 +1005,8 @@ def create_html_report(
                 coverage_url,
                 conclusions
             )
+            if analysis_interface.get_name() in analyses_to_run:
+                html_report_core += html_string
     html_report_core += "</div>"  # .collapsible
     html_report_core += "</div>"  # report box
 

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for creating HTML reports"""
+"""Module for creating JSON reports for sink coverage"""
 import os
 import logging
+
+from typing import List
 
 from fuzz_introspector import analysis
 from fuzz_introspector.datatypes import project_profile, fuzzer_profile
@@ -29,7 +31,7 @@ def create_json_report(
     coverage_url: str
 ) -> None:
     """
-    generate specific json report for saving the injection sinks
+    Generate specific json report for saving the injection sinks
     coverage for the fuzzing project. This method will output a json file
     which store all those reachable and coverage information for
     existing sink methods / functions in the fuzzing project.
@@ -38,11 +40,11 @@ def create_json_report(
     logger.info(" - Creating JSON report for sink coverage")
     if not proj_profile.has_coverage_data():
         logger.error(
-                    "No files with coverage data was found. This is either "
-                    "because an error occurred when compiling and running "
-                    "coverage runs, or because the introspector run was "
-                    "intentionally done without coverage collection. In order "
-                    "to get optimal results coverage data is needed."
+            "No files with coverage data was found. This is either "
+            "because an error occurred when compiling and running "
+            "coverage runs, or because the introspector run was "
+            "intentionally done without coverage collection. In order "
+            "to get optimal results coverage data is needed."
         )
 
     logger.info(" - Handling sink coverage analyses")
@@ -70,4 +72,3 @@ def create_json_report(
     # Write the json string to file
     with open(report_name, "a+") as file:
         file.write(result_str)
-

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -22,12 +22,11 @@ from typing import (
     Dict
 )
 
-from fuzz_introspector import analysis
+from fuzz_introspector import analysis, constants
 from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 
 
 logger = logging.getLogger(name=__name__)
-JSON_REPORT_FILE = 'fuzz-introspector.json'
 
 
 def _retrieve_json_section(
@@ -88,7 +87,8 @@ def create_json_report(
     logger.info("Finish handling sections that need json output")
 
     # Write the json string to file
-    if os.path.isfile(JSON_REPORT_FILE):
-        os.remove(JSON_REPORT_FILE)
-    with open(JSON_REPORT_FILE, "a+") as file:
+    report_file = constants.JSON_REPORT_FILE
+    if os.path.isfile(report_file):
+        os.remove(report_file)
+    with open(report_file, "a+") as file:
         file.write(result_str)

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for creating HTML reports"""
+import os
+import logging
+
+from fuzz_introspector import analysis
+from fuzz_introspector.datatypes import project_profile, fuzzer_profile
+
+
+logger = logging.getLogger(name=__name__)
+
+
+def create_json_report(
+    profiles: List[fuzzer_profile.FuzzerProfile],
+    proj_profile: project_profile.MergedProjectProfile,
+    coverage_url: str
+) -> None:
+    """
+    generate specific json report for saving the injection sinks
+    coverage for the fuzzing project. This method will output a json file
+    which store all those reachable and coverage information for
+    existing sink methods / functions in the fuzzing project.
+    """
+
+    logger.info(" - Creating JSON report for sink coverage")
+    if not proj_profile.has_coverage_data():
+        logger.error(
+                    "No files with coverage data was found. This is either "
+                    "because an error occurred when compiling and running "
+                    "coverage runs, or because the introspector run was "
+                    "intentionally done without coverage collection. In order "
+                    "to get optimal results coverage data is needed."
+        )
+
+    logger.info(" - Handling sink coverage analyses")
+    analysis_array = analysis.get_all_analyses()
+    for analysis_interface in analysis_array:
+        if analysis_interface.get_name() == "SinkCoverageAnalysis":
+            analysis_instance = analysis.instantiate_analysis_interface(
+                analysis_interface
+            )
+            result_str = analysis_instance.analysis_func(
+                None,
+                None,
+                proj_profile,
+                profiles,
+                None,
+                coverage_url,
+                None,
+                True
+            )
+
+    report_name = "sink_coverage.json"
+    if os.path.isfile(report_name):
+        os.remove(report_name)
+
+    # Write the json string to file
+    with open(report_name, "a+") as file:
+        file.write(result_str)
+

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Fuzz Introspector Authors
+# Copyright 2022 Fuzz Introspector Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Module for creating JSON reports for sink coverage"""
+"""Module for creating JSON reports"""
 import os
 import json
 import logging
@@ -28,6 +27,7 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 
 
 logger = logging.getLogger(name=__name__)
+JSON_REPORT_FILE = 'fuzz-introspector.json'
 
 
 def _retrieve_json_section(
@@ -46,23 +46,14 @@ def _retrieve_json_section(
             analysis_instance = analysis.instantiate_analysis_interface(
                 analysis_interface
             )
-            return analysis_instance.analysis_func(
-                None,
-                None,
-                proj_profile,
-                profiles,
-                None,
-                coverage_url,
-                None,
-                True
-            )
+            return analysis_instance.get_json_result_string
     return json.dumps([])
 
 
 def create_json_report(
     profiles: List[fuzzer_profile.FuzzerProfile],
     proj_profile: project_profile.MergedProjectProfile,
-    analyses_with_json: List[str],
+    output_json: List[str],
     coverage_url: str
 ) -> None:
     """
@@ -83,7 +74,7 @@ def create_json_report(
         )
 
     result_dict: Dict[str, Dict[str, Any]] = {'report': {}}
-    for analyses in analyses_with_json:
+    for analyses in output_json:
         logger.info(f" - Handling {analyses}")
         result_str = _retrieve_json_section(
             profiles,
@@ -95,9 +86,9 @@ def create_json_report(
 
     result_str = json.dumps(result_dict)
     logger.info("Finish handling sections that need json output")
+
     # Write the json string to file
-    report_name = "fuzz-introspector.json"
-    if os.path.isfile(report_name):
-        os.remove(report_name)
-    with open(report_name, "a+") as file:
+    if os.path.isfile(JSON_REPORT_FILE):
+        os.remove(JSON_REPORT_FILE)
+    with open(JSON_REPORT_FILE, "a+") as file:
         file.write(result_str)

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -14,9 +14,14 @@
 
 """Module for creating JSON reports for sink coverage"""
 import os
+import json
 import logging
 
-from typing import List
+from typing import (
+    Any,
+    List,
+    Dict
+)
 
 from fuzz_introspector import analysis
 from fuzz_introspector.datatypes import project_profile, fuzzer_profile
@@ -25,36 +30,23 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-def create_json_report(
+def _retrieve_json_section(
     profiles: List[fuzzer_profile.FuzzerProfile],
     proj_profile: project_profile.MergedProjectProfile,
+    analyser_name: str,
     coverage_url: str
-) -> None:
+) -> str:
     """
-    Generate specific json report for saving the injection sinks
-    coverage for the fuzzing project. This method will output a json file
-    which store all those reachable and coverage information for
-    existing sink methods / functions in the fuzzing project.
+    Generate json string for saving the result of a
+    specific analyser
     """
-
-    logger.info(" - Creating JSON report for sink coverage")
-    if not proj_profile.has_coverage_data():
-        logger.error(
-            "No files with coverage data was found. This is either "
-            "because an error occurred when compiling and running "
-            "coverage runs, or because the introspector run was "
-            "intentionally done without coverage collection. In order "
-            "to get optimal results coverage data is needed."
-        )
-
-    logger.info(" - Handling sink coverage analyses")
     analysis_array = analysis.get_all_analyses()
     for analysis_interface in analysis_array:
-        if analysis_interface.get_name() == "SinkCoverageAnalysis":
+        if analysis_interface.get_name() == analyser_name:
             analysis_instance = analysis.instantiate_analysis_interface(
                 analysis_interface
             )
-            result_str = analysis_instance.analysis_func(
+            return analysis_instance.analysis_func(
                 None,
                 None,
                 proj_profile,
@@ -64,11 +56,48 @@ def create_json_report(
                 None,
                 True
             )
+    return json.dumps([])
 
-    report_name = "sink_coverage.json"
+
+def create_json_report(
+    profiles: List[fuzzer_profile.FuzzerProfile],
+    proj_profile: project_profile.MergedProjectProfile,
+    analyses_with_json: List[str],
+    coverage_url: str
+) -> None:
+    """
+    Generate json report for the fuzz-introspector execution session.
+    This method is also extendable in the future to act in more
+    results from other sessions to be included in the json format
+    of the output.
+    """
+
+    logger.info(" - Creating JSON report for fuzz-introspetcor")
+    if not proj_profile.has_coverage_data():
+        logger.error(
+            "No files with coverage data was found. This is either "
+            "because an error occurred when compiling and running "
+            "coverage runs, or because the introspector run was "
+            "intentionally done without coverage collection. In order "
+            "to get optimal results coverage data is needed."
+        )
+
+    result_dict: Dict[str, Dict[str, Any]] = {'report': {}}
+    for analyses in analyses_with_json:
+        logger.info(f" - Handling {analyses}")
+        result_str = _retrieve_json_section(
+            profiles,
+            proj_profile,
+            analyses,
+            coverage_url
+        )
+        result_dict['report'][analyses] = json.loads(result_str)
+
+    result_str = json.dumps(result_dict)
+    logger.info("Finish handling sections that need json output")
+    # Write the json string to file
+    report_name = "fuzz-introspector.json"
     if os.path.isfile(report_name):
         os.remove(report_name)
-
-    # Write the json string to file
     with open(report_name, "a+") as file:
         file.write(result_str)

--- a/src/main.py
+++ b/src/main.py
@@ -85,12 +85,12 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         help="Language of project"
     )
     report_parser.add_argument(
-        "--analyses-with-json",
+        "--output-json",
         nargs="+",
         default=[
             "SinkCoverageAnalyser"
         ],
-        help="Analysis to run and requires separate json report output"
+        help="State which analysis requires separate json report output"
     )
 
     # Command for correlating binary files to fuzzerLog files
@@ -136,7 +136,7 @@ def main() -> int:
             args.enable_all_analyses,
             args.name,
             args.language,
-            args.analyses_with_json
+            args.output_json
         )
         logger.info("Ending fuzz introspector report generation")
     elif args.command == 'correlate':

--- a/src/main.py
+++ b/src/main.py
@@ -85,10 +85,12 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         help="Language of project"
     )
     report_parser.add_argument(
-        "--sink-coverage-report",
-        action='store_true',
-        default=True,
-        help="Generate separate sink coverage JSON report"
+        "--analyses-with-json",
+        nargs="+",
+        default=[
+            "SinkCoverageAnalyser"
+        ],
+        help="Analysis to run and requires separate json report output"
     )
 
     # Command for correlating binary files to fuzzerLog files
@@ -134,7 +136,7 @@ def main() -> int:
             args.enable_all_analyses,
             args.name,
             args.language,
-            args.sink_coverage_report
+            args.analyses_with_json
         )
         logger.info("Ending fuzz introspector report generation")
     elif args.command == 'correlate':

--- a/src/main.py
+++ b/src/main.py
@@ -84,6 +84,12 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         default="c-cpp",
         help="Language of project"
     )
+    report_parser.add_argument(
+        "--sink-coverage-report",
+        type='store_true',
+        default=True,
+        help="Generate separate sink coverage JSON report"
+    )
 
     # Command for correlating binary files to fuzzerLog files
     correlate_parser = subparsers.add_parser(
@@ -127,7 +133,8 @@ def main() -> int:
             args.correlation_file,
             args.enable_all_analyses,
             args.name,
-            args.language
+            args.language,
+            args.sink_coverage_report
         )
         logger.info("Ending fuzz introspector report generation")
     elif args.command == 'correlate':

--- a/src/main.py
+++ b/src/main.py
@@ -86,7 +86,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
     )
     report_parser.add_argument(
         "--sink-coverage-report",
-        type='store_true',
+        action='store_true',
         default=True,
         help="Generate separate sink coverage JSON report"
     )


### PR DESCRIPTION
Create a flow to allow the user of fuzz-introspector generate a separate json report for sink coverage information of the target project.

Issue #670

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>