### PR TITLE
Improve json output

### DIFF
--- a/src/fuzz_introspector/analyses/engine_input.py
+++ b/src/fuzz_introspector/analyses/engine_input.py
@@ -23,10 +23,13 @@ from typing import (
     Dict
 )
 
-from fuzz_introspector import analysis
-from fuzz_introspector import constants
-from fuzz_introspector import html_helpers
-from fuzz_introspector import utils
+from fuzz_introspector import (
+    analysis,
+    constants,
+    html_helpers,
+    json_report,
+    utils
+)
 from fuzz_introspector.analyses import calltree_analysis as cta
 from fuzz_introspector.datatypes import (
     project_profile,
@@ -129,6 +132,10 @@ class EngineInput(analysis.AnalysisInterface):
                 dictionary[f"k{kn}"] = const
                 kn += 1
         self.set_json_string_result(json.dumps(dictionary))
+        json_report.add_analysis_json_str_as_dict_to_report(
+            self.get_name(),
+            self.get_json_string_result()
+        )
         return dictionary_content
 
     def get_dictionary_section(

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -28,6 +28,7 @@ from fuzz_introspector import (
     code_coverage,
     cfg_load,
     html_helpers,
+    json_report,
     utils
 )
 
@@ -376,6 +377,10 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
         )
 
         self.set_json_string_result(json_row)
+        json_report.add_json_str_as_dict_to_report(
+            self.get_name(),
+            self.get_json_string_result()
+        )
 
         html_string = ""
         html_string += "<div class=\"report-box\">"

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -377,7 +377,7 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
         )
 
         self.set_json_string_result(json_row)
