### PR TITLE
html-report: move code into html_helpers

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -34,8 +34,6 @@ from fuzz_introspector.datatypes import project_profile, fuzzer_profile
 # For pretty printing the html code:
 from bs4 import BeautifulSoup as bs
 
-from fuzz_introspector.html_report import create_collapsible_element
-
 logger = logging.getLogger(name=__name__)
 
 
@@ -453,7 +451,7 @@ class FuzzCalltreeAnalysis(analysis.AnalysisInterface):
             collapsible_id = entry.source_file + entry.blocked_side_line_numder + random_suffix
             func_num = len(entry.blocked_unique_funcs)
             if func_num > 0:
-                collapsible_string = create_collapsible_element(
+                collapsible_string = html_helpers.create_collapsible_element(
                     str(func_num), entry.blocked_unique_funcs, collapsible_id)
             else:
                 collapsible_string = "None"

--- a/src/fuzz_introspector/analyses/optimal_targets.py
+++ b/src/fuzz_introspector/analyses/optimal_targets.py
@@ -260,6 +260,26 @@ class OptimalTargets(analysis.AnalysisInterface):
         html_string += ("</table>\n")
         return html_string
 
+    def create_top_summary_info(
+            self, tables: List[str],
+            proj_profile: project_profile.MergedProjectProfile) -> str:
+        html_string = ""
+
+        # Display reachability information
+        html_string += "<div style=\"display: flex; max-width: 50%\">"
+
+        html_string += html_helpers.create_percentage_graph(
+            "Functions statically reachable by fuzzers",
+            proj_profile.reached_func_count, proj_profile.total_functions)
+
+        html_string += html_helpers.create_percentage_graph(
+            "Cyclomatic complexity statically reachable by fuzzers",
+            proj_profile.reached_complexity, proj_profile.total_complexity)
+
+        html_string += "</div>"
+
+        return html_string
+
     def get_consequential_section(
             self, new_profile: project_profile.MergedProjectProfile,
             conclusions: List[html_helpers.HTMLConclusion], tables: List[str],
@@ -270,8 +290,7 @@ class OptimalTargets(analysis.AnalysisInterface):
             "<p>Implementing fuzzers that target the above functions "
             "will improve reachability such that it becomes:</p>")
         tables.append(f"myTable{len(tables)}")
-        html_string += html_report.create_top_summary_info(
-            tables, new_profile, conclusions, False)
+        html_string += self.create_top_summary_info(tables, new_profile)
 
         # Table with details about all functions in the project in case the
         # suggested fuzzers are implemented.

--- a/src/fuzz_introspector/html_helpers.py
+++ b/src/fuzz_introspector/html_helpers.py
@@ -278,6 +278,83 @@ def html_create_table_head(table_head: str,
     return html_str
 
 
+def get_simple_box(title: str, value: str) -> str:
+    """Wraps a title and value in a simle HTML div box, where the box has some
+    simple borders.
+    """
+
+    return f"""<div class="report-box"
+                    style="flex: 1; display: flex; flex-direction: column;">
+        <div style="font-size: 0.9rem;">
+          {title}
+        </div>
+        <div style="font-size: 1.2rem; font-weight: 550;">
+          {value}
+        </div>
+      </div>"""
+
+
+def create_collapsible_element(non_collapsed: str, collapsed: str,
+                               collapsible_id: str) -> str:
+    """Creates a string followed by a <div> that is collapsible. We use this
+    for displaying items in tables where the full substance of the item is
+    too large to display by default for all items, but we still want the user
+    to be able to see the full substance of the item on demand.
+    """
+    return f"""{ non_collapsed } : <div
+    class='wrap-collabsible'>
+        <input id='{collapsible_id}'
+               class='toggle'
+               type='checkbox'>
+            <label for='{collapsible_id}'
+                   class='lbl-toggle'>
+                View List
+            </label>
+        <div class='collapsible-content'>
+            <div class='content-inner'>
+                <p>
+                    {collapsed}
+                </p>
+            </div>
+        </div>
+    </div>"""
+
+
+def create_percentage_graph(title: str, numerator: int,
+                            denominator: int) -> str:
+    """Creates a percentage tag within a <div> tag. This is used to show
+    "how much X is of Y" for a {numerator, denominator} pair.
+    """
+    percentage = round(float(numerator) / float(denominator), 2) * 100.0
+    subtitle = f"{numerator} / {denominator}"
+    return f"""<div style="flex:1; margin-right: 20px"class="report-box mt-0">
+            <div style="font-weight: 600; text-align: center;">
+                {title}
+            </div>
+            <div class="flex-wrapper">
+              <div class="single-chart">
+                <svg viewBox="0 0 36 36" class="circular-chart green">
+                  <path class="circle-bg"
+                    d="M18 2.0845
+                      a 15.9155 15.9155 0 0 1 0 31.831
+                      a 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
+                  <path class="circle"
+                    stroke-dasharray="{percentage}, 100"
+                    d="M18 2.0845
+                      a 15.9155 15.9155 0 0 1 0 31.831
+                      a 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
+                  <text x="18" y="20.35" class="percentage">{str(percentage)[:4]}%</text>
+                </svg>
+              </div>
+            </div>
+            <div style="font-size: .9rem; color: #b5b5b5; text-align: center">
+              {subtitle}
+            </div>
+        </div>"""
+
+
 def prettify_html(html_doc: str) -> str:
     """Prettify a HTML document."""
     soup = bs4.BeautifulSoup(html_doc, "html.parser")

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -242,15 +242,14 @@ def create_all_function_table(
         collapsible_id = demangled_func_name + random_suffix
 
         if fd.hitcount > 0:
-            reached_by_fuzzers_row = create_collapsible_element(
+            reached_by_fuzzers_row = html_helpers.create_collapsible_element(
                 str(fd.hitcount), str(fd.reached_by_fuzzers), collapsible_id)
         else:
             reached_by_fuzzers_row = "0"
 
         if fd.arg_count > 0:
-            args_row = create_collapsible_element(str(fd.arg_count),
-                                                  str(fd.arg_types),
-                                                  collapsible_id + "2")
+            args_row = html_helpers.create_collapsible_element(
+                str(fd.arg_count), str(fd.arg_types), collapsible_id + "2")
         else:
             args_row = "0"
 
@@ -289,60 +288,6 @@ def create_all_function_table(
     return html_string, table_rows_json_html, table_rows_json_report
 
 
-def create_collapsible_element(non_collapsed: str, collapsed: str,
-                               collapsible_id: str) -> str:
-    return f"""{ non_collapsed } : <div
-    class='wrap-collabsible'>
-        <input id='{collapsible_id}'
-               class='toggle'
-               type='checkbox'>
-            <label
-                for='{collapsible_id}'
-                class='lbl-toggle'>
-                    View List
-            </label>
-        <div class='collapsible-content'>
-            <div class='content-inner'>
-                <p>
-                    {collapsed}
-                </p>
-            </div>
-        </div>
-    </div>"""
-
-
-def create_percentage_graph(title: str, numerator: int,
-                            denominator: int) -> str:
-    percentage = round(float(numerator) / float(denominator), 2) * 100.0
-    subtitle = f"{numerator} / {denominator}"
-    return f"""<div style="flex:1; margin-right: 20px"class="report-box mt-0">
-            <div style="font-weight: 600; text-align: center;">
-                {title}
-            </div>
-            <div class="flex-wrapper">
-              <div class="single-chart">
-                <svg viewBox="0 0 36 36" class="circular-chart green">
-                  <path class="circle-bg"
-                    d="M18 2.0845
-                      a 15.9155 15.9155 0 0 1 0 31.831
-                      a 15.9155 15.9155 0 0 1 0 -31.831"
-                  />
-                  <path class="circle"
-                    stroke-dasharray="{percentage}, 100"
-                    d="M18 2.0845
-                      a 15.9155 15.9155 0 0 1 0 31.831
-                      a 15.9155 15.9155 0 0 1 0 -31.831"
-                  />
-                  <text x="18" y="20.35" class="percentage">{str(percentage)[:4]}%</text>
-                </svg>
-              </div>
-            </div>
-            <div style="font-size: .9rem; color: #b5b5b5; text-align: center">
-              {subtitle}
-            </div>
-        </div>"""
-
-
 def create_boxed_top_summary_info(
         tables: List[str],
         proj_profile: project_profile.MergedProjectProfile,
@@ -351,17 +296,17 @@ def create_boxed_top_summary_info(
         display_coverage: bool = False) -> str:
     html_string = ""
 
-    html_string += create_percentage_graph(
+    html_string += html_helpers.create_percentage_graph(
         "Functions statically reachable by fuzzers",
         proj_profile.reached_func_count, proj_profile.total_functions)
 
-    html_string += create_percentage_graph(
+    html_string += html_helpers.create_percentage_graph(
         "Cyclomatic complexity statically reachable by fuzzers",
         proj_profile.reached_complexity, proj_profile.total_complexity)
 
     if display_coverage:
         covered_funcs = proj_profile.get_all_runtime_covered_functions()
-        html_string += create_percentage_graph(
+        html_string += html_helpers.create_percentage_graph(
             "Runtime code coverage of functions", len(covered_funcs),
             proj_profile.total_functions)
 
@@ -401,11 +346,11 @@ def create_top_summary_info(tables: List[str],
     # Display reachability information
     html_string += "<div style=\"display: flex; max-width: 50%\">"
 
-    html_string += create_percentage_graph(
+    html_string += html_helpers.create_percentage_graph(
         "Functions statically reachable by fuzzers",
         proj_profile.reached_func_count, proj_profile.total_functions)
 
-    html_string += create_percentage_graph(
+    html_string += html_helpers.create_percentage_graph(
         "Cyclomatic complexity statically reachable by fuzzers",
         proj_profile.reached_complexity, proj_profile.total_complexity)
 
@@ -630,15 +575,17 @@ def create_fuzzer_detailed_section(
                      f"to continue exploring more code at run time. ")))
 
     html_string += "<div style=\"display: flex; margin-bottom: 10px;\">"
-    html_string += get_simple_box("Covered functions",
-                                  str(total_hit_functions))
-    html_string += get_simple_box(
+    html_string += html_helpers.get_simple_box("Covered functions",
+                                               str(total_hit_functions))
+    html_string += html_helpers.get_simple_box(
         "Functions that are reachable but not covered",
         str(uncovered_reachable_funcs))
 
-    html_string += get_simple_box("Reachable functions", str(reachable_funcs))
-    html_string += get_simple_box("Percentage of reachable functions covered",
-                                  "%s%%" % str(round(cov_reach_proportion, 2)))
+    html_string += html_helpers.get_simple_box("Reachable functions",
+                                               str(reachable_funcs))
+    html_string += html_helpers.get_simple_box(
+        "Percentage of reachable functions covered",
+        "%s%%" % str(round(cov_reach_proportion, 2)))
     html_string += "</div>"
     html_string += "<div style=\"font-size: 0.85rem; color: #adadad; margin-bottom: 40px\">"
     html_string += "<b>NB:</b> The sum of <i>covered functions</i> and <i>functions " \
@@ -680,17 +627,6 @@ def create_fuzzer_detailed_section(
             [k, len(profile.file_targets[k])])
     html_string += "</table>\n"
     return html_string
-
-
-def get_simple_box(title: str, value: str) -> str:
-    return f"""<div class="report-box" style="flex: 1; display: flex; flex-direction: column;">
-        <div style="font-size: 0.9rem;">
-          {title}
-        </div>
-        <div style="font-size: 1.2rem; font-weight: 550;">
-          {value}
-        </div>
-      </div>"""
 
 
 def extract_highlevel_guidance(

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -336,41 +336,6 @@ def create_conclusions(conclusions: List[html_helpers.HTMLConclusion],
                                     description=""))
 
 
-def create_top_summary_info(tables: List[str],
-                            proj_profile: project_profile.MergedProjectProfile,
-                            conclusions: List[html_helpers.HTMLConclusion],
-                            extract_conclusion: bool,
-                            display_coverage: bool = False) -> str:
-    html_string = ""
-
-    # Display reachability information
-    html_string += "<div style=\"display: flex; max-width: 50%\">"
-
-    html_string += html_helpers.create_percentage_graph(
-        "Functions statically reachable by fuzzers",
-        proj_profile.reached_func_count, proj_profile.total_functions)
-
-    html_string += html_helpers.create_percentage_graph(
-        "Cyclomatic complexity statically reachable by fuzzers",
-        proj_profile.reached_complexity, proj_profile.total_complexity)
-
-    html_string += "</div>"
-    if display_coverage:
-        logger.info("Displaying coverage in summary")
-        covered_funcs = proj_profile.get_all_runtime_covered_functions()
-        html_string += f"Functions covered at runtime: { len(covered_funcs) }"
-        html_string += "<br>"
-    else:
-        logger.info("Not displaying coverage in summary")
-
-    # Add conclusion
-    if extract_conclusion:
-        create_conclusions(conclusions, proj_profile.reached_func_percentage,
-                           proj_profile.reached_complexity_percentage)
-
-    return html_string
-
-
 def create_fuzzer_detailed_section(
         proj_profile: project_profile.MergedProjectProfile,
         profile: fuzzer_profile.FuzzerProfile,


### PR DESCRIPTION
Move functions from `html_report.py` into `html_helpers.py` to have better separation between the code that assembles the overall report and that which creates the HTML text itself.