### PR TITLE
Auto-fuzz: Add heuristic 2 for jvm

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -122,7 +122,7 @@ def _handle_import(func_elem):
     return list(import_set)
 
 
-def _handle_argument(argType, init_dict, possible_target):
+def _handle_argument(argType, init_dict, possible_target, recursion_count):
     """Generate data creation statement for given argument type"""
     if argType == "int" or argType == "java.lang.Integer":
         return "data.consumeInt(0,100)"
@@ -151,7 +151,7 @@ def _handle_argument(argType, init_dict, possible_target):
     elif argType == "java.lang.String":
         return "data.consumeString(100)"
     else:
-        return _handle_object_creation(argType, init_dict, possible_target)
+        return _handle_object_creation(argType, init_dict, possible_target, recursion_count)
 
 
 def _search_concrete_subclass(classname, init_dict):
@@ -176,14 +176,15 @@ def _search_concrete_subclass(classname, init_dict):
     return None
 
 
-def _handle_object_creation(classname, init_dict, possible_target):
+def _handle_object_creation(classname, init_dict, possible_target, recursion_count):
     """
     Generate statement for Java object creation of the target class.
     If constructor (<init>) does existed in the yaml file, we will
     use it as reference, otherwise the default empty constructor
     are used.
     """
-    if init_dict and classname in init_dict.keys():
+    recursion_count += 1
+    if init_dict and classname in init_dict.keys() and recursion_count <= 10:
         # Process arguments for constructor
         try:
             arg_list = []
@@ -197,7 +198,7 @@ def _handle_object_creation(classname, init_dict, possible_target):
             classname = func_elem['functionSourceFile']
             for argType in func_elem['argTypes']:
                 arg_list.append(
-                    _handle_argument(argType, init_dict, possible_target))
+                    _handle_argument(argType, init_dict, possible_target, recursion_count))
             possible_target.exceptions_to_handle.update(
                 func_elem['JavaMethodInfo']['exceptions'])
             possible_target.imports_to_add.update(_handle_import(func_elem))
@@ -216,8 +217,8 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         - public class method which are not abstract or found in JDK library
         - have between 0-20 arguments
         - do not have "test" in the function name
-    The fuzz target is simply one that calls into the target function with
-    a string seeded with fuzz data.
+    The fuzz target is simply one that calls into the target class function with
+    suitable primitive fuzz data or simple concrete public constructor
 
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
@@ -243,6 +244,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         possible_target = FuzzTarget()
 
         # Store target method name
+        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
         func_name = func_elem['functionName'].split('].')[1].split('(')[0]
         possible_target.function_target = func_name
 
@@ -260,7 +262,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         # Store function parameter list
         for argType in func_elem['argTypes']:
             possible_target.variables_to_add.append(
-                _handle_argument(argType, None, possible_target))
+                _handle_argument(argType, None, possible_target, 0))
 
         # Create the actual source
         fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -268,6 +270,89 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
                                                           func_name)
         if len(possible_target.exceptions_to_handle) > 0:
             fuzzer_source_code += "  try {\n" + fuzzer_source_code
+            fuzzer_source_code += "  }\n"
+            counter = 1
+            for exc in possible_target.exceptions_to_handle:
+                fuzzer_source_code += "  catch (%s e%d) {}\n" % (exc, counter)
+                counter += 1
+        possible_target.fuzzer_source_code = fuzzer_source_code
+        possible_target.heuristics_used.append(HEURISTIC_NAME)
+
+        possible_targets.append(possible_target)
+
+
+def _generate_heuristic_2(yaml_dict, possible_targets):
+    """Heuristic 2.
+    Creates a FuzzTarget for each method that satisfy all:
+        - public object method which are not abstract or found in JDK library
+        - have between 0-20 arguments
+        - do not have "test" in the function name
+    The fuzz target is simply one that calls into the target function with
+    a string seeded with fuzz data. It will create the object with the class
+    constructor before calling the function. Primitive type will be passed
+    with the seeded fuzz data.
+
+    Will also add proper exception handling based on the exception list
+    provided by the frontend code.
+    """
+    HEURISTIC_NAME="jvm-autofuzz-heuristics-2"
+    # Retrieve <init> method definition for all classes
+    init_dict = {}
+    method_list = []
+    for func_elem in yaml_dict['All functions']['Elements']:
+        if "<init>" in func_elem['functionName']:
+            init_dict[func_elem['functionSourceFile']] = func_elem
+        else:
+            method_list.append(func_elem)
+    print(len(method_list))
+    for func_elem in method_list:
+        print(func_elem['functionName'])
+        java_method_info = func_elem['JavaMethodInfo']
+
+        # Skip method which doese not match this heuristic
+        if java_method_info['static']:
+            continue
+        if not java_method_info['public']:
+            continue
+        if not java_method_info['concrete']:
+            continue
+        if java_method_info['javaLibraryMethod']:
+            continue
+        if len(func_elem['argTypes']) > 20:
+            continue
+        if "test" in func_elem['functionName']:
+            continue
+
+        possible_target = FuzzTarget()
+
+        # Store target method name
+        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
+        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
+        possible_target.function_target = func_name
+
+        # Store function class
+        func_class = func_elem['functionSourceFile'].replace('$', '.')
+        possible_target.function_class = func_class
+
+        # Store exceptions thrown by the target method
+        possible_target.exceptions_to_handle.update(java_method_info['exceptions'])
+
+        # Store java import statement
+        possible_target.imports_to_add.update(_handle_import(func_elem))
+
+        # Store function parameter list
+        for argType in func_elem['argTypes']:
+            possible_target.variables_to_add.append(_handle_argument(argType, init_dict, possible_target, 0))
+
+        # Create the actual source
+        fuzzer_source_code = "  // Heuristic name: %s\n"%(HEURISTIC_NAME)
+        fuzzer_source_code += "  %s obj = %s;\n" % (
+            func_class,
+            _handle_object_creation(func_class, init_dict, possible_target, 0)
+        )
+        fuzzer_source_code += "  obj.%s($VARIABLE$);\n" % (func_name)
+        if len(possible_target.exceptions_to_handle) > 0:
+            fuzzer_source_code = "  try {\n" + fuzzer_source_code
             fuzzer_source_code += "  }\n"
             counter = 1
             for exc in possible_target.exceptions_to_handle:
