### PR TITLE
data_loader: wrap data loading to catch unicode errors

### DIFF
--- a/src/fuzz_introspector/data_loader.py
+++ b/src/fuzz_introspector/data_loader.py
@@ -140,12 +140,9 @@ def add_func_to_reached_and_clone(
 
 def _load_profile(data_file: str, language: str, profiles: queue.Queue):
     """Internal function used for multithreaded profile loading"""
-    try:
-        profile = read_fuzzer_data_file_to_profile(data_file, language)
-        if profile is not None:
-            profiles.put(profile)
-    except UnicodeDecodeError:
-        raise DataLoaderError("Yaml file is broken with Unicode issues")
+    profile = read_fuzzer_data_file_to_profile(data_file, language)
+    if profile is not None:
+        profiles.put(profile)
 
 
 def load_all_profiles(

--- a/src/fuzz_introspector/data_loader.py
+++ b/src/fuzz_introspector/data_loader.py
@@ -140,9 +140,12 @@ def add_func_to_reached_and_clone(
 
 def _load_profile(data_file: str, language: str, profiles: queue.Queue):
     """Internal function used for multithreaded profile loading"""
-    profile = read_fuzzer_data_file_to_profile(data_file, language)
-    if profile is not None:
-        profiles.put(profile)
+    try:
+        profile = read_fuzzer_data_file_to_profile(data_file, language)
+        if profile is not None:
+            profiles.put(profile)
+    except UnicodeDecodeError:
+        raise DataLoaderError("Yaml file is broken with Unicode issues")
 
 
 def load_all_profiles(

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -85,6 +85,8 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
             data_dict: Dict[Any, Any] = yaml.safe_load(stream)
             return data_dict
     except Exception:
+        # YAML library does not completely wrap exceptions, so unless
+        # we catch all exceptions here we might end up in a crashing state.
         # This likely fails as the LLVM frontend now is putting multiple docs in
         # same yaml file. See commit 737ba72.
         pass
@@ -97,6 +99,8 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
             data = yaml_f.read()
             docs = yaml.safe_load_all(data)
     except Exception as e:
+        # YAML library does not completely wrap exceptions, so unless
+        # we catch all exceptions here we might end up in a crashing state.
         logger.info("Failed loading YAML: " + str(e))
         return None
 
@@ -115,6 +119,8 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
                         doc['All functions']['Elements']
                     )
     except Exception as e:
+        # YAML library does not completely wrap exceptions, so unless
+        # we catch all exceptions here we might end up in a crashing state.
         logger.info("Failed loading YAML: " + str(e))
         return None
 

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -84,7 +84,7 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         with open(filename, 'r') as stream:
             data_dict: Dict[Any, Any] = yaml.safe_load(stream)
             return data_dict
-    except yaml.YAMLError:
+    except Exception:
         # This likely fails as the LLVM frontend now is putting multiple docs in
         # same yaml file. See commit 737ba72.
         pass
@@ -96,7 +96,7 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         with open(filename, 'r') as yaml_f:
             data = yaml_f.read()
             docs = yaml.safe_load_all(data)
-    except yaml.YAMLError as e:
+    except Exception as e:
         logger.info("Failed loading YAML: " + str(e))
         return None
 
@@ -114,9 +114,10 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
                     content['All functions']['Elements'].extend(
                         doc['All functions']['Elements']
                     )
-    except yaml.YAMLError as e:
+    except Exception as e:
         logger.info("Failed loading YAML: " + str(e))
         return None
+
     if "Fuzzer filename" not in content:
         return None
     if "All functions" not in content:


### PR DESCRIPTION
This should fix a bug found by the report fuzzer.

Signed-off-by: David Korczynski <david@adalogics.com>