### PR TITLE
JVM implementation: Fix all around include and depth calculation

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -104,7 +104,7 @@ def run_introspector_frontend(target_class, jar_set):
       jarfile_str,
       target_class.replace(".class", ""),
       "fuzzerTestOneInput", # entrymethod
-      "jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt." # exclude prefix
+      ";jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt." # include prefix ; exclude prefix
   ]
 
   print("Running command: [%s]" % " ".join(cmd))

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -39,6 +39,11 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -i|--includeprefix)
+      INCLUDEPREFIX="$2"
+      shift
+      shift
+      ;;
     *)
       echo "Unknown option $1"
       exit 1
@@ -63,8 +68,13 @@ then
 fi
 if [ -z $EXCLUDEPREFIX ]
 then
-    echo "No exclude prefix list  defined, using default exclude prefix list"
+    echo "No exclude prefix list defined, using default exclude prefix list"
     EXCLUDEPREFIX="jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt."
+fi
+if [ -z $INCLUDEPREFIX ]
+then
+    echo "No include prefix list defined, using empty include prefix list"
+    INCLUDEPREFIX="jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt."
 fi
 
 # Build and execute the call graph generator
@@ -74,5 +84,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD $EXCLUDEPREFIX
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD $INCLUDEPREFIX;$EXCLUDEPREFIX
 done

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -74,7 +74,7 @@ fi
 if [ -z $INCLUDEPREFIX ]
 then
     echo "No include prefix list defined, using empty include prefix list"
-    INCLUDEPREFIX="jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt."
+    INCLUDEPREFIX=
 fi
 
 # Build and execute the call graph generator