-        json_report.add_json_str_as_dict_to_report(
+        json_report.add_analysis_json_str_as_dict_to_report(
             self.get_name(),
             self.get_json_string_result()
         )

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -100,7 +100,7 @@ def run_analysis_on_dir(
 
     logger.info(f"Analyses to run: {str(analyses_to_run)}")
     logger.info("[+] Creating HTML report")
-    analyser_instance_dict = html_report.create_html_report(
+    html_report.create_html_report(
         profiles,
         proj_profile,
         analyses_to_run,
@@ -109,15 +109,5 @@ def run_analysis_on_dir(
         proj_profile.basefolder,
         report_name
     )
-
-    logger.info(f"Analyses with json output: {str(analyser_instance_dict.keys())}")
-    if len(analyser_instance_dict.keys()) > 0:
-        logger.info("[+] Creating JSON report")
-        json_report.create_json_report(
-            profiles,
-            proj_profile,
-            analyser_instance_dict,
-            coverage_url
-        )
 
     return constants.APP_EXIT_SUCCESS

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -21,7 +21,6 @@ from fuzz_introspector import analysis
 from fuzz_introspector import constants
 from fuzz_introspector import data_loader
 from fuzz_introspector import html_report
-from fuzz_introspector import json_report
 from fuzz_introspector import utils
 from fuzz_introspector.datatypes import project_profile
 

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -829,7 +829,7 @@ def create_html_report(
     coverage_url: str,
     basefolder: str,
     report_name: str
-) -> Dict[str, analysis.AnalysisInterface]:
+) -> None:
     """
     Logs a complete report. This is the current main place for looking at
     data produced by fuzz introspector.
@@ -997,7 +997,6 @@ def create_html_report(
 
     # Combine and distinguish analyser requires output in html or both (html and json)
     combined_analyses = analyses_to_run
-    analyser_instance_dict: Dict[str, analysis.AnalysisInterface] = {}
     for analyses in output_json:
         if analyses not in analyses_to_run:
             combined_analyses.append(analyses)
@@ -1019,8 +1018,6 @@ def create_html_report(
             )
             if analysis_name in analyses_to_run:
                 html_report_core += html_string
-            if analysis_name in output_json:
-                analyser_instance_dict[analysis_name] = analysis_instance
     html_report_core += "</div>"  # .collapsible
     html_report_core += "</div>"  # report box
 
@@ -1124,6 +1121,3 @@ def create_html_report(
     style_dir = os.path.join(basedir, "styling")
     for s in ["clike.js", "prism.css", "prism.js", "styles.css", "custom.js", "calltree.js"]:
         shutil.copy(os.path.join(style_dir, s), s)
-
-    # Return analysis instance that requires json report
-    return analyser_instance_dict

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -29,57 +29,30 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 logger = logging.getLogger(name=__name__)
 
 
-def _retrieve_json_section(
-    analyser_name: str,
-    analysis_instance: analysis.AnalysisInterface
-) -> str:
+def add_dict_to_json_report(dict_to_add) -> None:
+    """Adds the contents of a dictionary to the contents the json report.
+    This is an expensive operation in that it will load the json report
+    to merge the contents.
     """
-    Generate json string for saving the result of a
-    specific analyser
-    """
-    if analyser_name in [item.get_name() for item in analysis.get_all_analyses()]:
-        return analysis_instance.get_json_string_result()
-    return json.dumps([])
+    logger.info("Adding contents to summary")
+    if not os.path.isfile(constants.SUMMARY_FILE):
+        existing_contents = dict()
+    else:
+        with open(constants.SUMMARY_FILE, "r") as report_fd:
+            existing_contents = json.load(report_fd)
+
+    # Update the contents
+    existing_contents.update(dict_to_add)
+
+    # Write back the json file
+    with open(constants.SUMMARY_FILE, 'w') as report_fd:
+        json.dump(existing_contents, report_fd)
 
 
-def create_json_report(
-    profiles: List[fuzzer_profile.FuzzerProfile],
-    proj_profile: project_profile.MergedProjectProfile,
-    analyser_instance_dict: Dict[str, analysis.AnalysisInterface],
-    coverage_url: str
-) -> None:
-    """
-    Generate json report for the fuzz-introspector execution session.
-    This method is also extendable in the future to act in more
-    results from other sessions to be included in the json format
-    of the output.
-    """
+def add_analysis_dict_to_json_report(analysis_name, dict_to_add) -> None:
+    """Wraps dictionary into an appropriate format"""
+    add_dict_to_json_report({'analyses': {analysis_name: dict_to_add}})
 
-    logger.info(" - Creating JSON report for fuzz-introspetcor")
-    if not proj_profile.has_coverage_data():
-        logger.error(
-            "No files with coverage data was found. This is either "
-            "because an error occurred when compiling and running "
-            "coverage runs, or because the introspector run was "
-            "intentionally done without coverage collection. In order "
-            "to get optimal results coverage data is needed."
-        )
 
-    result_dict: Dict[str, Dict[str, Any]] = {'report': {}}
-    for analyses_name in analyser_instance_dict.keys():
-        logger.info(f" - Handling {analyses_name}")
-        result_str = _retrieve_json_section(
-            analyses_name,
-            analyser_instance_dict[analyses_name]
-        )
-        result_dict['report'][analyses_name] = json.loads(result_str)
-
-    result_str = json.dumps(result_dict)
-    logger.info("Finish handling sections that need json output")
-
-    # Write the json string to file
-    report_file = constants.JSON_REPORT_FILE
-    if os.path.isfile(report_file):
-        os.remove(report_file)
-    with open(report_file, "a+") as file:
-        file.write(result_str)
+def add_json_str_as_dict_to_report(analysis_name, json_str) -> None:
+    add_analysis_dict_to_json_report(analysis_name, json.loads(json_str))

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -18,18 +18,16 @@ import logging
 
 from typing import (
     Any,
-    List,
     Dict
 )
 
-from fuzz_introspector import analysis, constants
-from fuzz_introspector.datatypes import project_profile, fuzzer_profile
+from fuzz_introspector import constants
 
 
 logger = logging.getLogger(name=__name__)
 
 
-def add_dict_to_json_report(dict_to_add) -> None:
+def add_dict_to_json_report(dict_to_add: Dict[Any, Any]) -> None:
     """Adds the contents of a dictionary to the contents the json report.
     This is an expensive operation in that it will load the json report
     to merge the contents.
@@ -49,10 +47,13 @@ def add_dict_to_json_report(dict_to_add) -> None:
         json.dump(existing_contents, report_fd)
 
 
-def add_analysis_dict_to_json_report(analysis_name, dict_to_add) -> None:
+def add_analysis_dict_to_json_report(
+    analysis_name: str,
+    dict_to_add: Dict[Any, Any]
+) -> None:
     """Wraps dictionary into an appropriate format"""
     add_dict_to_json_report({'analyses': {analysis_name: dict_to_add}})
 
 
-def add_json_str_as_dict_to_report(analysis_name, json_str) -> None:
+def add_analysis_json_str_as_dict_to_report(analysis_name: str, json_str: str) -> None:
     add_analysis_dict_to_json_report(analysis_name, json.loads(json_str))


### PR DESCRIPTION
This removes the use of `fuzz-introspector.json` as we already had `summary.json` as a file for outputting data. The existing approach is to write the json contents when it's ready (using https://github.com/ossf/fuzz-introspector/blob/aeddd0658b7a76af5cbdc2dc035e3381755eeb66/src/fuzz_introspector/utils.py#L229) so am switching to a similar approach for the sink analyser. More refactoring is needed shortly to place all outputting logic into `json_report.py` instead of `utils.py`