### PR TITLE
JVM bug: Fix naming problem

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -185,10 +185,9 @@ class CustomSenceTransformer extends SceneTransformer {
 
         if (m.getName().equals(this.entryMethodStr) && c.getName().equals(this.entryClassStr)) {
           this.entryMethod = m;
-          element.setFunctionName(m.getSubSignature().split(" ")[1]);
-        } else {
-          element.setFunctionName("[" + c.getFilePath() + "]." + m.getSubSignature().split(" ")[1]);
         }
+
+        element.setFunctionName("[" + c.getFilePath() + "]." + m.getSubSignature().split(" ")[1]);
         element.setFunctionSourceFile(c.getFilePath());
         element.setFunctionLinenumber(m.getJavaSourceStartLineNumber());
         element.setReturnType(m.getReturnType().toString());

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -85,7 +85,9 @@ class FuzzerProfile:
         elif self.target_lang == "python":
             return self.entrypoint_fun
         elif self.target_lang == "jvm":
-            return "fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)"
+            cname = self.fuzzer_source_file
+            arg = 'com.code_intelligence.jazzer.api.FuzzedDataProvider'
+            return f"[{cname}].fuzzerTestOneInput({arg})"
         else:
             return None
 
@@ -381,6 +383,7 @@ class FuzzerProfile:
                 self.functions_reached_by_fuzzer = (
                     self.all_class_functions[self.entrypoint_function].functions_reached
                 )
+                self.functions_reached_by_fuzzer.append(self.entrypoint_function)
                 return
 
         # Find Python entrypoint
@@ -388,6 +391,7 @@ class FuzzerProfile:
             ep_key = f"{self.entrypoint_mod}.{self.entrypoint_fun}"
             reached = self.all_class_functions[ep_key].functions_reached
             self.functions_reached_by_fuzzer = reached
+            self.functions_reached_by_fuzzer.append(self.entrypoint_function)
             return
 
         # Find JVM entrypoint
@@ -396,6 +400,7 @@ class FuzzerProfile:
                 self.functions_reached_by_fuzzer = (
                     self.all_class_functions[self.entrypoint_function].functions_reached
                 )
+                self.functions_reached_by_fuzzer.append(self.entrypoint_function)
                 return
 
         raise DataLoaderError("Can not identify entrypoint")

--- a/tests/java/test1/.config
+++ b/tests/java/test1/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test1.jar
 entryclass=TestFuzzer
-reached=[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[TestFuzzer].main(java.lang.String[])
+reached=[java.io.PrintStream].println(java.lang.String):[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[TestFuzzer].main(java.lang.String[]):[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
 optimalreached=[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[TestFuzzer].main(java.lang.String[])
+optimalunreached=[TestFuzzer].main(java.lang.String[])
 filereached=java.io.PrintStream:['TestFuzzer'];TestFuzzer:['TestFuzzer']
 filecovered=java.io.PrintStream:[];TestFuzzer:[]

--- a/tests/java/test10/.config
+++ b/tests/java/test10/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test10.jar
 entryclass=Fuzz.TestFuzzer
-reached=[Fuzz.Female].getName():[Fuzz.Female].getTitle():[Fuzz.Female].femaleStuff():[Fuzz.Male].getName():[Fuzz.Male].getTitle():[Fuzz.Male].maleStuff():[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.Robot].getName():[Fuzz.Human].getName():[Fuzz.Android].getName()
-optimalreached=[Fuzz.Female].getName():[Fuzz.Female].getTitle():[Fuzz.Female].femaleStuff():[Fuzz.Male].getName():[Fuzz.Male].getTitle():[Fuzz.Male].maleStuff():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.Robot].getName():[Fuzz.Human].getName():[Fuzz.Android].getName()
+reached=[Fuzz.Female].getName():[Fuzz.Female].getTitle():[Fuzz.Female].femaleStuff():[Fuzz.Male].getName():[Fuzz.Male].getTitle():[Fuzz.Male].maleStuff():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.Robot].getName():[Fuzz.Human].getName():[Fuzz.Android].getName()
+optimalreached=[Fuzz.Female].getName():[Fuzz.Female].getTitle():[Fuzz.Female].femaleStuff():[Fuzz.Male].getName():[Fuzz.Male].getTitle():[Fuzz.Male].maleStuff():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.Robot].getName():[Fuzz.Human].getName():[Fuzz.Android].getName()
 filereached=Fuzz.Female:['Fuzz.TestFuzzer'];Fuzz.Android:[];Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];Fuzz.Male:['Fuzz.TestFuzzer'];Fuzz.Human:[];Fuzz.Robot:[];java.io.PrintStream:['Fuzz.TestFuzzer']
 filecovered=Fuzz.Female:[];Fuzz.Android:[];Fuzz.TestFuzzer:[];Fuzz.Male:[];Fuzz.Human:[];Fuzz.Robot:[];java.io.PrintStream:[]

--- a/tests/java/test11/.config
+++ b/tests/java/test11/.config
@@ -1,0 +1,4 @@
+jarfile=$PWD/test11.jar
+entryclass=TestFuzzer
+filereached=TestFuzzer:['TestFuzzer'];FunctionTest:['TestFuzzer']
+filecovered=TestFuzzer:[];FunctionTest:[]

--- a/tests/java/test2/.config
+++ b/tests/java/test2/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test2.jar
 entryclass=TestFuzzer
-reached=[TestFuzzer].function1():[TestFuzzer].function2():[java.io.PrintStream].println(java.lang.String)
-unreached=[TestFuzzer].functionPublicDead():[TestFuzzer].functionPrivateDead():fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[TestFuzzer].main(java.lang.String[])
-optimalreached=[TestFuzzer].function1():[TestFuzzer].function2():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=[TestFuzzer].functionPublicDead():[TestFuzzer].functionPrivateDead():fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[TestFuzzer].main(java.lang.String[])
+reached=[TestFuzzer].function1():[TestFuzzer].function2():[java.io.PrintStream].println(java.lang.String):[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[TestFuzzer].functionPublicDead():[TestFuzzer].functionPrivateDead():[TestFuzzer].main(java.lang.String[])
+optimalreached=[TestFuzzer].function1():[TestFuzzer].function2():[java.io.PrintStream].println(java.lang.String):[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[TestFuzzer].functionPublicDead():[TestFuzzer].functionPrivateDead():[TestFuzzer].main(java.lang.String[])
 filereached=java.io.PrintStream:['TestFuzzer'];TestFuzzer:['TestFuzzer']
 filecovered=java.io.PrintStream:[];TestFuzzer:[]

--- a/tests/java/test3/.config
+++ b/tests/java/test3/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test3.jar
 entryclass=TestFuzzer
-reached=[FunctionTest].function1():[FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[TestFuzzer].main(java.lang.String[]):[FunctionTest].functionPublicDead():[FunctionTest].functionPrivateDead()
-optimalreached=[FunctionTest].function1():[FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[TestFuzzer].main(java.lang.String[]):[FunctionTest].functionPublicDead():[FunctionTest].functionPrivateDead()
+reached=[FunctionTest].function1():[FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[TestFuzzer].main(java.lang.String[]):[FunctionTest].functionPublicDead():[FunctionTest].functionPrivateDead()
+optimalreached=[FunctionTest].function1():[FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[TestFuzzer].main(java.lang.String[]):[FunctionTest].functionPublicDead():[FunctionTest].functionPrivateDead()
 filereached=FunctionTest:['TestFuzzer'];java.io.PrintStream:['TestFuzzer'];TestFuzzer:['TestFuzzer']
 filecovered=FunctionTest:[];java.io.PrintStream:[];TestFuzzer:[]

--- a/tests/java/test4/.config
+++ b/tests/java/test4/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test4.jar
 entryclass=Fuzz.TestFuzzer
-reached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
-optimalreached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
+reached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
+optimalreached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
 filereached=java.io.PrintStream:['Fuzz.TestFuzzer'];Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];Fuzz.FunctionTest:['Fuzz.TestFuzzer']
 filecovered=java.io.PrintStream:[];Fuzz.TestFuzzer:[];Fuzz.FunctionTest:[]

--- a/tests/java/test5/.config
+++ b/tests/java/test5/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test5.jar
 entryclass=Fuzz.TestFuzzer
-reached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead()
-optimalreached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead()
+reached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead()
+optimalreached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead()
 filereached=Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];java.io.PrintStream:['Fuzz.TestFuzzer'];Function.FunctionTest:['Fuzz.TestFuzzer']
 filecovered=Fuzz.TestFuzzer:[];java.io.PrintStream:[];Function.FunctionTest:[]

--- a/tests/java/test6/.config
+++ b/tests/java/test6/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test6.jar
 entryclass=Fuzz.TestFuzzer:Fuzz.TestFuzzer2
-reached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer2].main(java.lang.String[]):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
-optimalreached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer2].main(java.lang.String[]):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+reached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer2].main(java.lang.String[])
+optimalreached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer2].main(java.lang.String[])
 filereached=Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];java.io.PrintStream:['Fuzz.TestFuzzer', 'Fuzz.TestFuzzer2'];Function.FunctionTest:['Fuzz.TestFuzzer', 'Fuzz.TestFuzzer2'];Fuzz.TestFuzzer2:['Fuzz.TestFuzzer2']
 filecovered=Fuzz.TestFuzzer:[];java.io.PrintStream:[];Function.FunctionTest:[];Fuzz.TestFuzzer2:[]

