### PR TITLE
Json report: Make json string result an instance variable

### DIFF
--- a/src/fuzz_introspector/analyses/bug_digestor.py
+++ b/src/fuzz_introspector/analyses/bug_digestor.py
@@ -34,22 +34,20 @@ class Analysis(analysis.AnalysisInterface):
     in .json format or as HTML string that can be embedded in the HTML report.
     """
     name: str = "BugDigestorAnalysis"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
         self.display_html = False
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -42,22 +42,20 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "FuzzCalltreeAnalysis"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
         logger.info("Creating FuzzCalltreeAnalysis")
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -41,22 +41,19 @@ class DriverContents:
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "FuzzDriverSynthesizerAnalysis"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -38,22 +38,20 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "FuzzEngineInputAnalysis"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
         self.display_html = False
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,
@@ -130,7 +128,7 @@ class Analysis(analysis.AnalysisInterface):
                 dictionary_content += f"k{kn}=\"{const}\"\n"
                 dictionary[f"k{kn}"] = const
                 kn += 1
-        Analysis.set_json_string_result(json.dumps(dictionary))
+        self.set_json_string_result(json.dumps(dictionary))
         return dictionary_content
 
     def get_dictionary_section(

--- a/src/fuzz_introspector/analyses/filepath_analyser.py
+++ b/src/fuzz_introspector/analyses/filepath_analyser.py
@@ -31,22 +31,19 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "FilePathAnalyser"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def all_files_targeted(
         self,

--- a/src/fuzz_introspector/analyses/function_call_analyser.py
+++ b/src/fuzz_introspector/analyses/function_call_analyser.py
@@ -40,22 +40,19 @@ class Analysis(analysis.AnalysisInterface):
     project and if those calls are statically reached or dynamically covered.
     """
     name: str = "ThirdPartyAPICoverageAnalyser"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def get_source_file(self, callsite) -> str:
         """This function aims to dig up the callsitecalltree of a function

--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -33,22 +33,19 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "MetadataAnalysis"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -39,22 +39,19 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "OptimalTargets"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
+++ b/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
@@ -31,22 +31,19 @@ logger = logging.getLogger(name=__name__)
 
 class Analysis(analysis.AnalysisInterface):
     name: str = "RuntimeCoverageAnalysis"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def analysis_func(
         self,

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -119,22 +119,19 @@ class Analysis(analysis.AnalysisInterface):
     code / command injection through though fuzzing on sink functions / methods..
     """
     name: str = "SinkCoverageAnalyser"
-    json_string_result: str = "[]"
 
     def __init__(self) -> None:
-        pass
+        self.json_string_result = "[]"
 
     @classmethod
     def get_name(cls):
         return cls.name
 
-    @classmethod
-    def get_json_string_result(cls):
-        return cls.json_string_result
+    def get_json_string_result(self):
+        return self.json_string_result
 
-    @classmethod
-    def set_json_string_result(cls, json_string):
-        cls.json_string_result = json_string
+    def set_json_string_result(self, json_string):
+        self.json_string_result = json_string
 
     def _get_source_file(self, callsite) -> str:
         """This function aims to dig up the callsitecalltree of a function
@@ -380,7 +377,7 @@ class Analysis(analysis.AnalysisInterface):
             reachable_function_list
         )
 
-        Analysis.set_json_string_result(json_row)
+        self.set_json_string_result(json_row)
 
         html_string = ""
         html_string += "<div class=\"report-box\">"

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -95,15 +95,13 @@ class AnalysisInterface(abc.ABC):
         """Return name of analysis"""
         pass
 
-    @classmethod
     @abc.abstractmethod
-    def get_json_string_result(cls):
+    def get_json_string_result(self):
         """Return json_string_result"""
         pass
 
-    @classmethod
     @abc.abstractmethod
-    def set_json_string_result(cls, string):
+    def set_json_string_result(self, string):
         """Return json_string_result"""
         pass
 

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -100,7 +100,7 @@ def run_analysis_on_dir(
 
     logger.info(f"Analyses to run: {str(analyses_to_run)}")
     logger.info("[+] Creating HTML report")
-    html_report.create_html_report(
+    analyser_instance_dict = html_report.create_html_report(
         profiles,
         proj_profile,
         analyses_to_run,
@@ -110,13 +110,13 @@ def run_analysis_on_dir(
         report_name
     )
 
-    logger.info(f"Analyses with json output: {str(analyses_to_run)}")
-    if len(output_json) > 0:
+    logger.info(f"Analyses with json output: {str(analyser_instance_dict.keys())}")
+    if len(analyser_instance_dict.keys()) > 0:
         logger.info("[+] Creating JSON report")
         json_report.create_json_report(
             profiles,
             proj_profile,
-            output_json,
+            analyser_instance_dict,
             coverage_url
         )
 

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -19,7 +19,8 @@ import logging
 from typing import (
     Any,
     List,
-    Dict
+    Dict,
+    Type
 )
 
 from fuzz_introspector import analysis, constants
@@ -30,29 +31,22 @@ logger = logging.getLogger(name=__name__)
 
 
 def _retrieve_json_section(
-    profiles: List[fuzzer_profile.FuzzerProfile],
-    proj_profile: project_profile.MergedProjectProfile,
     analyser_name: str,
-    coverage_url: str
+    analysis_instance: analysis.AnalysisInterface
 ) -> str:
     """
     Generate json string for saving the result of a
     specific analyser
     """
-    analysis_array = analysis.get_all_analyses()
-    for analysis_interface in analysis_array:
-        if analysis_interface.get_name() == analyser_name:
-            analysis_instance = analysis.instantiate_analysis_interface(
-                analysis_interface
-            )
-            return analysis_instance.get_json_string_result()
+    if analyser_name in [item.get_name() for item in analysis.get_all_analyses()]:
+       return analysis_instance.get_json_string_result()
     return json.dumps([])
 
 
 def create_json_report(
     profiles: List[fuzzer_profile.FuzzerProfile],
     proj_profile: project_profile.MergedProjectProfile,
-    output_json: List[str],
+    analyser_instance_dict: Dict[str, analysis.AnalysisInterface],
     coverage_url: str
 ) -> None:
     """
@@ -73,15 +67,13 @@ def create_json_report(
         )
 
     result_dict: Dict[str, Dict[str, Any]] = {'report': {}}
-    for analyses in output_json:
-        logger.info(f" - Handling {analyses}")
+    for analyses_name in analyser_instance_dict.keys():
+        logger.info(f" - Handling {analyses_name}")
         result_str = _retrieve_json_section(
-            profiles,
-            proj_profile,
-            analyses,
-            coverage_url
+            analyses_name,
+            analyser_instance_dict[analyses_name]
         )
-        result_dict['report'][analyses] = json.loads(result_str)
+        result_dict['report'][analyses_name] = json.loads(result_str)
 
     result_str = json.dumps(result_dict)
     logger.info("Finish handling sections that need json output")

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -19,8 +19,7 @@ import logging
 from typing import (
     Any,
     List,
-    Dict,
-    Type
+    Dict
 )
 
 from fuzz_introspector import analysis, constants
@@ -39,7 +38,7 @@ def _retrieve_json_section(
     specific analyser
     """
     if analyser_name in [item.get_name() for item in analysis.get_all_analyses()]:
-       return analysis_instance.get_json_string_result()
+        return analysis_instance.get_json_string_result()
     return json.dumps([])
 
 


### PR DESCRIPTION
This PR aims to revamp the json string result object and make it an instance variable. Then fix the logic to store those analyser instance that request to be included in the resulting json report.