### PR TITLE
html_report: catch recursion errors when beautifying html

### DIFF
--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -1120,7 +1120,10 @@ def create_html_report(
 
     # Pretty print the html document
     soup = bs4.BeautifulSoup(html_full_doc, "html.parser")
-    prettyHTML = soup.prettify()
+    try:
+        prettyHTML = soup.prettify()
+    except RecursionError:
+        prettyHTML = html_full_doc
 
     # Remove existing html report
     report_name = "fuzz_report.html"


### PR DESCRIPTION
Prettifying is cosmetical, and not a necessity.

The prettify function may throw a recursion error, so catch these and progress anyways. This caused the boost build to fail.

Signed-off-by: David Korczynski <david@adalogics.com>