### PR TITLE
More restricted regex for loading coverage reports

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -27,9 +27,9 @@ from typing import (
 
 from fuzz_introspector import utils
 
-COVERAGE_SWITCH_REGEX = re.compile(r'.*\|.*switch.*\(.*\)')
-COVERAGE_CASE_REGEX = re.compile(r'.*\|.*case.*:')
-COVERAGE_BRANCH_REGEX = re.compile(r'.*\|.*Branch.*\(.*:.*\):')
+COVERAGE_SWITCH_REGEX = re.compile(r'.*\|.*\sswitch.*\(.*\)')
+COVERAGE_CASE_REGEX = re.compile(r'.*\|.*\scase.*:')
+COVERAGE_BRANCH_REGEX = re.compile(r'.*\|.*\sBranch.*\(.*:.*\):')
 
 logger = logging.getLogger(name=__name__)
 


### PR DESCRIPTION
This avoids matching keywords in the middle of variable of function names.

For example, this line will not match `COVERAGE_CASE_REGEX`:
```
strncasecmp((const char *) packet->line[packet->parsed_lines].ptr, "Transfer-Encoding: ", 19) == 0)
``` 

Signed-off-by: Navidem <navid.emamdoost@gmail.com>