### PR TITLE
Auto-Fuzz: Fix concrete subclass searching logic

### DIFF
--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 MAX_FUZZERS_PER_PROJECT = 10
+MAX_TARGET_PER_PROJECT = 100
 MAX_THREADS = 4
 
 git_repos = {

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MAX_FUZZERS_PER_PROJECT = 10
-MAX_TARGET_PER_PROJECT = 100
+MAX_TARGET_PER_PROJECT_HEURISTIC = 100
 MAX_THREADS = 4
 
 git_repos = {

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -14,6 +14,7 @@
 
 import os
 import yaml
+import itertools
 
 from typing import List, Set, Any
 
@@ -27,14 +28,23 @@ class FuzzTarget:
     imports_to_add: Set[str]
     heuristics_used: List[str]
 
-    def __init__(self):
-        self.function_target = ""
-        self.function_class = ""
-        self.exceptions_to_handle = set()
-        self.fuzzer_source_code = ""
-        self.variables_to_add = []
-        self.imports_to_add = set()
-        self.heuristics_used = []
+    def __init__(self, orig=None):
+        if orig:
+            self.function_target = orig.function_target
+            self.function_class = orig.function_class
+            self.exceptions_to_handle = orig.exceptions_to_handle
+            self.fuzzer_source_code = orig.fuzzer_source_code
+            self.variables_to_add = orig.variables_to_add
+            self.imports_to_add = orig.imports_to_add
+            self.heuristics_used = orig.heuristics_used
+        else:
+            self.function_target = ""
+            self.function_class = ""
+            self.exceptions_to_handle = set()
+            self.fuzzer_source_code = ""
+            self.variables_to_add = []
+            self.imports_to_add = set()
+            self.heuristics_used = []
 
     def __dict__(self):
         return {"function": self.function_target}
@@ -125,36 +135,36 @@ def _handle_import(func_elem):
 def _handle_argument(argType, init_dict, possible_target, recursion_count):
     """Generate data creation statement for given argument type"""
     if argType == "int" or argType == "java.lang.Integer":
-        return "data.consumeInt(0,100)"
+        return ["data.consumeInt(0,100)"]
     elif argType == "int[]" or argType == "java.lang.Integer[]":
-        return "data.consumeInts(100)"
+        return ["data.consumeInts(100)"]
     elif argType == "boolean" or argType == "java.lang.Boolean":
-        return "data.consumeBoolean()"
+        return ["data.consumeBoolean()"]
     elif argType == "boolean[]" or argType == "java.lang.Boolean[]":
-        return "data.consumeBooleans(100)"
+        return ["data.consumeBooleans(100)"]
     elif argType == "byte" or argType == "java.lang.Byte":
-        return "data.consumeByte()"
+        return ["data.consumeByte()"]
     elif argType == "byte[]" or argType == "java.lang.Byte[]":
-        return "data.consumeBytes(100)"
+        return ["data.consumeBytes(100)"]
     elif argType == "short" or argType == "java.lang.Short":
-        return "data.consumeShort()"
+        return ["data.consumeShort()"]
     elif argType == "short[]" or argType == "java.lang.Short[]":
-        return "data.consumeShorts(100)"
+        return ["data.consumeShorts(100)"]
     elif argType == "long" or argType == "java.lang.Long":
-        return "data.consumeLong()"
+        return ["data.consumeLong()"]
     elif argType == "long[]" or argType == "java.lang.Long[]":
-        return "data.consumeLongs(100)"
+        return ["data.consumeLongs(100)"]
     elif argType == "float" or argType == "java.lang.Float":
-        return "data.consumeFloat()"
+        return ["data.consumeFloat()"]
     elif argType == "char" or argType == "java.lang.Character":
-        return "data.consumeCharacter()"
+        return ["data.consumeCharacter()"]
     elif argType == "java.lang.String":
-        return "data.consumeString(100)"
+        return ["data.consumeString(100)"]
     else:
         return _handle_object_creation(argType, init_dict, possible_target, recursion_count)
 
 
-def _search_concrete_subclass(classname, init_dict):
+def _search_concrete_subclass(classname, init_dict, result_list = []):
     """Search concrete subclass for the target classname"""
     for key in init_dict:
         func_elem = init_dict[key]
@@ -166,14 +176,15 @@ def _search_concrete_subclass(classname, init_dict):
             continue
 
         if java_info['classConcrete'] and java_info['public']:
-            return func_elem
+            if func_elem not in result_list:
+                result_list.append(func_elem)
         else:
-            result = _search_concrete_subclass(func_elem['functionSourceFile'],
-                                               init_dict)
-            if result:
-                return result
+            for result in _search_concrete_subclass(func_elem['functionSourceFile'],
+                                                    init_dict):
+                if result not in result_list:
+                    result_list.append(result)
 
-    return None
+    return result_list
 
 
 def _handle_object_creation(classname, init_dict, possible_target, recursion_count):
@@ -184,34 +195,45 @@ def _handle_object_creation(classname, init_dict, possible_target, recursion_cou
     are used.
     """
     recursion_count += 1
-    if init_dict and classname in init_dict.keys() and recursion_count <= 10:
+    if init_dict and classname in init_dict.keys() and recursion_count <= 5:
         # Process arguments for constructor
         try:
             arg_list = []
+            class_list = []
             func_elem = init_dict[classname]
 
-            if not func_elem['JavaMethodInfo']['classConcrete']:
-                func_elem = _search_concrete_subclass(classname, init_dict)
-            if not func_elem:
+            if func_elem['JavaMethodInfo']['classConcrete']:
+                class_list.append(func_elem)
+            else:
+                class_list.extend(_search_concrete_subclass(classname, init_dict))
+            if len(class_list) == 0:
                 return "new " + classname.replace("$", ".") + "()"
 
-            classname = func_elem['functionSourceFile']
-            for argType in func_elem['argTypes']:
-                arg_list.append(
-                    _handle_argument(argType, init_dict, possible_target, recursion_count))
-            possible_target.exceptions_to_handle.update(
-                func_elem['JavaMethodInfo']['exceptions'])
-            possible_target.imports_to_add.update(_handle_import(func_elem))
-            return "new " + classname.replace(
-                "$", ".") + "(" + ",".join(arg_list) + ")"
+            result_list = []
+            handled = []
+            for elem in class_list:
+                if elem in handled:
+                    continue
+                handled.append(elem)
+                classname = elem['functionSourceFile']
+                for argType in elem['argTypes']:
+                    arg_list.append(
+                        _handle_argument(argType, init_dict, possible_target, recursion_count))
+                possible_target.exceptions_to_handle.update(
+                    elem['JavaMethodInfo']['exceptions'])
+                possible_target.imports_to_add.update(_handle_import(func_elem))
+                for args_item in list(itertools.product(*arg_list)):
+                    result_list.append("new " + classname.replace(
+                        "$", ".") + "(" + ",".join(args_item) + ")")
+            return result_list
         except RecursionError:
             # Fail to create constructor code with parameters, using default constructor
-            return "new " + classname.replace("$", ".") + "()"
+            return ["new " + classname.replace("$", ".") + "()"]
     else:
-        return "new " + classname.replace("$", ".") + "()"
+        return ["new " + classname.replace("$", ".") + "()"]
 
 
-def _generate_heuristic_1(yaml_dict, possible_targets):
+def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
     """Heuristic 1.
     Creates a FuzzTarget for each method that satisfy all:
         - public class method which are not abstract or found in JDK library
@@ -225,6 +247,9 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-1"
     for func_elem in yaml_dict['All functions']['Elements']:
+        if len(possible_targets) > max_target:
+            return
+
         java_method_info = func_elem['JavaMethodInfo']
 
         # Skip method which doese not match this heuristic
@@ -262,7 +287,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         # Store function parameter list
         for argType in func_elem['argTypes']:
             possible_target.variables_to_add.append(
-                _handle_argument(argType, None, possible_target, 0))
+                _handle_argument(argType, None, possible_target, 0)[0])
 
         # Create the actual source
         fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -281,7 +306,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         possible_targets.append(possible_target)
 
 
-def _generate_heuristic_2(yaml_dict, possible_targets):
+def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
     """Heuristic 2.
     Creates a FuzzTarget for each method that satisfy all:
         - public object method which are not abstract or found in JDK library
@@ -304,9 +329,11 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
             init_dict[func_elem['functionSourceFile']] = func_elem
         else:
             method_list.append(func_elem)
-    print(len(method_list))
+
     for func_elem in method_list:
-        print(func_elem['functionName'])
+        if len(possible_targets) > max_target:
+            return
+
         java_method_info = func_elem['JavaMethodInfo']
 
         # Skip method which doese not match this heuristic
@@ -340,31 +367,36 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
         # Store java import statement
         possible_target.imports_to_add.update(_handle_import(func_elem))
 
-        # Store function parameter list
+        # Get all possible argument lists with different possible object creation combination
         for argType in func_elem['argTypes']:
-            possible_target.variables_to_add.append(_handle_argument(argType, init_dict, possible_target, 0))
+             possible_target.variables_to_add.append(_handle_argument(argType, init_dict, possible_target, 0)[0])
 
-        # Create the actual source
-        fuzzer_source_code = "  // Heuristic name: %s\n"%(HEURISTIC_NAME)
-        fuzzer_source_code += "  %s obj = %s;\n" % (
-            func_class,
-            _handle_object_creation(func_class, init_dict, possible_target, 0)
-        )
-        fuzzer_source_code += "  obj.%s($VARIABLE$);\n" % (func_name)
-        if len(possible_target.exceptions_to_handle) > 0:
-            fuzzer_source_code = "  try {\n" + fuzzer_source_code
-            fuzzer_source_code += "  }\n"
-            counter = 1
-            for exc in possible_target.exceptions_to_handle:
-                fuzzer_source_code += "  catch (%s e%d) {}\n" % (exc, counter)
-                counter += 1
-        possible_target.fuzzer_source_code = fuzzer_source_code
-        possible_target.heuristics_used.append(HEURISTIC_NAME)
+        # Get all object creation statement for each possible concrete classes of the object
+        object_creation_list = _handle_object_creation(func_class, init_dict, possible_target, 0)
 
-        possible_targets.append(possible_target)
+        for object_creation_item in object_creation_list:
+            # Create possible target for all possible object creation statement
+            # Clone the base target object
+            cloned_possible_target = FuzzTarget(possible_target)
+
+            # Create the actual source
+            fuzzer_source_code = "  // Heuristic name: %s\n"%(HEURISTIC_NAME)
+            fuzzer_source_code += "  %s obj = %s;\n" % (func_class, object_creation_item)
+            fuzzer_source_code += "  obj.%s($VARIABLE$);\n" % (func_name)
+            if len(cloned_possible_target.exceptions_to_handle) > 0:
+                fuzzer_source_code = "  try {\n" + fuzzer_source_code
+                fuzzer_source_code += "  }\n"
+                counter = 1
+                for exc in cloned_possible_target.exceptions_to_handle:
+                    fuzzer_source_code += "  catch (%s e%d) {}\n" % (exc, counter)
+                    counter += 1
+            cloned_possible_target.fuzzer_source_code = fuzzer_source_code
+            cloned_possible_target.heuristics_used.append(HEURISTIC_NAME)
+
+            possible_targets.append(cloned_possible_target)
 
 
-def generate_possible_targets(proj_folder):
+def generate_possible_targets(proj_folder, max_target):
     """Generate all possible targets for a given project folder"""
 
     # Read the Fuzz Introspector generated data
@@ -374,7 +406,7 @@ def generate_possible_targets(proj_folder):
         yaml_dict = yaml.safe_load(stream)
 
     possible_targets = []
-    _generate_heuristic_1(yaml_dict, possible_targets)
-    _generate_heuristic_2(yaml_dict, possible_targets)
+    _generate_heuristic_1(yaml_dict, possible_targets, max_target)
+#    _generate_heuristic_2(yaml_dict, possible_targets, max_target)
 
     return possible_targets

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -122,7 +122,7 @@ def _handle_import(func_elem):
     return list(import_set)
 
 
-def _handle_argument(argType, init_dict, possible_target):
+def _handle_argument(argType, init_dict, possible_target, recursion_count):
     """Generate data creation statement for given argument type"""
     if argType == "int" or argType == "java.lang.Integer":
         return "data.consumeInt(0,100)"
@@ -151,7 +151,7 @@ def _handle_argument(argType, init_dict, possible_target):
     elif argType == "java.lang.String":
         return "data.consumeString(100)"
     else:
-        return _handle_object_creation(argType, init_dict, possible_target)
+        return _handle_object_creation(argType, init_dict, possible_target, recursion_count)
 
 
 def _search_concrete_subclass(classname, init_dict):
@@ -176,14 +176,15 @@ def _search_concrete_subclass(classname, init_dict):
     return None
 
 
-def _handle_object_creation(classname, init_dict, possible_target):
+def _handle_object_creation(classname, init_dict, possible_target, recursion_count):
     """
     Generate statement for Java object creation of the target class.
     If constructor (<init>) does existed in the yaml file, we will
     use it as reference, otherwise the default empty constructor
     are used.
     """
-    if init_dict and classname in init_dict.keys():
+    recursion_count += 1
+    if init_dict and classname in init_dict.keys() and recursion_count <= 10:
         # Process arguments for constructor
         try:
             arg_list = []
@@ -197,7 +198,7 @@ def _handle_object_creation(classname, init_dict, possible_target):
             classname = func_elem['functionSourceFile']
             for argType in func_elem['argTypes']:
                 arg_list.append(
-                    _handle_argument(argType, init_dict, possible_target))
+                    _handle_argument(argType, init_dict, possible_target, recursion_count))
             possible_target.exceptions_to_handle.update(
                 func_elem['JavaMethodInfo']['exceptions'])
             possible_target.imports_to_add.update(_handle_import(func_elem))
@@ -216,8 +217,8 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         - public class method which are not abstract or found in JDK library
         - have between 0-20 arguments
         - do not have "test" in the function name
-    The fuzz target is simply one that calls into the target function with
-    a string seeded with fuzz data.
+    The fuzz target is simply one that calls into the target class function with
+    suitable primitive fuzz data or simple concrete public constructor
 
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
@@ -243,6 +244,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         possible_target = FuzzTarget()
 
         # Store target method name
+        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
         func_name = func_elem['functionName'].split('].')[1].split('(')[0]
         possible_target.function_target = func_name
 
@@ -260,7 +262,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
         # Store function parameter list
         for argType in func_elem['argTypes']:
             possible_target.variables_to_add.append(
-                _handle_argument(argType, None, possible_target))
+                _handle_argument(argType, None, possible_target, 0))
 
         # Create the actual source
         fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -268,6 +270,89 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
                                                           func_name)
         if len(possible_target.exceptions_to_handle) > 0:
             fuzzer_source_code += "  try {\n" + fuzzer_source_code
+            fuzzer_source_code += "  }\n"
+            counter = 1
+            for exc in possible_target.exceptions_to_handle:
+                fuzzer_source_code += "  catch (%s e%d) {}\n" % (exc, counter)
+                counter += 1
+        possible_target.fuzzer_source_code = fuzzer_source_code
+        possible_target.heuristics_used.append(HEURISTIC_NAME)
+
+        possible_targets.append(possible_target)
+
+
+def _generate_heuristic_2(yaml_dict, possible_targets):
+    """Heuristic 2.
+    Creates a FuzzTarget for each method that satisfy all:
+        - public object method which are not abstract or found in JDK library
+        - have between 0-20 arguments
+        - do not have "test" in the function name
+    The fuzz target is simply one that calls into the target function with
+    a string seeded with fuzz data. It will create the object with the class
+    constructor before calling the function. Primitive type will be passed
+    with the seeded fuzz data.
+
+    Will also add proper exception handling based on the exception list
+    provided by the frontend code.
+    """
+    HEURISTIC_NAME="jvm-autofuzz-heuristics-2"
+    # Retrieve <init> method definition for all classes
+    init_dict = {}
+    method_list = []
+    for func_elem in yaml_dict['All functions']['Elements']:
+        if "<init>" in func_elem['functionName']:
+            init_dict[func_elem['functionSourceFile']] = func_elem
+        else:
+            method_list.append(func_elem)
+    print(len(method_list))
+    for func_elem in method_list:
+        print(func_elem['functionName'])
+        java_method_info = func_elem['JavaMethodInfo']
+
+        # Skip method which doese not match this heuristic
+        if java_method_info['static']:
+            continue
+        if not java_method_info['public']:
+            continue
+        if not java_method_info['concrete']:
+            continue
+        if java_method_info['javaLibraryMethod']:
+            continue
+        if len(func_elem['argTypes']) > 20:
+            continue
+        if "test" in func_elem['functionName']:
+            continue
+
+        possible_target = FuzzTarget()
+
+        # Store target method name
+        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
+        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
+        possible_target.function_target = func_name
+
+        # Store function class
+        func_class = func_elem['functionSourceFile'].replace('$', '.')
+        possible_target.function_class = func_class
+
+        # Store exceptions thrown by the target method
+        possible_target.exceptions_to_handle.update(java_method_info['exceptions'])
+
+        # Store java import statement
+        possible_target.imports_to_add.update(_handle_import(func_elem))
+
+        # Store function parameter list
+        for argType in func_elem['argTypes']:
+            possible_target.variables_to_add.append(_handle_argument(argType, init_dict, possible_target, 0))
+
+        # Create the actual source
+        fuzzer_source_code = "  // Heuristic name: %s\n"%(HEURISTIC_NAME)
+        fuzzer_source_code += "  %s obj = %s;\n" % (
+            func_class,
+            _handle_object_creation(func_class, init_dict, possible_target, 0)
+        )
+        fuzzer_source_code += "  obj.%s($VARIABLE$);\n" % (func_name)
+        if len(possible_target.exceptions_to_handle) > 0:
+            fuzzer_source_code = "  try {\n" + fuzzer_source_code
             fuzzer_source_code += "  }\n"
             counter = 1
             for exc in possible_target.exceptions_to_handle:
@@ -290,5 +375,6 @@ def generate_possible_targets(proj_folder):
 
     possible_targets = []
     _generate_heuristic_1(yaml_dict, possible_targets)
+    _generate_heuristic_2(yaml_dict, possible_targets)
 
     return possible_targets

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -588,6 +588,6 @@ if __name__ == "__main__":
         elif sys.argv[1] == 'java':
             run_on_projects("jvm")
         else:
-            print("Please give a language of either {python, jvm}")
+            print("Please give a language of either {python, java}")
     else:
         run_on_projects("python")

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -555,7 +555,8 @@ def autofuzz_project_from_github(github_url,
                 oss_fuzz_base_project.project_folder)
         elif language == "jvm":
             possible_targets = fuzz_driver_generation_jvm.generate_possible_targets(
-                oss_fuzz_base_project.project_folder, constants.MAX_TARGET_PER_PROJECT)
+                oss_fuzz_base_project.project_folder,
+                constants.MAX_TARGET_PER_PROJECT_HEURISTIC)
 
     print("Generated %d possible targets for %s." %
           (len(possible_targets), github_url))

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -555,7 +555,7 @@ def autofuzz_project_from_github(github_url,
                 oss_fuzz_base_project.project_folder)
         elif language == "jvm":
             possible_targets = fuzz_driver_generation_jvm.generate_possible_targets(
-                oss_fuzz_base_project.project_folder)
+                oss_fuzz_base_project.project_folder, constants.MAX_TARGET_PER_PROJECT)
 
     print("Generated %d possible targets for %s." %
           (len(possible_targets), github_url))


### PR DESCRIPTION
For Java program, it is possible to specify a abstract superclass or interface as the argument type and all object of its subclass or class implemnting that interface are all valid object for that argument type. There is possibility that there are more than one possible options for the concrete object, this PR aims to generate object creation statement for each of the possibility in order to cover more fuzzer choice and targets. This PR also adds in a new constant for limiting the number of target generated for each project to increase efficiency.