### PR TITLE
requirements: specify sphinx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pep8
 mypy
 psutil
 pytest
-sphinx
+sphinx==6.0.0
 sphinx_rtd_theme
 configparser
 coverage


### PR DESCRIPTION
This is because readthedocs uses an older version of sphinx to generate docs, which produces different output to the latest sphinx. Specify version so it's fixed.

Signed-off-by: David Korczynski <david@adalogics.com>