### PR TITLE
Auto-fuzz: Add tqdm module to requirement for python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ configparser
 coverage
 atheris
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability 
+tqdm # For displaying loading bar (auto-fuzz tool)


### PR DESCRIPTION
The post processing of auto-fuzz uses the tqdm python module to display loading bar when the process check the auto generated fuzzer. This PR adds the tqdm module to the python dependency requirement list to enable it.