### PR TITLE
JVM implementation bug: Fix package inclusion and exclusion bug

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -84,6 +84,7 @@ public class CallGraphGenerator {
     Options.v().set_process_dir(jarFiles);
     Options.v().set_prepend_classpath(true);
     Options.v().set_src_prec(Options.src_prec_java);
+    Options.v().set_include_all(true);
     Options.v().set_exclude(custom.getExcludeList());
     Options.v().set_no_bodies_for_excluded(true);
     Options.v().set_allow_phantom_refs(true);
@@ -109,6 +110,7 @@ public class CallGraphGenerator {
     Scene.v().setEntryPoints(entryPoints);
 
     // Load all related classes
+    Scene.v().loadBasicClasses();
     Scene.v().loadNecessaryClasses();
 
     // Start the generation


### PR DESCRIPTION
Add in all include options to force all library classes to be handled. These library classes includes package prefix which are considered as native code, which may accidentally covers some project with package name prefix same as these native package.

Solve issue #683 

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>