### PR TITLE
Rename analyses to avoid Analysis class

### DIFF
--- a/src/fuzz_introspector/analyses/__init__.py
+++ b/src/fuzz_introspector/analyses/__init__.py
@@ -1,4 +1,3 @@
-from fuzz_introspector.analyses import calltree_analysis
 from fuzz_introspector.analyses import bug_digestor
 from fuzz_introspector.analyses import driver_synthesizer
 from fuzz_introspector.analyses import engine_input

--- a/src/fuzz_introspector/analyses/__init__.py
+++ b/src/fuzz_introspector/analyses/__init__.py
@@ -1,0 +1,24 @@
+from fuzz_introspector.analyses import calltree_analysis
+from fuzz_introspector.analyses import bug_digestor
+from fuzz_introspector.analyses import driver_synthesizer
+from fuzz_introspector.analyses import engine_input
+from fuzz_introspector.analyses import filepath_analyser
+from fuzz_introspector.analyses import function_call_analyser
+from fuzz_introspector.analyses import metadata
+from fuzz_introspector.analyses import optimal_targets
+from fuzz_introspector.analyses import runtime_coverage_analysis
+from fuzz_introspector.analyses import sinks_analyser
+
+# Ordering here is important as top analysis will be shown first in the report
+all_analyses = [
+  bug_digestor.BugDigestor,
+  calltree_analysis.FuzzCalltreeAnalysis,
+  driver_synthesizer.DriverSynthesizer,
+  engine_input.EngineInput,
+  filepath_analyser.FilePathAnalysis,
+  function_call_analyser.ThirdPartyAPICoverageAnalyser,
+  metadata.MetadataAnalysis,
+  optimal_targets.OptimalTargets,
+  runtime_coverage_analysis.RuntimeCoverageAnalysis,
+  sinks_analyser.SinkCoverageAnalyser
+]

--- a/src/fuzz_introspector/analyses/__init__.py
+++ b/src/fuzz_introspector/analyses/__init__.py
@@ -9,16 +9,16 @@ from fuzz_introspector.analyses import optimal_targets
 from fuzz_introspector.analyses import runtime_coverage_analysis
 from fuzz_introspector.analyses import sinks_analyser
 
+# All optional analyses.
 # Ordering here is important as top analysis will be shown first in the report
 all_analyses = [
-    bug_digestor.BugDigestor,
-    calltree_analysis.FuzzCalltreeAnalysis,
-    driver_synthesizer.DriverSynthesizer,
+    optimal_targets.OptimalTargets,
     engine_input.EngineInput,
+    runtime_coverage_analysis.RuntimeCoverageAnalysis,
+    driver_synthesizer.DriverSynthesizer,
+    bug_digestor.BugDigestor,
     filepath_analyser.FilePathAnalysis,
     function_call_analyser.ThirdPartyAPICoverageAnalyser,
     metadata.MetadataAnalysis,
-    optimal_targets.OptimalTargets,
-    runtime_coverage_analysis.RuntimeCoverageAnalysis,
     sinks_analyser.SinkCoverageAnalyser
 ]

--- a/src/fuzz_introspector/analyses/__init__.py
+++ b/src/fuzz_introspector/analyses/__init__.py
@@ -11,14 +11,14 @@ from fuzz_introspector.analyses import sinks_analyser
 
 # Ordering here is important as top analysis will be shown first in the report
 all_analyses = [
-  bug_digestor.BugDigestor,
-  calltree_analysis.FuzzCalltreeAnalysis,
-  driver_synthesizer.DriverSynthesizer,
-  engine_input.EngineInput,
-  filepath_analyser.FilePathAnalysis,
-  function_call_analyser.ThirdPartyAPICoverageAnalyser,
-  metadata.MetadataAnalysis,
-  optimal_targets.OptimalTargets,
-  runtime_coverage_analysis.RuntimeCoverageAnalysis,
-  sinks_analyser.SinkCoverageAnalyser
+    bug_digestor.BugDigestor,
+    calltree_analysis.FuzzCalltreeAnalysis,
+    driver_synthesizer.DriverSynthesizer,
+    engine_input.EngineInput,
+    filepath_analyser.FilePathAnalysis,
+    function_call_analyser.ThirdPartyAPICoverageAnalyser,
+    metadata.MetadataAnalysis,
+    optimal_targets.OptimalTargets,
+    runtime_coverage_analysis.RuntimeCoverageAnalysis,
+    sinks_analyser.SinkCoverageAnalyser
 ]

