### PR TITLE
ci: specify paths for several jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'frontends/**'
   schedule:
     - cron: '35 17 * * 5'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
     paths:
       - 'src/**'
       - 'frontends/**'
+      - '.github/workflows/codeql.yml'
   schedule:
     - cron: '35 17 * * 5'
 

--- a/.github/workflows/google-java.yml
+++ b/.github/workflows/google-java.yml
@@ -1,6 +1,9 @@
 name: Java Format
 permissions: read-all
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'frontends/java/**'
 jobs:
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/google-java.yml
+++ b/.github/workflows/google-java.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'frontends/java/**'
+      - '.github/workflows/google-java.yml'
 jobs:
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/jvm-unit-test.yml
+++ b/.github/workflows/jvm-unit-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'frontends/**'
+      - '.github/workflows/jvm-unit-test.yml'
 permissions: read-all
 jobs:
   build:

--- a/.github/workflows/jvm-unit-test.yml
+++ b/.github/workflows/jvm-unit-test.yml
@@ -1,6 +1,9 @@
 name: JUnit-Frontends
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'frontends/**'
 permissions: read-all
 jobs:
   build:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,11 @@
 name: Mypy
 
-on:  pull_request
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'frontends/python/**'
+      - 'oss_fuzz_integration/**'
 permissions: read-all
 jobs:
   build:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -6,6 +6,7 @@ on:
       - 'src/**'
       - 'frontends/python/**'
       - 'oss_fuzz_integration/**'
+      - '.github/workflows/mypy.yml'
 permissions: read-all
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,7 @@ on:
       - 'frontends/**'
       - 'src/**'
       - 'test/**'
+      - '.github/workflows/testing.yml'
 permissions: read-all
 jobs:
   unittests:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,11 @@
 name: Unit tests
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'frontends/**'
+      - 'src/**'
+      - 'test/**'
 permissions: read-all
 jobs:
   unittests:


### PR DESCRIPTION
This is to make the CI only run relevant jobs for relevant code, in order to speed it up when it's not needed.

Signed-off-by: David Korczynski <david@adalogics.com>