### PR TITLE
fix the out-of-date patch for `checkout_build_install_llvm.sh`

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -25,19 +25,6 @@ index 6cc06bee..1e4a2496 100644
  RUN /root/checkout_build_install_llvm.sh
  RUN rm /root/checkout_build_install_llvm.sh
  
-diff --git a/infra/base-images/base-clang/checkout_build_install_llvm.sh b/infra/base-images/base-clang/checkout_build_install_llvm.sh
-index 2b403cfd..65f0ea55 100755
---- a/infra/base-images/base-clang/checkout_build_install_llvm.sh
-+++ b/infra/base-images/base-clang/checkout_build_install_llvm.sh
-@@ -129,7 +129,7 @@ cp -rf /fuzz-introspector/frontends/llvm/lib/Transforms/FuzzIntrospector ./llvm/
- 
- # LLVM currently does not support dynamically loading LTO passes. Thus, we
- # hardcode it into Clang instead. Ref: https://reviews.llvm.org/D77704
--/fuzz-introspector/sed_cmds.sh
-+/fuzz-introspector/frontends/llvm/patch-llvm.sh
- cd $OLD_WORKING_DIR
- 
- mkdir -p $WORK/llvm-stage2 $WORK/llvm-stage1
 diff --git a/infra/base-images/base-runner/Dockerfile b/infra/base-images/base-runner/Dockerfile
 index bc034e19..929e3499 100755
 --- a/infra/base-images/base-runner/Dockerfile


### PR DESCRIPTION
I deleted the out-of-date part in the `oss-fuzz-patches.diff`.

### Detail
Following the first bash pieces of the [doc](https://fuzz-introspector.readthedocs.io/en/latest/user-guides/comparing-introspector-reports.html), the execution will fail at `./build_post_processing.sh` due to the out-of-date patch file. The root cause is that `ossfuzz/infra/base-images/base-clang/checkout_build_install_llvm.sh` has already updated the code in its [latest commit](https://github.com/google/oss-fuzz/blob/461d60ccc2e4d5cf0428616cdee284ed6e616fe4/infra/base-images/base-clang/checkout_build_install_llvm.sh#L132).

After deletion, the workflow in the doc works.

```bash
# error log
$ ./build_post_processing.sh
+ '[' -d oss-fuzz ']'
+ echo 'Cloning oss-fuzz'
Cloning oss-fuzz
+ git clone https://github.com/google/oss-fuzz
Cloning into 'oss-fuzz'...
remote: Enumerating objects: 60142, done.
remote: Counting objects: 100% (121/121), done.
remote: Compressing objects: 100% (74/74), done.
remote: Total 60142 (delta 70), reused 84 (delta 47), pack-reused 60021
Receiving objects: 100% (60142/60142), 39.77 MiB | 17.67 MiB/s, done.
Resolving deltas: 100% (41157/41157), done.
+ echo 'Applying diffs'
Applying diffs
+ cd oss-fuzz
+ git apply --ignore-space-change --ignore-whitespace ../oss-fuzz-patches.diff
error: patch failed: infra/base-images/base-clang/checkout_build_install_llvm.sh:129
error: infra/base-images/base-clang/checkout_build_install_llvm.sh: patch does not apply

```