### PR TITLE
clusterfuzz-lite: prefer binary when installing matplotlib

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 pip3 install --upgrade pip
-pip3 install -r requirements.txt
+pip3 install --prefer-binary -r requirements.txt
 
 cp src/test/fuzz/*.py .
 


### PR DESCRIPTION
The goal is to speed up the CI.

Signed-off-by: David Korczynski <david@adalogics.com>