--- a/src/fuzz_introspector/analyses/bug_digestor.py
+++ b/src/fuzz_introspector/analyses/bug_digestor.py
@@ -28,7 +28,7 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class BugDigestor(analysis.AnalysisInterface):
     """Analysis for creating input consumed by a fuzzer, e.g. a dictionary
     and fuzzer focus functions in libFuzzer. The analysis outputs this either
     in .json format or as HTML string that can be embedded in the HTML report.
@@ -60,7 +60,7 @@ class Analysis(analysis.AnalysisInterface):
         conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
         """Digests and creates HTML about bugs found by the fuzzers."""
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
         input_bugs = data_loader.try_load_input_bugs()
         if len(input_bugs) == 0:
             return ""

--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -40,7 +40,7 @@ from fuzz_introspector.html_report import create_collapsible_element
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class FuzzCalltreeAnalysis(analysis.AnalysisInterface):
     name: str = "FuzzCalltreeAnalysis"
 
     def __init__(self) -> None:

--- a/src/fuzz_introspector/analyses/driver_synthesizer.py
+++ b/src/fuzz_introspector/analyses/driver_synthesizer.py
@@ -39,7 +39,7 @@ class DriverContents:
         self.target_fds: List[function_profile.FunctionProfile] = list()
 
 
-class Analysis(analysis.AnalysisInterface):
+class DriverSynthesizer(analysis.AnalysisInterface):
     name: str = "FuzzDriverSynthesizerAnalysis"
 
     def __init__(self) -> None:
@@ -66,7 +66,7 @@ class Analysis(analysis.AnalysisInterface):
         conclusions: List[html_helpers.HTMLConclusion],
         fuzz_targets=None
     ) -> str:
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
         html_string = ""
         html_string += "<div class=\"report-box\">"
         html_string += html_helpers.html_add_header_with_link(
@@ -77,7 +77,7 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "<div class=\"collapsible\">"
 
         if fuzz_targets is None or len(fuzz_targets) == 0:
-            A1 = optimal_targets.Analysis()
+            A1 = optimal_targets.OptimalTargets()
 
             _, optimal_target_functions = A1.iteratively_get_optimal_targets(
                 proj_profile
@@ -184,6 +184,6 @@ class Analysis(analysis.AnalysisInterface):
 
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
-        logger.info(f" - Completed analysis {Analysis.get_name()}")
+        logger.info(f" - Completed analysis {self.get_name()}")
 
         return html_string

--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -36,7 +36,7 @@ from fuzz_introspector.datatypes import (
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class EngineInput(analysis.AnalysisInterface):
     name: str = "FuzzEngineInputAnalysis"
 
     def __init__(self) -> None:
@@ -63,7 +63,7 @@ class Analysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         if not self.display_html:
             toc_list = []
@@ -104,7 +104,7 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        logger.info(f" - Completed analysis {Analysis.get_name()}")
+        logger.info(f" - Completed analysis {self.get_name()}")
         if not self.display_html:
             html_string = ""
 
@@ -164,7 +164,7 @@ class Analysis(analysis.AnalysisInterface):
             toc_list
         )
 
-        calltree_analysis = cta.Analysis()
+        calltree_analysis = cta.FuzzCalltreeAnalysis()
         fuzz_blockers = calltree_analysis.get_fuzz_blockers(
             profile,
             max_blockers_to_extract=10

--- a/src/fuzz_introspector/analyses/filepath_analyser.py
+++ b/src/fuzz_introspector/analyses/filepath_analyser.py
@@ -29,7 +29,7 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class FilePathAnalysis(analysis.AnalysisInterface):
     name: str = "FilePathAnalyser"
 
     def __init__(self) -> None:
@@ -65,7 +65,7 @@ class Analysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         all_proj_files = self.all_files_targeted(proj_profile)
         all_proj_dirs = set()

--- a/src/fuzz_introspector/analyses/function_call_analyser.py
+++ b/src/fuzz_introspector/analyses/function_call_analyser.py
@@ -34,7 +34,7 @@ from fuzz_introspector.datatypes import (
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class ThirdPartyAPICoverageAnalyser(analysis.AnalysisInterface):
     """This Analysis aims to analyse and generate html report content table
     to show all occurence of third party function call within the target
     project and if those calls are statically reached or dynamically covered.
