### PR TITLE
project_profile: refine calculation of project-wide coverage stats

### DIFF
--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -161,8 +161,14 @@ class MergedProjectProfile:
         :returns: List of strings corresponding to function names
         """
         all_covered_functions = []
-        for funcname in self.runtime_coverage.covmap:
-            all_covered_functions.append(funcname)
+        for funcname in self.get_all_functions_with_source():
+            is_covered = False
+            coverage_data = self.runtime_coverage.get_hit_details(funcname)
+            if len(coverage_data) > 0:
+                is_covered = True
+            if is_covered:
+                all_covered_functions.append(funcname)
+
         return all_covered_functions
 
     def get_function_summaries(self) -> Tuple[int, int, int, float, float]:


### PR DESCRIPTION
Only include function names identified in the frontend static analysis when calculating project-wide coverage. This is because coverage reports and static analysis may provide some different information about the program if sanitizers/static analysis is not done consistently. This is e.g. an example in libfido2
https://github.com/ossf/fuzz-introspector/issues/812 where the coverage report includes a lot of functions from third-party libraries but these libraries are not being included in the fuzz introspector static analysis. We should guard against those situations and for now we will make the static analysis the decising component.

Signed-off-by: David Korczynski <david@adalogics.com>