### PR TITLE
project-profile: add accessor for all functions

### DIFF
--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -86,7 +86,8 @@ class FunctionProfile:
 
     @property
     def has_source_file(self) -> bool:
-        return self.function_source_file == ''
+        return (self.function_source_file != ''
+                and len(self.function_source_file.strip()) > 0)
 
     def load_func_branch_profiles(
             self, yaml_branch_profiles: Any

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -86,8 +86,7 @@ class FunctionProfile:
 
     @property
     def has_source_file(self) -> bool:
-        return (self.function_source_file != ''
-                and len(self.function_source_file.strip()) > 0)
+        return len(self.function_source_file.strip()) > 0
 
     def load_func_branch_profiles(
             self, yaml_branch_profiles: Any

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -84,6 +84,10 @@ class FunctionProfile:
         self.new_unreached_complexity: int = 0
         self.total_cyclomatic_complexity: int = 0
 
+    @property
+    def has_source_file(self) -> bool:
+        return self.function_source_file == ''
+
     def load_func_branch_profiles(
             self, yaml_branch_profiles: Any
     ) -> Dict[str, branch_profile.BranchProfile]:

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -373,16 +373,16 @@ class MergedProjectProfile:
         """
         return self.all_functions
 
-
-    def get_all_functions_with_source(self) -> Dict[str, function_profile.FunctionProfile]:
+    def get_all_functions_with_source(
+            self) -> Dict[str, function_profile.FunctionProfile]:
         """Returns all functions where there was a source code location
         attached, which roughly corresponds to functions declared in the
         project or third parties where source code was pulled in.
         """
         all_functions = self.get_all_functions()
 
-        local_functions_with_source: Dict[str,
-                                 function_profile.FunctionProfile] = dict()
+        local_functions_with_source: Dict[
+            str, function_profile.FunctionProfile] = dict()
 
         for func_name in all_functions:
             func_profile = self.all_functions[func_name]

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -340,14 +340,14 @@ class MergedProjectProfile:
 
     def _get_total_unreached_function_count(self) -> int:
         unreached_function_count = 0
-        for fd in self.all_functions.values():
+        for fd in self.get_all_functions_with_source().values():
             if fd.hitcount == 0:
                 unreached_function_count += 1
         return unreached_function_count
 
     def _get_total_reached_function_count(self) -> int:
         reached_function_count = 0
-        for fd in self.all_functions.values():
+        for fd in self.get_all_functions_with_source().values():
             if fd.hitcount != 0:
                 reached_function_count += 1
         return reached_function_count
@@ -355,9 +355,37 @@ class MergedProjectProfile:
     def _get_total_complexity(self) -> Tuple[int, int]:
         reached_complexity = 0
         unreached_complexity = 0
-        for fd in self.all_functions.values():
+        for fd in self.get_all_functions_with_source().values():
             if fd.hitcount == 0:
                 unreached_complexity += fd.cyclomatic_complexity
             else:
                 reached_complexity += fd.cyclomatic_complexity
         return reached_complexity, unreached_complexity
+
+    def get_all_functions(self) -> Dict[str, function_profile.FunctionProfile]:
+        """Returns all function profiles of this project. This includes both
+        functions of the module where file paths are available, and, also
+        functions of external dependencies that are just destinations of
+        callsites, namely where there was no source code to inspect.
+
+        Use only this for accessing/inspecting/operating on the functions, and
+        not the internal all_functions dictionary.
+        """
+        return self.all_functions
+
+
+    def get_all_functions_with_source(self) -> Dict[str, function_profile.FunctionProfile]:
+        """Returns all functions where there was a source code location
+        attached, which roughly corresponds to functions declared in the
+        project or third parties where source code was pulled in.
+        """
+        all_functions = self.get_all_functions()
+
+        local_functions_with_source: Dict[str,
+                                 function_profile.FunctionProfile] = dict()
+
+        for func_name in all_functions:
+            func_profile = self.all_functions[func_name]
+            if not func_profile.has_source_file:
+                local_functions_with_source[func_name] = func_profile
+        return local_functions_with_source

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -386,6 +386,6 @@ class MergedProjectProfile:
 
         for func_name in all_functions:
             func_profile = self.all_functions[func_name]
-            if not func_profile.has_source_file:
+            if func_profile.has_source_file:
                 local_functions_with_source[func_name] = func_profile
         return local_functions_with_source

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -217,7 +217,7 @@ def create_all_function_table(
     table_rows_json_html = []
     table_rows_json_report = []
 
-    for fd_k, fd in proj_profile.all_functions.items():
+    for fd_k, fd in proj_profile.get_all_functions_with_source().items():
         demangled_func_name = utils.demangle_cpp_func(fd.function_name)
         try:
             func_total_lines, hit_lines = proj_profile.runtime_coverage.get_hit_summary(


### PR DESCRIPTION
Add accessor function for working on the function dictionary, and also a wrapper function that filters external functions. This wrapper is then used to capture most of the statistic data displayed.

Ref: https://github.com/ossf/fuzz-introspector/issues/819

Signed-off-by: David Korczynski <david@adalogics.com>