--- a/tests/java/test7/.config
+++ b/tests/java/test7/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test7-1.jar:$PWD/test7-2.jar
 entryclass=Fuzz.TestFuzzer:Fuzz2.TestFuzzer2
-reached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz2.TestFuzzer2].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz2.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
-optimalreached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz2.TestFuzzer2].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz2.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+reached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz2.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz2.TestFuzzer2].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer].main(java.lang.String[])
+optimalreached=[Function.FunctionTest].function1():[Function.FunctionTest].function2():[java.io.PrintStream].println(java.lang.String):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz2.TestFuzzer2].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz2.TestFuzzer2].main(java.lang.String[]):[Function.FunctionTest].functionPublicDead():[Function.FunctionTest].functionPrivateDead():[Fuzz.TestFuzzer].main(java.lang.String[])
 filereached=Fuzz2.TestFuzzer2:['Fuzz2.TestFuzzer2'];Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];java.io.PrintStream:['Fuzz2.TestFuzzer2', 'Fuzz.TestFuzzer'];Function.FunctionTest:['Fuzz2.TestFuzzer2', 'Fuzz.TestFuzzer']
 filecovered=Fuzz2.TestFuzzer2:[];Fuzz.TestFuzzer:[];java.io.PrintStream:[];Function.FunctionTest:[]

