### PR TITLE
JVM Integration: Fix maven missing bug

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -39,7 +39,7 @@ def is_jvm_frontend_built():
 
 def build_jvm_frontend():
   if not is_jvm_frontend_built():
-    subprocess.check_call(f"{target_mvn} clean package -Dmaven.test.skip", shell=True)
+    subprocess.check_call(f"apt install maven -y && {target_mvn} clean package -Dmaven.test.skip", shell=True)
 
   if not is_jvm_frontend_built():
     return False


### PR DESCRIPTION
Some JVM project is built with gradle and thus its docker file does not have maven installed. This make the frontend java code failed to compile with maven. Fix the oss-fuzz-main.py script to install maven before compiling the frontend code for java.