### PR TITLE
JVM integration: Add class info for constructor

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -452,9 +452,18 @@ class CustomSenceTransformer extends SceneTransformer {
         JavaMethodInfo methodInfo = new JavaMethodInfo();
         methodInfo.setIsConcrete(method.isConcrete());
         methodInfo.setIsPublic(method.isPublic());
+        methodInfo.setIsClassConcrete(sootClass.isConcrete());
+        if (sootClass.hasSuperclass()) {
+          methodInfo.setSuperClass(sootClass.getSuperclass().getName());
+        }
         for (SootClass exception : method.getExceptions()) {
           methodInfo.addException(exception.getFilePath());
         }
+        Iterator<SootClass> interfaces = sootClass.getInterfaces().snapshotIterator();
+        while (interfaces.hasNext()) {
+          methodInfo.addInterface(interfaces.next().getName());
+        }
+
         element.setJavaMethodInfo(methodInfo);
 
         methodList.addFunctionElement(element);

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
@@ -20,18 +20,24 @@ import java.util.List;
 
 public class JavaMethodInfo {
   private List<String> exceptions;
+  private List<String> interfaces;
+  private String superClass;
   private Integer methodStatus;
   private Boolean isConcrete;
   private Boolean isJavaLibraryMethod;
   private Boolean isPublic;
   private Boolean isStatic;
+  private Boolean isClassConcrete;
 
   public JavaMethodInfo() {
     this.exceptions = new ArrayList<String>();
+    this.interfaces = new ArrayList<String>();
+    this.superClass = "";
     this.isConcrete = true;
     this.isJavaLibraryMethod = false;
     this.isPublic = true;
     this.isStatic = false;
+    this.isClassConcrete = true;
   }
 
   public List<String> getExceptions() {
@@ -44,6 +50,26 @@ public class JavaMethodInfo {
 
   public void setExceptions(List<String> exceptions) {
     this.exceptions = exceptions;
+  }
+
+  public String getSuperClass() {
+    return this.superClass;
+  }
+
+  public void setSuperClass(String superClass) {
+    this.superClass = superClass;
+  }
+
+  public List<String> getInterfaces() {
+    return this.interfaces;
+  }
+
+  public void addInterface(String interfaceName) {
+    this.interfaces.add(interfaceName);
+  }
+
+  public void setInterfaces(List<String> interfaces) {
+    this.interfaces = interfaces;
   }
 
   public Boolean isConcrete() {
@@ -76,5 +102,13 @@ public class JavaMethodInfo {
 
   public void setIsStatic(Boolean isStatic) {
     this.isStatic = isStatic;
+  }
+
+  public Boolean isClassConcrete() {
+    return this.isClassConcrete;
+  }
+
+  public void setIsClassConcrete(Boolean isClassConcrete) {
+    this.isClassConcrete = isClassConcrete;
   }
 }


### PR DESCRIPTION
In order to accommodate object creation, we need to know if the class itself is abstract or not or if it is an interface, and possible super class and implemented interface. The major usage of these information is to look for concrete subclasses for constructor calling because abstract class or interface are not able to construct. This PR add the superclass, implemented interface information for the class of the method to the data.yaml file. Also, an additional boolean value are added showing if that class is concrete or not, that is if that class's constructor can be called directly.