### PR TITLE
Java Integration: Add constructorto yaml file

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -182,7 +182,7 @@ class CustomSenceTransformer extends SceneTransformer {
     }
 
     // Required for auto-fuzz
-    // excludeMethodList.add("<init>");
+    excludeMethodList.add("<init>");
     excludeMethodList.add("<clinit>");
     excludeMethodList.add("finalize");
 
@@ -254,6 +254,7 @@ class CustomSenceTransformer extends SceneTransformer {
       } else {
         System.out.println("[Callgraph] [SKIP] class: " + cname);
       }
+      this.includeConstructor(c);
     }
     System.out.println("[Callgraph] Finished going through classes");
 
@@ -424,6 +425,41 @@ class CustomSenceTransformer extends SceneTransformer {
       System.err.println(e);
     }
     System.out.println("Finish processing for fuzzer: " + this.entryClassStr);
+  }
+
+  // Include empty profile for class constructor for reference
+  private void includeConstructor(SootClass sootClass) {
+    List<SootMethod> mList = new LinkedList<SootMethod>(sootClass.getMethods());
+    for (SootMethod method : mList) {
+      if (method.getName().equals("<init>")) {
+        FunctionElement element = new FunctionElement();
+        String name = "[" + sootClass.getName() + "]." + method.getSubSignature().split(" ")[1];
+        element.setFunctionName(name);
+        element.setFunctionSourceFile(sootClass.getName());
+        element.setFunctionLinenumber(method.getJavaSourceStartLineNumber());
+        element.setReturnType("");
+        element.setFunctionDepth(0);
+        element.setArgCount(method.getParameterCount());
+        for (soot.Type type : method.getParameterTypes()) {
+          element.addArgType(type.toString());
+        }
+        element.setFunctionUses(0);
+        element.setEdgeCount(0);
+        element.setBBCount(0);
+        element.setiCount(0);
+        element.setCyclomaticComplexity(0);
+
+        JavaMethodInfo methodInfo = new JavaMethodInfo();
+        methodInfo.setIsConcrete(method.isConcrete());
+        methodInfo.setIsPublic(method.isPublic());
+        for (SootClass exception : method.getExceptions()) {
+          methodInfo.addException(exception.getFilePath());
+        }
+        element.setJavaMethodInfo(methodInfo);
+
+        methodList.addFunctionElement(element);
+      }
+    }
   }
 
   // Include empty profile for touched sink methods

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -181,7 +181,8 @@ class CustomSenceTransformer extends SceneTransformer {
       }
     }
 
-    excludeMethodList.add("<init>");
+    // Required for auto-fuzz
+    // excludeMethodList.add("<init>");
     excludeMethodList.add("<clinit>");
     excludeMethodList.add("finalize");
 

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -485,7 +485,7 @@ class FuzzerProfile:
                 )
 
             if self.target_lang == "jvm" and "<init>" in elem['functionName']:
-                logger.debug(f"Skipping <init> method for JVM")
+                logger.debug("Skipping <init> method for JVM")
                 continue
 
             func_profile = function_profile.FunctionProfile(elem)

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -484,6 +484,10 @@ class FuzzerProfile:
                     f"May have non-normalised function: {elem['functionName']}"
                 )
 
+            if self.target_lang == "jvm" and "<init>" in elem['functionName']:
+                logger.debug(f"Skipping <init> method for JVM")
+                continue
+
             func_profile = function_profile.FunctionProfile(elem)
             logger.debug(f"Adding {func_profile.function_name}")
             self.all_class_functions[func_profile.function_name] = func_profile


### PR DESCRIPTION
In the current logic, the constructors and destructors of all java classes has been ignored by the JVM frontend. This PR includes empty profile for all constructors (including constructor for library classes or excluded classes) into the yaml file in order to give referencing information for further analysis of object method which requires creating contructor for object initialisation. Only limited information like argument list or exceptions thrown by contructors will be included. Also, constructor will not be handled in the call tree generation process to avoid flooding the result.