### PR TITLE
frontends: python: handle import error when using importlib

### DIFF
--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -123,6 +123,8 @@ class FuzzerVisitor(ast.NodeVisitor):
                 specs = importlib.util.find_spec(_import)
             except ModuleNotFoundError:
                 continue
+            except ImportError:
+                continue
             if specs is not None:
                 print("Spec:")
                 print(specs)


### PR DESCRIPTION
This handles issues observed on OSS-Fuzz, e.g.
```
Step #6 - "compile-libfuzzer-introspector-x86_64": Traceback (most recent call last):
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 170, in <module>
Step #6 - "compile-libfuzzer-introspector-x86_64":     fuzz_packages = get_package_paths(filename)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 159, in get_package_paths
Step #6 - "compile-libfuzzer-introspector-x86_64":     fuzz_visitor.print_specifics()
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 123, in print_specifics
Step #6 - "compile-libfuzzer-introspector-x86_64":     specs = importlib.util.find_spec(_import)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/importlib/util.py", line 94, in find_spec
Step #6 - "compile-libfuzzer-introspector-x86_64":     parent = __import__(parent_name, fromlist=['__path__'])
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/site-packages/h5py/__init__.py", line 25, in <module>
Step #6 - "compile-libfuzzer-introspector-x86_64":     from . import _errors
Step #6 - "compile-libfuzzer-introspector-x86_64": ImportError: /usr/local/lib/python3.8/site-packages/h5py/_errors.cpython-38-x86_64-linux-gnu.so: undefined symbol: __sancov_lowest_stack
Step #6 - "compile-libfuzzer-introspector-x86_64": ********************************************************************************
```

Signed-off-by: DavidKorczynski <david@adalogics.com>