### PR TITLE
fix bug in json report creation

### DIFF
--- a/src/fuzz_introspector/constants.py
+++ b/src/fuzz_introspector/constants.py
@@ -24,8 +24,7 @@ APP_EXIT_ERROR = 1
 APP_EXIT_SUCCESS = 0
 
 INPUT_BUG_FILE = "input_bugs.json"
-
-JSON_REPORT_FILE = "fuzz-introspector.json"
+JSON_REPORT_KEY_PROJECT = 'MergedProjectProfile'
 
 # Color constants used for call trees. Composed of tuples,
 # (min, max, color) where

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -267,14 +267,13 @@ class MergedProjectProfile:
          reached_complexity_percentage,
          unreached_complexity_percentage) = self.get_complexity_summaries()
 
-        json_report.add_fuzzer_key_value_to_report(
-            "MergedProjectProfile",
+        json_report.add_project_key_value_to_report(
             "stats",
             {
                 "total-complexity": total_complexity,
                 "complexity-reached": complexity_reached,
                 "complexity-unreached": complexity_unreached,
-                "reached-complexity-percentage": complexity_unreached,
+                "reached-complexity-percentage": reached_complexity_percentage,
                 "unreached-complexity-percentage": unreached_complexity_percentage
             }
         )

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -87,8 +87,28 @@ def add_fuzzer_key_value_to_report(
     """
     contents = _get_summary_dict()
 
+    # Update the report accordingly
     if fuzzer_name not in contents:
         contents[fuzzer_name] = dict()
     contents[fuzzer_name][key] = value
+
+    _overwrite_report_with_dict(contents)
+
+
+def add_project_key_value_to_report(
+    key: str,
+    value: Any
+) -> None:
+    """Add the key/value pair to the json report under the project key.
+
+    Will overwrite the existing key/value pair if the key already exists in
+    the report.
+    """
+    contents = _get_summary_dict()
+
+    # Update the report accordingly
+    if constants.JSON_REPORT_KEY_PROJECT not in contents:
+        contents[constants.JSON_REPORT_KEY_PROJECT] = dict()
+    contents[constants.JSON_REPORT_KEY_PROJECT][key] = value
 
     _overwrite_report_with_dict(contents)


### PR DESCRIPTION
When dumping a project profile to json "reached-complexity-percentage" is set to be `complexity_unreached` whereas it shold be `reached_complexity_percentage`. Also adds some utility and helper functions.

Signed-off-by: David Korczynski <david@adalogics.com>