### PR TITLE
Jvm bug: Fix semicolon bug

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -104,7 +104,7 @@ def run_introspector_frontend(target_class, jar_set):
       jarfile_str,
       target_class.replace(".class", ""),
       "fuzzerTestOneInput", # entrymethod
-      "';jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt.'" # include prefix ; exclude prefix
+      "===jdk.:java.:javax.:sun.:sunw.:com.sun.:com.ibm.:com.apple.:apple.awt." # include prefix === exclude prefix
   ]
 
   print("Running command: [%s]" % " ".join(cmd))

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -84,5 +84,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$INCLUDEPREFIX;$EXCLUDEPREFIX"
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$INCLUDEPREFIX===$EXCLUDEPREFIX"
 done

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -65,8 +65,8 @@ public class CallGraphGenerator {
     String includePrefix = "";
     String excludePrefix = "";
     if (args.length == 4) {
-      includePrefix = args[3].split(";")[0];
-      excludePrefix = args[3].split(";")[1];
+      includePrefix = args[3].split("===")[0];
+      excludePrefix = args[3].split("===")[1];
     }
 
     if (jarFiles.size() < 1) {


### PR DESCRIPTION
Fix the bug that python subprocess call cannot accept semicolon as valid character.

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>