### PR TITLE
refactor json reporting

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -26,11 +26,15 @@ from typing import (
     Type,
 )
 
-from fuzz_introspector import utils
-from fuzz_introspector import constants
-from fuzz_introspector import cfg_load
-from fuzz_introspector import code_coverage
-from fuzz_introspector import html_helpers
+from fuzz_introspector import (
+    cfg_load,
+    code_coverage,
+    constants,
+    html_helpers,
+    json_report,
+    utils
+)
+
 from fuzz_introspector.datatypes import (
     project_profile,
     fuzzer_profile,
@@ -420,7 +424,11 @@ def overlay_calltree_with_coverage(
                 'function_name': blk.function_name
             }
         )
-    utils.write_to_summary_file(profile.identifier, 'branch_blockers', branch_blockers_list)
+    json_report.add_fuzzer_key_value_to_report(
+        profile.identifier,
+        'branch_blockers',
+        branch_blockers_list
+    )
 
 
 def update_branch_complexities(all_functions: Dict[str, function_profile.FunctionProfile],

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -25,9 +25,12 @@ from typing import (
     Tuple,
 )
 
-from fuzz_introspector import cfg_load
-from fuzz_introspector import code_coverage
-from fuzz_introspector import utils
+from fuzz_introspector import (
+    cfg_load,
+    code_coverage,
+    json_report,
+    utils
+)
 from fuzz_introspector.datatypes import function_profile
 from fuzz_introspector.exceptions import DataLoaderError
 
@@ -362,7 +365,7 @@ class FuzzerProfile:
 
     def write_stats_to_summary_file(self) -> None:
         file_target_count = len(self.file_targets) if self.file_targets is not None else 0
-        utils.write_to_summary_file(
+        json_report.add_fuzzer_key_value_to_report(
             self.identifier,
             "stats",
             {

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -22,9 +22,12 @@ from typing import (
     Tuple,
 )
 
-from fuzz_introspector import code_coverage
-from fuzz_introspector import utils
-from fuzz_introspector import exceptions
+from fuzz_introspector import (
+    code_coverage,
+    exceptions,
+    json_report,
+    utils
+)
 from fuzz_introspector.datatypes import function_profile, fuzzer_profile
 
 logger = logging.getLogger(name=__name__)
@@ -264,7 +267,7 @@ class MergedProjectProfile:
          reached_complexity_percentage,
          unreached_complexity_percentage) = self.get_complexity_summaries()
 
-        utils.write_to_summary_file(
+        json_report.add_fuzzer_key_value_to_report(
             "MergedProjectProfile",
             "stats",
             {

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -31,11 +31,15 @@ from typing import (
     Tuple,
 )
 
-from fuzz_introspector import analysis
-from fuzz_introspector import utils
-from fuzz_introspector import cfg_load
-from fuzz_introspector import constants
-from fuzz_introspector import html_helpers
+from fuzz_introspector import (
+    analysis,
+    cfg_load,
+    constants,
+    html_helpers,
+    json_report,
+    utils
+)
+
 from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 
 
@@ -700,7 +704,7 @@ def create_fuzzer_detailed_section(
         logger.info("reachable funcs is 0")
         cov_reach_proportion = 0.0
     str_percentage = "%.5s%%" % str(cov_reach_proportion)
-    utils.write_to_summary_file(
+    json_report.add_fuzzer_key_value_to_report(
         profile.identifier,
         "coverage-blocker-stats",
         {

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(name=__name__)
 
 
 def _get_summary_dict() -> Dict[Any, Any]:
+    """Returns the current json report on disk as a dictionary."""
     if not os.path.isfile(constants.SUMMARY_FILE):
         existing_contents = dict()
     else:
@@ -38,6 +39,9 @@ def _get_summary_dict() -> Dict[Any, Any]:
 
 
 def _overwrite_report_with_dict(new_dict: Dict[Any, Any]) -> None:
+    """Writes `new_dict` as contents to the report on disk. Will overwrite any
+    contents of the existing report.
+    """
     # Write back the json file
     with open(constants.SUMMARY_FILE, 'w') as report_fd:
         json.dump(dict(new_dict), report_fd)
@@ -47,7 +51,11 @@ def add_analysis_dict_to_json_report(
     analysis_name: str,
     dict_to_add: Dict[Any, Any]
 ) -> None:
-    """Wraps dictionary into an appropriate format"""
+    """Wraps dictionary into an appropriate format
+
+    Will overwrite the existing key/value pair for the analysis if it already
+    exists as an analysis in the report.
+    """
     contents = _get_summary_dict()
     if 'analyses' not in contents:
         contents['analyses'] = dict()
@@ -60,7 +68,10 @@ def add_analysis_json_str_as_dict_to_report(
     analysis_name: str,
     json_str: str
 ) -> None:
-    """Converts a json string to a dictionary and add it to the report"""
+    """Converts a json string to a dictionary and add it to the report.
+
+    Will overwrite the existing key/value pair for the analysis if it already
+    exists as an analysis in the report."""
     add_analysis_dict_to_json_report(analysis_name, json.loads(json_str))
 
 
@@ -69,7 +80,11 @@ def add_fuzzer_key_value_to_report(
     key: str,
     value: Any
 ) -> None:
-    """Add the key/value pair to the json report under the fuzzer key"""
+    """Add the key/value pair to the json report under the fuzzer key.
+
+    Will overwrite the existing key/value pair under the fuzzer if it already
+    exists in the report.
+    """
     contents = _get_summary_dict()
 
     if fuzzer_name not in contents:

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -27,24 +27,20 @@ from fuzz_introspector import constants
 logger = logging.getLogger(name=__name__)
 
 
-def add_dict_to_json_report(dict_to_add: Dict[Any, Any]) -> None:
-    """Adds the contents of a dictionary to the contents the json report.
-    This is an expensive operation in that it will load the json report
-    to merge the contents.
-    """
-    logger.info("Adding contents to summary")
+def _get_summary_dict() -> Dict[Any, Any]:
     if not os.path.isfile(constants.SUMMARY_FILE):
         existing_contents = dict()
     else:
         with open(constants.SUMMARY_FILE, "r") as report_fd:
             existing_contents = json.load(report_fd)
 
-    # Update the contents
-    existing_contents.update(dict_to_add)
+    return existing_contents
 
+
+def _overwrite_report_with_dict(new_dict: Dict[Any, Any]) -> None:
     # Write back the json file
     with open(constants.SUMMARY_FILE, 'w') as report_fd:
-        json.dump(existing_contents, report_fd)
+        json.dump(dict(new_dict), report_fd)
 
 
 def add_analysis_dict_to_json_report(
@@ -52,8 +48,32 @@ def add_analysis_dict_to_json_report(
     dict_to_add: Dict[Any, Any]
 ) -> None:
     """Wraps dictionary into an appropriate format"""
-    add_dict_to_json_report({'analyses': {analysis_name: dict_to_add}})
+    contents = _get_summary_dict()
+    if 'analyses' not in contents:
+        contents['analyses'] = dict()
+    contents['analyses'][analysis_name] = dict_to_add
+
+    _overwrite_report_with_dict(contents)
 
 
-def add_analysis_json_str_as_dict_to_report(analysis_name: str, json_str: str) -> None:
+def add_analysis_json_str_as_dict_to_report(
+    analysis_name: str,
+    json_str: str
+) -> None:
+    """Converts a json string to a dictionary and add it to the report"""
     add_analysis_dict_to_json_report(analysis_name, json.loads(json_str))
+
+
+def add_fuzzer_key_value_to_report(
+    fuzzer_name: str,
+    key: str,
+    value: Any
+) -> None:
+    """Add the key/value pair to the json report under the fuzzer key"""
+    contents = _get_summary_dict()
+
+    if fuzzer_name not in contents:
+        contents[fuzzer_name] = dict()
+    contents[fuzzer_name][key] = value
+
+    _overwrite_report_with_dict(contents)

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -226,27 +226,6 @@ def approximate_python_coverage_files(src1: str, src2: str) -> bool:
         return False
 
 
-def write_to_summary_file(fuzzer: str, key: str, value: Any) -> None:
-    """Writes a key value pair to summary file, for a given fuzzer
-    key. If the fuzzer does not exist as top key in the summary file
-    then it is created"""
-
-    if not os.path.isfile(constants.SUMMARY_FILE):
-        json_data = dict()
-    else:
-        json_fd = open(constants.SUMMARY_FILE)
-        json_data = json.load(json_fd)
-        json_fd.close()
-
-    if fuzzer not in json_data:
-        json_data[fuzzer] = dict()
-
-    json_data[fuzzer][key] = value
-
-    with open(constants.SUMMARY_FILE, 'w') as json_file:
-        json.dump(json_data, json_file)
-
-
 def get_target_coverage_url(
     coverage_url: str,
     target_name: str,


### PR DESCRIPTION
Remove the use of write_to_summary in the utils.py module, and make more convenient wrapper functions in json_report.py. This also overcomes some existing limitations where we basically overwrote various key/value pairs in the report.

Signed-off-by: David Korczynski <david@adalogics.com>