### PR TITLE
JVM Implementation: Fix soot logic to include callsite for all processed methods

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -45,8 +45,8 @@ import soot.SootClass;
 import soot.SootMethod;
 import soot.Transform;
 import soot.Unit;
-import soot.jimple.Stmt;
 import soot.jimple.InvokeExpr;
+import soot.jimple.Stmt;
 import soot.jimple.internal.JIfStmt;
 import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.jimple.toolkits.callgraph.Edge;
@@ -306,7 +306,7 @@ class CustomSenceTransformer extends SceneTransformer {
               }
               if (unit instanceof JIfStmt) {
                 element.addBranchProfile(
-                  handleIfStatement(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
+                    handleIfStatement(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
               }
             }
             iCount++;
@@ -646,17 +646,16 @@ class CustomSenceTransformer extends SceneTransformer {
 
     return mergedClassName.toString();
   }
-  
+
   /**
-    * The method retrieve the invocation body of a statement if existed.
-	* Then it determine the information of the method invoked and store
-	* them in the result to record the callsite information of the invoked 
-	* method in its parent method.
-    *
-    * @param  stmt           the statement to handle
-    * @param  sourceFilePath the file path for the parent method
-    * @return                the callsite object to store in the output yaml file
-    */
+   * The method retrieve the invocation body of a statement if existed. Then it determine the
+   * information of the method invoked and store them in the result to record the callsite
+   * information of the invoked method in its parent method.
+   *
+   * @param stmt the statement to handle
+   * @param sourceFilePath the file path for the parent method
+   * @return the callsite object to store in the output yaml file
+   */
   private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath) {
     // Handle statements of a method
     if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
@@ -669,43 +668,43 @@ class CustomSenceTransformer extends SceneTransformer {
         return callsite;
       }
     }
-    
+
     return null;
   }
-  
+
   private BranchProfile handleIfStatement(
       List<Block> blocks, Unit unit, String cname, Map<String, Integer> functionLineMap) {
     // Handle if branch
     BranchProfile branchProfile = new BranchProfile();
-    
+
     Integer trueBlockLineNumber = unit.getJavaSourceStartLineNumber() + 1;
-    Integer falseBlockLineNumber = 
-      ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
-    
-    Map<String, Integer> trueBlockLine = 
-      getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
+    Integer falseBlockLineNumber =
+        ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
+
+    Map<String, Integer> trueBlockLine =
+        getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
     Map<String, Integer> falseBlockLine =
-      getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
+        getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
 
     // True branch
     if (!trueBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-        processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
+          processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
     }
 
     // False branch
     if (!falseBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-        processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
+          processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
     }
-    
+
     branchProfile.setBranchString(cname + ":" + unit.getJavaSourceStartLineNumber());
-    
+
     return branchProfile;
   }
