### PR TITLE
auto-fuzz: fix up java integration

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -105,10 +105,11 @@ WORKDIR $SRC/%s
 
 def gen_dockerfile_jvm(github_url, project_name):
     DOCKER_STEPS = """FROM gcr.io/oss-fuzz-base/base-builder-jvm
-RUN curl -L https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
-unzip maven.zip -d $SRC/maven && rm -rf maven.zip
+#RUN curl -L https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
+COPY maven.zip $SRC/maven.zip
+RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
-RUN git clone --depth 1 %s %s
+#RUN git clone --depth 1 %s %s
 COPY %s %s
 COPY *.sh *.java $SRC/
 WORKDIR $SRC/%s

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -65,7 +65,9 @@ class FuzzTarget:
                 if "/*IMPORTS*/" in line:
                     # Insert Java class import statement
                     content += "".join(self.imports_to_add)
+                    content += "\n// "
                     content += ",".join(self.heuristics_used)
+                    content += "\n"
                 elif "/*CODE*/" in line:
                     # Insert Fuzzer main code logic and replace variables
                     code = self.fuzzer_source_code.replace(

--- a/tools/auto-fuzz/post_process.py
+++ b/tools/auto-fuzz/post_process.py
@@ -105,11 +105,18 @@ def _print_summary_of_trial_run(trial_run,
         proj_name = proj_name + " " * (50 - len(proj_name))
     if len(trial_name) < 21:
         trial_name = trial_name + " " * (21 - len(trial_name))
+    python_fuzz_path = os.path.join(autofuzz_project_dir, trial_run['name'],
+                                    "fuzz_1.py")
+    jvm_fuzz_path = os.path.join(autofuzz_project_dir, trial_run['name'],
+                                 "Fuzz1.java")
+    fuzz_path = ""
+    if os.path.isfile(python_fuzz_path):
+        fuzz_path = python_fuzz_path
+    elif os.path.isfile(jvm_fuzz_path):
+        fuzz_path = jvm_fuzz_path
     print("%s :: %15s ::  %21s :: %5s :: %s :: %s" %
           (proj_name, autofuzz_project_dir, trial_name,
-           str(trial_run['max_cov']),
-           os.path.join(autofuzz_project_dir, trial_run['name'],
-                        "fuzz_1.py"), trial_run['heuristics-used']))
+           str(trial_run['max_cov']), fuzz_path, trial_run['heuristics-used']))
 
 
 def get_top_trial_run(trial_runs):


### PR DESCRIPTION
- Fix bug in template, where the heuristics added to the code was not commented out.
- Only download maven once to save network bandwidth, then copy it over in each Dockerfile.
- Don't clone the repository in the Dockerfile as we copy it over instead.
- Make it possible to specify which language to test.
- Make the post processing able to give correct paths to java fuzzers.