@@ -189,7 +189,7 @@ class Analysis(analysis.AnalysisInterface):
            call location is dynamically covered by any of the fuzzers, and also show the
            name of the fuzzers that covered that line of code.
         """
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         # Getting data
         callsite_list = []

--- a/src/fuzz_introspector/analyses/metadata.py
+++ b/src/fuzz_introspector/analyses/metadata.py
@@ -31,7 +31,7 @@ from fuzz_introspector.datatypes import (
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class MetadataAnalysis(analysis.AnalysisInterface):
     name: str = "MetadataAnalysis"
 
     def __init__(self) -> None:
@@ -57,7 +57,7 @@ class Analysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         html_string = ""
         html_string += "<div class=\"report-box\">"
@@ -109,6 +109,6 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        logger.info(f" - Completed analysis {Analysis.get_name()}")
+        logger.info(f" - Completed analysis {self.get_name()}")
 
         return html_string

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -37,7 +37,7 @@ from fuzz_introspector.datatypes import (
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class OptimalTargets(analysis.AnalysisInterface):
     name: str = "OptimalTargets"
 
     def __init__(self) -> None:
@@ -79,7 +79,7 @@ class Analysis(analysis.AnalysisInterface):
         rather than substitute it.
         """
 
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         html_string = ""
         html_string += html_helpers.html_add_header_with_link(
@@ -108,7 +108,7 @@ class Analysis(analysis.AnalysisInterface):
             basefolder
         )
 
-        logger.info(f" - Completed analysis {Analysis.get_name()}")
+        logger.info(f" - Completed analysis {self.get_name()}")
         html_string += "</div>"  # .collapsible
 
         return html_string

--- a/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
+++ b/src/fuzz_introspector/analyses/runtime_coverage_analysis.py
@@ -29,7 +29,7 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-class Analysis(analysis.AnalysisInterface):
+class RuntimeCoverageAnalysis(analysis.AnalysisInterface):
     name: str = "RuntimeCoverageAnalysis"
 
     def __init__(self) -> None:
@@ -55,7 +55,7 @@ class Analysis(analysis.AnalysisInterface):
         coverage_url: str,
         conclusions: List[html_helpers.HTMLConclusion]
     ) -> str:
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         html_string = ""
         html_string += "<div class=\"report-box\">"
@@ -120,7 +120,7 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        logger.info(f" - Completed analysis {Analysis.get_name()}")
+        logger.info(f" - Completed analysis {self.get_name()}")
 
         return html_string
 

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -119,7 +119,7 @@ SINK_FUNCTION = {
 }
 
 
-class Analysis(analysis.AnalysisInterface):
+class SinkCoverageAnalyser(analysis.AnalysisInterface):
     """This Analysis aims to analyse and generate html report content table
     to show all occurence of possible sink functions / methods existed in the
     target project and if those functions / methods are statically reached or
@@ -341,7 +341,7 @@ class Analysis(analysis.AnalysisInterface):
            those sink functions / methods.
         Remark: json report will be generated instead of html report if tables is None
         """
-        logger.info(f" - Running analysis {Analysis.get_name()}")
+        logger.info(f" - Running analysis {self.get_name()}")
 
         # Get full function /  callsite list for all fuzzer's profiles
         callsite_list, function_list = self._retrieve_data_list(proj_profile, profiles)
@@ -417,5 +417,5 @@ class Analysis(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
-        logger.info(f" - Finish running analysis {Analysis.get_name()}")
+        logger.info(f" - Finish running analysis {self.get_name()}")
         return html_string

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -130,31 +130,8 @@ class FuzzBranchBlocker:
 
 
 def get_all_analyses() -> List[Type[AnalysisInterface]]:
-    # Ordering here is important as top analysis will be shown first in the report
-    from fuzz_introspector.analyses import (
-        driver_synthesizer,
-        engine_input,
-        optimal_targets,
-        runtime_coverage_analysis,
-        bug_digestor,
-        filepath_analyser,
-        function_call_analyser,
-        metadata,
-        sinks_analyser
-    )
-
-    analysis_array = [
-        optimal_targets.Analysis,
-        engine_input.Analysis,
-        runtime_coverage_analysis.Analysis,
-        driver_synthesizer.Analysis,
-        bug_digestor.Analysis,
-        filepath_analyser.Analysis,
-        function_call_analyser.Analysis,
-        metadata.Analysis,
-        sinks_analyser.Analysis
-    ]
-    return analysis_array
+    from fuzz_introspector import analyses
+    return analyses.all_analyses
 
 
 def callstack_get_parent(

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -508,7 +508,7 @@ def create_fuzzer_detailed_section(
         "Call tree", 3, toc_list, link=f"call_tree_{curr_tt_profile}")
 
     from fuzz_introspector.analyses import calltree_analysis as cta
-    calltree_analysis = cta.Analysis()
+    calltree_analysis = cta.FuzzCalltreeAnalysis()
     calltree_file_name = calltree_analysis.create_calltree(profile)
 
     html_string += f"""<p class='no-top-margin'>The calltree shows the


### PR DESCRIPTION
All analyses have an `Analysis` class, which is slightly annoying for python documentation (https://fuzz-introspector.readthedocs.io/) as it shows all of them with the same name. This changes the general names to plugin-specific names, and then has a list in analyses/__init__.py with all of the various plugin names. This improves documentation and I think also makes the code better.

Signed-off-by: David Korczynski <david@adalogics.com>