@@ -290,5 +375,6 @@ def generate_possible_targets(proj_folder):
 
     possible_targets = []
     _generate_heuristic_1(yaml_dict, possible_targets)
+    _generate_heuristic_2(yaml_dict, possible_targets)
 
     return possible_targets

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -151,7 +151,8 @@ def _handle_argument(argType, init_dict, possible_target, recursion_count):
     elif argType == "java.lang.String":
         return "data.consumeString(100)"
     else:
-        return _handle_object_creation(argType, init_dict, possible_target, recursion_count)
+        return _handle_object_creation(argType, init_dict, possible_target,
+                                       recursion_count)
 
 
 def _search_concrete_subclass(classname, init_dict):
@@ -176,7 +177,8 @@ def _search_concrete_subclass(classname, init_dict):
     return None
 
 
-def _handle_object_creation(classname, init_dict, possible_target, recursion_count):
+def _handle_object_creation(classname, init_dict, possible_target,
+                            recursion_count):
     """
     Generate statement for Java object creation of the target class.
     If constructor (<init>) does existed in the yaml file, we will
@@ -198,7 +200,8 @@ def _handle_object_creation(classname, init_dict, possible_target, recursion_cou
             classname = func_elem['functionSourceFile']
             for argType in func_elem['argTypes']:
                 arg_list.append(
-                    _handle_argument(argType, init_dict, possible_target, recursion_count))
+                    _handle_argument(argType, init_dict, possible_target,
+                                     recursion_count))
             possible_target.exceptions_to_handle.update(
                 func_elem['JavaMethodInfo']['exceptions'])
             possible_target.imports_to_add.update(_handle_import(func_elem))
@@ -295,7 +298,7 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME="jvm-autofuzz-heuristics-2"
+    HEURISTIC_NAME = "jvm-autofuzz-heuristics-2"
     # Retrieve <init> method definition for all classes
     init_dict = {}
     method_list = []
@@ -335,21 +338,22 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
         possible_target.function_class = func_class
 
         # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(java_method_info['exceptions'])
+        possible_target.exceptions_to_handle.update(
+            java_method_info['exceptions'])
 
         # Store java import statement
         possible_target.imports_to_add.update(_handle_import(func_elem))
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            possible_target.variables_to_add.append(_handle_argument(argType, init_dict, possible_target, 0))
+            possible_target.variables_to_add.append(
+                _handle_argument(argType, init_dict, possible_target, 0))
 
         # Create the actual source
-        fuzzer_source_code = "  // Heuristic name: %s\n"%(HEURISTIC_NAME)
+        fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
         fuzzer_source_code += "  %s obj = %s;\n" % (
             func_class,
-            _handle_object_creation(func_class, init_dict, possible_target, 0)
-        )
+            _handle_object_creation(func_class, init_dict, possible_target, 0))
         fuzzer_source_code += "  obj.%s($VARIABLE$);\n" % (func_name)
         if len(possible_target.exceptions_to_handle) > 0:
             fuzzer_source_code = "  try {\n" + fuzzer_source_code

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -588,6 +588,6 @@ if __name__ == "__main__":
         elif sys.argv[1] == 'java':
             run_on_projects("jvm")
         else:
-            print("Please give a language of either {python, jvm}")
+            print("Please give a language of either {python, java}")
     else:
         run_on_projects("python")


### PR DESCRIPTION
Add heuristic 2 for jvm auto fuzzer generator, also limit the maximum recursion for concrete subclass discovery to 10 to avoid infinity loop from cross constructor referencing.