-  
+
   private BranchSide processBranch(
       Map<String, Integer> blockLine, String cname, Map<String, Integer> functionLineMap) {
     BranchSide branchSide = new BranchSide();

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -45,8 +45,8 @@ import soot.SootClass;
 import soot.SootMethod;
 import soot.Transform;
 import soot.Unit;
-import soot.jimple.Stmt;
 import soot.jimple.InvokeExpr;
+import soot.jimple.Stmt;
 import soot.jimple.internal.JIfStmt;
 import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.jimple.toolkits.callgraph.Edge;
@@ -306,7 +306,7 @@ class CustomSenceTransformer extends SceneTransformer {
               }
               if (unit instanceof JIfStmt) {
                 element.addBranchProfile(
-                  handleIfStatement(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
+                    handleIfStatement(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
               }
             }
             iCount++;
@@ -646,7 +646,7 @@ class CustomSenceTransformer extends SceneTransformer {
 
     return mergedClassName.toString();
   }
-  
+
   private Callsite handleStatement(Stmt stmt, String sourceFilePath) {
     // Handle statements of a method
     if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
@@ -659,43 +659,43 @@ class CustomSenceTransformer extends SceneTransformer {
         return callsite;
       }
     }
-    
+
     return null;
   }
-  
+
   private BranchProfile handleIfStatement(
       List<Block> blocks, Unit unit, String cname, Map<String, Integer> functionLineMap) {
     // Handle if branch
     BranchProfile branchProfile = new BranchProfile();
-    
+
     Integer trueBlockLineNumber = unit.getJavaSourceStartLineNumber() + 1;
-    Integer falseBlockLineNumber = 
-      ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
-    
-    Map<String, Integer> trueBlockLine = 
-      getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
+    Integer falseBlockLineNumber =
+        ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
+
+    Map<String, Integer> trueBlockLine =
+        getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
     Map<String, Integer> falseBlockLine =
-      getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
+        getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
 
     // True branch
     if (!trueBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-        processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
+          processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
     }
 
     // False branch
     if (!falseBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-        processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
+          processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
     }
-    
+
     branchProfile.setBranchString(cname + ":" + unit.getJavaSourceStartLineNumber());
-    
+
     return branchProfile;
   }
-  
+
   private BranchSide processBranch(
       Map<String, Integer> blockLine, String cname, Map<String, Integer> functionLineMap) {
     BranchSide branchSide = new BranchSide();

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -45,8 +45,8 @@ import soot.SootClass;
 import soot.SootMethod;
 import soot.Transform;
 import soot.Unit;
-import soot.jimple.InvokeExpr;
 import soot.jimple.Stmt;
+import soot.jimple.InvokeExpr;
 import soot.jimple.internal.JIfStmt;
 import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.jimple.toolkits.callgraph.Edge;
@@ -300,13 +300,13 @@ class CustomSenceTransformer extends SceneTransformer {
             // Looping statement from all blocks from this specific method.
             Unit unit = blockIt.next();
             if (unit instanceof Stmt) {
-              Callsite callsite = handleStatement((Stmt) unit, c.getFilePath());
+              Callsite callsite = handleMethodInvocationInStatement((Stmt) unit, c.getFilePath());
               if (callsite != null) {
                 element.addCallsite(callsite);
               }
               if (unit instanceof JIfStmt) {
                 element.addBranchProfile(
-                    handleIfStatement(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
+                  handleIfStatement(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
               }
             }
             iCount++;
@@ -646,8 +646,18 @@ class CustomSenceTransformer extends SceneTransformer {
 
     return mergedClassName.toString();
   }
-
-  private Callsite handleStatement(Stmt stmt, String sourceFilePath) {
+  
+  /**
+    * The method retrieve the invocation body of a statement if existed.
+	* Then it determine the information of the method invoked and store
+	* them in the result to record the callsite information of the invoked 
+	* method in its parent method.
+    *
+    * @param  stmt           the statement to handle
+    * @param  sourceFilePath the file path for the parent method
+    * @return                the callsite object to store in the output yaml file
+    */
+  private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath) {
     // Handle statements of a method
     if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
       InvokeExpr expr = stmt.getInvokeExpr();
@@ -659,43 +669,43 @@ class CustomSenceTransformer extends SceneTransformer {
         return callsite;
       }
     }
-
+    
     return null;
   }
-
+  
   private BranchProfile handleIfStatement(
       List<Block> blocks, Unit unit, String cname, Map<String, Integer> functionLineMap) {
     // Handle if branch
     BranchProfile branchProfile = new BranchProfile();
-
+    
     Integer trueBlockLineNumber = unit.getJavaSourceStartLineNumber() + 1;
-    Integer falseBlockLineNumber =
-        ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
-
-    Map<String, Integer> trueBlockLine =
-        getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
+    Integer falseBlockLineNumber = 
+      ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
+    
+    Map<String, Integer> trueBlockLine = 
+      getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
     Map<String, Integer> falseBlockLine =
-        getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
+      getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
 
     // True branch
     if (!trueBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-          processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
+        processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
     }
 
     // False branch
     if (!falseBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-          processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
+        processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
     }
-
+    
     branchProfile.setBranchString(cname + ":" + unit.getJavaSourceStartLineNumber());
-
+    
     return branchProfile;
   }
-
+  
   private BranchSide processBranch(
       Map<String, Integer> blockLine, String cname, Map<String, Integer> functionLineMap) {
     BranchSide branchSide = new BranchSide();

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -298,7 +298,7 @@ class CustomSenceTransformer extends SceneTransformer {
             Unit unit = blockIt.next();
             if (unit instanceof JIfStmt) {
               element.addBranchProfile(
-                handleIfBranch(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
+                  handleIfBranch(blockGraph.getBlocks(), unit, c.getName(), functionLineMap));
             }
             iCount++;
           }
@@ -637,40 +637,40 @@ class CustomSenceTransformer extends SceneTransformer {
 
     return mergedClassName.toString();
   }
-  
+
   private BranchProfile handleIfBranch(
       List<Block> blocks, Unit unit, String cname, Map<String, Integer> functionLineMap) {
     // Handle if branch
     BranchProfile branchProfile = new BranchProfile();
-    
+
     Integer trueBlockLineNumber = unit.getJavaSourceStartLineNumber() + 1;
-    Integer falseBlockLineNumber = 
-      ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
-    
-    Map<String, Integer> trueBlockLine = 
-      getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
+    Integer falseBlockLineNumber =
+        ((JIfStmt) unit).getUnitBoxes().get(0).getUnit().getJavaSourceStartLineNumber();
+
+    Map<String, Integer> trueBlockLine =
+        getBlockStartEndLineWithLineNumber(blocks, trueBlockLineNumber);
     Map<String, Integer> falseBlockLine =
-      getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
+        getBlockStartEndLineWithLineNumber(blocks, falseBlockLineNumber);
 
     // True branch
     if (!trueBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-        processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
+          processBranch(trueBlockLine, cname + ":" + start, functionLineMap));
     }
 
     // False branch
     if (!falseBlockLine.isEmpty()) {
       Integer start = falseBlockLine.get("start");
       branchProfile.addBranchSides(
-        processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
+          processBranch(falseBlockLine, cname + ":" + (start - 1), functionLineMap));
     }
-    
+
     branchProfile.setBranchString(cname + ":" + unit.getJavaSourceStartLineNumber());
-    
+
     return branchProfile;
   }
-  
+
   private BranchSide processBranch(
       Map<String, Integer> blockLine, String cname, Map<String, Integer> functionLineMap) {
     BranchSide branchSide = new BranchSide();

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/Callsite.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/Callsite.java
@@ -16,8 +16,6 @@
 package ossf.fuzz.introspector.soot.yaml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Callsite {
   private String source;

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/Callsite.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/Callsite.java
@@ -1,0 +1,43 @@
+// Copyright 2022 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package ossf.fuzz.introspector.soot.yaml;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Callsite {
+  private String source;
+  private String methodName;
+
+  @JsonProperty("Src")
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  @JsonProperty("Dst")
+  public String getMethodName() {
+    return methodName;
+  }
+
+  public void setMethodName(String methodName) {
+    this.methodName = methodName;
+  }
+}

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
@@ -37,6 +37,7 @@ public class FunctionElement {
   private List<String> functionsReached;
   private Integer functionUses;
   private List<BranchProfile> branchProfiles;
+  private List<Callsite> callsites;
 
   public FunctionElement() {
     this.argTypes = new ArrayList<String>();
@@ -44,6 +45,7 @@ public class FunctionElement {
     this.argNames = new ArrayList<String>();
     this.functionsReached = new ArrayList<String>();
     this.branchProfiles = new ArrayList<BranchProfile>();
+    this.callsites = new ArrayList<Callsite>();
   }
 
   public String getFunctionName() {
@@ -205,5 +207,18 @@ public class FunctionElement {
 
   public void setBranchProfiles(List<BranchProfile> branchProfiles) {
     this.branchProfiles = branchProfiles;
+  }
+
+  @JsonProperty("Callsites")
+  public List<Callsite> getCallsites() {
+    return callsites;
+  }
+
+  public void addCallsite(Callsite callsite) {
+    this.callsites.add(callsite);
+  }
+
+  public void setCallsites(List<Callsite> callsites) {
+    this.callsites = callsites;
   }
 }


### PR DESCRIPTION
Fix soot logic to loop through all statement in processed methods to record its method invocation. This can help to provide callsite information and line number of every methods that has a parent function (with source code provided).

Signed-off-by: Arthur Chan <arthur.chan@adalogics.com>