### PR TITLE
Sink Analyser:Fix python builtin package naming

### DIFF
--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -54,8 +54,8 @@ SINK_FUNCTION = {
         ('', 'fdopen')
     ],
     'python': [
-        ('', 'exec'),
-        ('', 'eval'),
+        ('<builtin>', 'exec'),
+        ('<builtin>', 'eval'),
         ('subprocess', 'call'),
         ('subprocess', 'run'),
         ('subprocess', 'Popen'),
@@ -269,6 +269,8 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
             elif target_lang == "python":
                 func_name = fd.function_name
                 package = fd.function_source_file
+                if func_name.startswith("<builtin>."):
+                    package, func_name = func_name.split(".", 1)
             elif target_lang == "jvm":
                 func_name = fd.function_name.split('(')[0]
                 if "." in func_name:


### PR DESCRIPTION
Fix naming handling for python which has <builtin> tag added for those function call in default package.

Signed-off-by: Arthur Chan <arthurchan@adalogics.com>