--- a/tests/java/test8/.config
+++ b/tests/java/test8/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test8.jar
 entryclass=Fuzz.TestFuzzer
-reached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].functionRecursion(int)
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
-optimalreached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].functionRecursion(int)
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
+reached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].functionRecursion(int):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
+optimalreached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].functionRecursion(int):[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
 filereached=Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];Fuzz.FunctionTest:['Fuzz.TestFuzzer']
 filecovered=Fuzz.TestFuzzer:[];Fuzz.FunctionTest:[]

--- a/tests/java/test9/.config
+++ b/tests/java/test9/.config
@@ -1,8 +1,8 @@
 jarfile=$PWD/test9.jar
 entryclass=Fuzz.TestFuzzer
-reached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2()
-unreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
-optimalreached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2()
-optimalunreached=fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
+reached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2():[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+unreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
+optimalreached=[Fuzz.FunctionTest].function1():[Fuzz.FunctionTest].function2():[Fuzz.TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+optimalunreached=[Fuzz.TestFuzzer].main(java.lang.String[]):[Fuzz.FunctionTest].functionPublicDead():[Fuzz.FunctionTest].functionPrivateDead()
 filereached=Fuzz.TestFuzzer:['Fuzz.TestFuzzer'];Fuzz.FunctionTest:['Fuzz.TestFuzzer']
 filecovered=Fuzz.TestFuzzer:[];Fuzz.FunctionTest:[]


### PR DESCRIPTION
Fix naming output problem of Soot code for the entry method. Also changing the fuzz-introspector code to match the updated entry function names. Also include the entry function to the reached function list.

Last but not least, update the unit testing to match the changed name.

Relies on #702 

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>