### PR TITLE
fuzz: specify arg values in fuzz_report_generation

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 from fuzz_introspector import utils
+from fuzz_introspector import exceptions
 
 COVERAGE_SWITCH_REGEX = re.compile(r'.*\|.*\sswitch.*\(.*\)')
 COVERAGE_CASE_REGEX = re.compile(r'.*\|.*\scase.*:')
@@ -664,8 +665,11 @@ def load_jvm_coverage(
         return cp
 
     cp.coverage_files.append(xml_file)
-    xml_tree = ET.parse(xml_file)
-    root = xml_tree.getroot()
+    try:
+        xml_tree = ET.parse(xml_file)
+        root = xml_tree.getroot()
+    except Exception:
+        raise exceptions.DataLoaderError("Error %s as xml file" % (xml_file))
 
     for package in root.findall('package'):
         for cl in package.findall('sourcefile'):

--- a/src/test/fuzz/test_fuzz_cov_load.py
+++ b/src/test/fuzz/test_fuzz_cov_load.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fuzz cov_load.py"""
+
+import os
+import sys
+import atheris
+import pytest
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../")
+
+from fuzz_introspector import code_coverage  # noqa: E402
+from fuzz_introspector import exceptions  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"random_data",
+        b"more random data"
+    ]
+)
+def test_TestOneInput(data):
+    """Fuzz coverage loading functions.
+
+    The rational behind this is that the coverage files may be broken, and
+    we should be resilient against that."""
+    cov_file = "jacoco.xml"
+    with open(cov_file, "wb") as f:
+        f.write(data)
+
+    # Read the file as a calltree
+    try:
+        code_coverage.load_jvm_coverage(os.getcwd())
+    except exceptions.FuzzIntrospectorError:
+        pass
+
+    if os.path.isfile(cov_file):
+        os.remove(cov_file)
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(
+        sys.argv,
+        test_TestOneInput,
+        enable_python_coverage=True
+    )
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/fuzz/test_fuzz_report_generation.py
+++ b/src/test/fuzz/test_fuzz_report_generation.py
@@ -60,15 +60,15 @@ def test_TestOneInput(data: bytes):
 
     try:
         commands.run_analysis_on_dir(
-            target_folder = report_dir,
-            coverage_url = "random_coverage_url",
-            analyses_to_run = analyses_to_run,
-            correlation_file = correlation_file,
-            enable_all_analyses = False,
-            report_name = "report name",
-            language = lang_list[lang_choice],
-            output_json = [],
-            parallelise = False
+            target_folder=report_dir,
+            coverage_url="random_coverage_url",
+            analyses_to_run=analyses_to_run,
+            correlation_file=correlation_file,
+            enable_all_analyses=False,
+            report_name="report name",
+            language=lang_list[lang_choice],
+            output_json=[],
+            parallelise=False
         )
     except exceptions.FuzzIntrospectorError:
         pass

--- a/src/test/fuzz/test_fuzz_report_generation.py
+++ b/src/test/fuzz/test_fuzz_report_generation.py
@@ -60,14 +60,15 @@ def test_TestOneInput(data: bytes):
 
     try:
         commands.run_analysis_on_dir(
-            report_dir,
-            "random_coverage_url",
-            analyses_to_run,
-            correlation_file,
-            False,
-            "report name",
-            lang_list[lang_choice],
-            False
+            target_folder = report_dir,
+            coverage_url = "random_coverage_url",
+            analyses_to_run = analyses_to_run,
+            correlation_file = correlation_file,
+            enable_all_analyses = False,
+            report_name = "report name",
+            language = lang_list[lang_choice],
+            output_json = [],
+            parallelise = False
         )
     except exceptions.FuzzIntrospectorError:
         pass


### PR DESCRIPTION
This is one of the reason some issues have not been reported by the fuzzer. https://github.com/ossf/fuzz-introspector/pull/686 introduced a new argument to `run_analysis_on_dir` which caused an argument in the fuzzer (the last argument, `False`) to reference a new argument. The effect is that the underlying loading of yaml profiles were multi-threaded, which consequntly do not propagate exceptions.

This commit changes it to specify arguments when calling `run_analysis_on_dir` so future scenarios won't switch the arguments as such. Note, I don't think this would have detected the branch blocker issues as this happened before the above change.

Ref: https://github.com/ossf/fuzz-introspector/issues/693

Signed-off-by: David Korczynski <david@adalogics.com>