@@ -84,5 +84,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD $INCLUDEPREFIX;$EXCLUDEPREFIX
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$INCLUDEPREFIX;$EXCLUDEPREFIX"
 done

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -62,9 +62,11 @@ public class CallGraphGenerator {
     List<String> jarFiles = Arrays.asList(args[0].split(":"));
     String entryClass = args[1];
     String entryMethod = args[2];
+    String includePrefix = "";
     String excludePrefix = "";
     if (args.length == 4) {
-      excludePrefix = args[3];
+      includePrefix = args[3].split(";")[0];
+      excludePrefix = args[3].split(";")[1];
     }
 
     if (jarFiles.size() < 1) {
@@ -77,14 +79,14 @@ public class CallGraphGenerator {
 
     // Add an custom analysis phase to Soot
     CustomSenceTransformer custom =
-        new CustomSenceTransformer(entryClass, entryMethod, excludePrefix);
+        new CustomSenceTransformer(entryClass, entryMethod, includePrefix, excludePrefix);
     PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
 
     // Set basic settings for the call graph generation
     Options.v().set_process_dir(jarFiles);
     Options.v().set_prepend_classpath(true);
     Options.v().set_src_prec(Options.src_prec_java);
-    Options.v().set_include_all(true);
+    Options.v().set_include(custom.getIncludeList());
     Options.v().set_exclude(custom.getExcludeList());
     Options.v().set_no_bodies_for_excluded(true);
     Options.v().set_allow_phantom_refs(true);
@@ -119,6 +121,7 @@ public class CallGraphGenerator {
 }
 
 class CustomSenceTransformer extends SceneTransformer {
+  private List<String> includeList;
   private List<String> excludeList;
   private List<String> excludeMethodList;
   private List<Block> visitedBlock;
@@ -128,13 +131,23 @@ class CustomSenceTransformer extends SceneTransformer {
   private SootMethod entryMethod;
   private FunctionConfig methodList;
 
-  public CustomSenceTransformer(String entryClassStr, String entryMethodStr, String excludePrefix) {
+  public CustomSenceTransformer(
+    String entryClassStr,
+    String entryMethodStr,
+    String includePrefix,
+    String excludePrefix) {
     this.entryClassStr = entryClassStr;
     this.entryMethodStr = entryMethodStr;
     this.entryMethod = null;
 
+    includeList = new LinkedList<String>();
     excludeList = new LinkedList<String>();
 
+    for (String include : includePrefix.split(":")) {
+      if (!include.equals("")) {
+        includeList.add(include);
+      }
+    }
     for (String exclude : excludePrefix.split(":")) {
       if (!exclude.equals("")) {
         excludeList.add(exclude);
@@ -395,22 +408,24 @@ class CustomSenceTransformer extends SceneTransformer {
   // Shorthand for calculateDepth from Top
   private void calculateDepth() {
     for (FunctionElement element : methodList.getFunctionElements()) {
-      element.setFunctionDepth(this.calculateDepth(element));
+      element.setFunctionDepth(this.calculateDepth(element, new HashSet<FunctionElement>()));
     }
   }
 
   // Calculate method depth
-  private Integer calculateDepth(FunctionElement element) {
+  private Integer calculateDepth(FunctionElement element, Set<FunctionElement> handled) {
     Integer depth = element.getFunctionDepth();
 
-    if (depth > 0) {
+    if ((depth > 0) || (handled.contains(element))) {
       return depth;
     }
+
+    handled.add(element);
 
     for (String reachedName : element.getFunctionsReached()) {
       FunctionElement reachedElement = this.searchElement(reachedName);
       if (reachedElement != null) {
-        Integer newDepth = this.calculateDepth(reachedElement) + 1;
+        Integer newDepth = this.calculateDepth(reachedElement, handled) + 1;
         depth = (newDepth > depth) ? newDepth : depth;
       }
     }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -132,10 +132,7 @@ class CustomSenceTransformer extends SceneTransformer {
   private FunctionConfig methodList;
 
   public CustomSenceTransformer(
-    String entryClassStr,
-    String entryMethodStr,
-    String includePrefix,
-    String excludePrefix) {
+      String entryClassStr, String entryMethodStr, String includePrefix, String excludePrefix) {
     this.entryClassStr = entryClassStr;
     this.entryMethodStr = entryMethodStr;
     this.entryMethod = null;
@@ -657,6 +654,10 @@ class CustomSenceTransformer extends SceneTransformer {
     }
 
     return mergedClassName.toString();
+  }
+
+  public List<String> getIncludeList() {
+    return includeList;
   }
 
   public List<String> getExcludeList() {

--- a/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
+++ b/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
@@ -16,15 +16,19 @@ public class CustomSenceTransformerTest {
 
   @Test
   public void testBasic() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "");
+    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "", "");
     assertTrue(custom instanceof SceneTransformer);
     assertTrue(custom instanceof CustomSenceTransformer);
+    assertEquals(custom.getIncludeList().size(), 0);
     assertEquals(custom.getExcludeList().size(), 0);
   }
 
   @Test
   public void testExcludePrefix() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "abc:def:ghi");
+    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "abc:def:ghi", "jkl:mno:pqr");
+    assertEquals(custom.getIncludeList().size(), 3);
+    Object[] expected = {"jkl", "mnof", "pqr"};
+    assertArrayEquals(custom.getIncludeList().toArray(), expected);
     assertEquals(custom.getExcludeList().size(), 3);
     Object[] expected = {"abc", "def", "ghi"};
     assertArrayEquals(custom.getExcludeList().toArray(), expected);

--- a/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
+++ b/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
@@ -25,12 +25,13 @@ public class CustomSenceTransformerTest {
 
   @Test
   public void testExcludePrefix() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "abc:def:ghi", "jkl:mno:pqr");
+    CustomSenceTransformer custom =
+        new CustomSenceTransformer("", "", "abc:def:ghi", "jkl:mno:pqr");
     assertEquals(custom.getIncludeList().size(), 3);
-    Object[] expected = {"jkl", "mnof", "pqr"};
-    assertArrayEquals(custom.getIncludeList().toArray(), expected);
     assertEquals(custom.getExcludeList().size(), 3);
-    Object[] expected = {"abc", "def", "ghi"};
-    assertArrayEquals(custom.getExcludeList().toArray(), expected);
+    Object[] eexpected = {"jkl", "mno", "pqr"};
+    Object[] iexpected = {"abc", "def", "ghi"};
+    assertArrayEquals(custom.getIncludeList().toArray(), iexpected);
+    assertArrayEquals(custom.getExcludeList().toArray(), eexpected);
   }
 }


### PR DESCRIPTION
Fix slow execution and out of stack memory problem. Change the calculation of function depth and add in options to include necessary package instead of including all library packages at once.

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>