### PR TITLE
Auto-fuzz: Fix java autofuzz build fail

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -259,10 +259,6 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
             continue
         if func_elem['returnType'] != classname:
             continue
-        if not classname == "javassist.CtClass":
-            continue
-        if "makeClass" not in func_elem['functionName']:
-            continue
 
         func_name = func_elem['functionName'].split('(')[0].split('].')[1]
         func_class = func_elem['functionSourceFile']
@@ -430,6 +426,8 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
+        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
+            continue
 
         possible_target = FuzzTarget()
 
@@ -517,6 +515,8 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
         if len(func_elem['argTypes']) > 20:
             continue
         if "test" in func_elem['functionName']:
+            continue
+        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
             continue
 
         possible_target = FuzzTarget()
@@ -627,6 +627,8 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
+        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
+            continue
 
         possible_target = FuzzTarget()
 
@@ -732,7 +734,7 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
-        if "javassist.CtClass" not in func_elem['functionSourceFile']:
+        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
             continue
 
         possible_target = FuzzTarget()

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -426,7 +426,9 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
-        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
+        if "jazzer" in func_elem[
+                'functionName'] or "fuzzerTestOneInput" in func_elem[
+                    'functionName']:
             continue
 
         possible_target = FuzzTarget()
@@ -516,7 +518,9 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
-        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
+        if "jazzer" in func_elem[
+                'functionName'] or "fuzzerTestOneInput" in func_elem[
+                    'functionName']:
             continue
 
         possible_target = FuzzTarget()
@@ -627,7 +631,9 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
-        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
+        if "jazzer" in func_elem[
+                'functionName'] or "fuzzerTestOneInput" in func_elem[
+                    'functionName']:
             continue
 
         possible_target = FuzzTarget()
@@ -734,7 +740,9 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
             continue
         if "test" in func_elem['functionName']:
             continue
-        if "jazzer" in func_elem['functionName'] or "fuzzerTestOneInput" in func_elem['functionName']:
+        if "jazzer" in func_elem[
+                'functionName'] or "fuzzerTestOneInput" in func_elem[
+                    'functionName']:
             continue
 
         possible_target = FuzzTarget()

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -206,7 +206,8 @@ def _maven_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['PATH'] = os.path.join(basedir, "apache-maven-3.6.3", "bin") + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(basedir, "apache-maven-3.6.3",
+                                   "bin") + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = [
@@ -234,7 +235,8 @@ def _gradle_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, "gradle-7.4.2")
-    env_var['PATH'] = os.path.join(basedir, "gradle-7.4.2", "bin") + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(basedir, "gradle-7.4.2",
+                                   "bin") + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = [
@@ -305,8 +307,8 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     # Compile and package fuzzer to jar file
     cmd = [
-        "javac -cp jazzer_standalone.jar:%s ../Fuzz1.java" % ":".join(jarfiles),
-        "jar cvf ../Fuzz1.jar ../Fuzz1.class"
+        "javac -cp jazzer_standalone.jar:%s ../Fuzz1.java" %
+        ":".join(jarfiles), "jar cvf ../Fuzz1.jar ../Fuzz1.class"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),
@@ -401,9 +403,9 @@ def build_and_test_single_possible_target(idx_folder,
         maven_dst = os.path.join(dst_oss_fuzz_project.project_folder,
                                  "maven.zip")
         gradle_path = os.path.join(oss_fuzz_base_project.project_folder,
-                                  "gradle.zip")
+                                   "gradle.zip")
         gradle_dst = os.path.join(dst_oss_fuzz_project.project_folder,
-                                 "gradle.zip")
+                                  "gradle.zip")
         shutil.copy(maven_path, maven_dst)
         shutil.copy(gradle_path, gradle_dst)
 
@@ -582,7 +584,7 @@ def autofuzz_project_from_github(github_url,
         # Download Gradle
         GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"
         target_gradle_path = os.path.join(oss_fuzz_base_project.project_folder,
-                                               "gradle.zip")
+                                          "gradle.zip")
         with open(target_gradle_path, 'wb') as gf:
             gf.write(requests.get(GRADLE_URL).content)
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -22,6 +22,7 @@ import constants
 import requests
 import shlex
 import tarfile
+import zipfile
 import threading
 try:
     import tqdm
@@ -38,6 +39,7 @@ import oss_fuzz_manager
 import fuzz_driver_generation_python
 import fuzz_driver_generation_jvm
 
+from io import BytesIO
 from typing import List, Any
 from multiprocessing.dummy import Pool as ThreadPool
 
@@ -196,6 +198,60 @@ def run_static_analysis_python(git_repo, basedir):
     return ret
 
 
+def _maven_build_project(basedir, projectdir):
+    """Helper method to build project using maven"""
+    # Prepare maven
+    with zipfile.ZipFile(os.path.join(basedir, "maven.zip"), "r") as mf:
+        mf.extractall(basedir)
+
+    # Set environment variable
+    env_var = os.environ.copy()
+    env_var['PATH'] = os.path.join(basedir, "apache-maven-3.6.3", "bin") + ":" + env_var['PATH']
+
+    # Build project with maven
+    cmd = [
+        "mvn clean package", "-DskipTests", "-Djavac.src.version=15",
+        "-Djavac.target.version=15", "-Dmaven.javadoc.skip=true"
+    ]
+    try:
+        subprocess.check_call(" ".join(cmd),
+                              shell=True,
+                              timeout=1800,
+                              stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL,
+                              env=env_var,
+                              cwd=projectdir)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _gradle_build_project(basedir, projectdir):
+    """Helper method to build project using maven"""
+    # Prepare gradle
+    with zipfile.ZipFile(os.path.join(basedir, "gradle.zip"), "r") as gf:
+        gf.extractall(basedir)
+
+    # Set environment variable
+    env_var = os.environ.copy()
+    env_var['GRADLE_HOME'] = os.path.join(basedir, "gradle-7.4.2")
+    env_var['PATH'] = os.path.join(basedir, "gradle-7.4.2", "bin") + ":" + env_var['PATH']
+
+    # Build project with maven
+    cmd = [
+        "./gradlew clean build"
+    ]
+    try:
+        subprocess.check_call(" ".join(cmd),
+                              shell=True,
+                              timeout=1800,
+#                              stdout=subprocess.DEVNULL,
+#                              stderr=subprocess.DEVNULL,
+                              env=env_var,
+                              cwd=projectdir)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def run_static_analysis_jvm(git_repo, basedir):
     possible_imports = set()
     curr_dir = os.getcwd()
@@ -214,19 +270,18 @@ def run_static_analysis_jvm(git_repo, basedir):
     except subprocess.TimeoutExpired:
         pass
 
-    cmd = [
-        "mvn clean package", "-DskipTests", "-Djavac.src.version=15",
-        "-Djavac.target.version=15", "-Dmaven.javadoc.skip=true"
-    ]
-    try:
-        subprocess.check_call(" ".join(cmd),
-                              shell=True,
-                              timeout=1800,
-                              stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL,
-                              cwd=os.path.join(basedir, "work", "proj"))
-    except subprocess.TimeoutExpired:
-        pass
+    projectdir = os.path.join(basedir, "work", "proj")
+
+    if os.path.exists(os.path.join(projectdir, "pom.xml")):
+        # Maven project
+        _maven_build_project(basedir, projectdir)
+    elif os.path.exists(os.path.join(projectdir, "build.gradle")):
+        # Gradle project
+        _gradle_build_project(basedir, projectdir)
+    else:
+        # Unknown project type
+        print("Unknown project type.\n")
+        return False
 
     # Retrieve Jazzer package for building fuzzer
     jazzer_url = "https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v0.15.0/jazzer-linux.tar.gz"
@@ -253,7 +308,7 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     # Retrieve path of all jar files
     jarfiles = [os.path.abspath("../Fuzz1.jar")]
-    for root, _, files in os.walk(os.path.join(basedir, "work", "proj")):
+    for root, _, files in os.walk(projectdir):
         if "target" in root:
             for file in files:
                 if file.endswith(".jar"):
@@ -503,14 +558,22 @@ def autofuzz_project_from_github(github_url,
                          oss_fuzz_base_project.project_name)):
         return False
 
-    # If this is a jvm target download maven once so we don't have to do it
-    # for each proejct.
+    # If this is a jvm target download maven and gradle once so we don't
+    # have to do it for each proejct.
     if language == "jvm":
+        # Download Maven
         MAVEN_URL = "https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
         target_maven_path = os.path.join(oss_fuzz_base_project.project_folder,
                                          "maven.zip")
         with open(target_maven_path, 'wb') as mf:
             mf.write(requests.get(MAVEN_URL).content)
+
+        # Download Gradle
+        GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"
+        target_gradle_path = os.path.join(oss_fuzz_base_project.project_folder,
+                                               "gradle.zip")
+        with open(target_gradle_path, 'wb') as gf:
+            gf.write(requests.get(GRADLE_URL).content)
 
     # Generate the base Dockerfile, build.sh, project.yaml and fuzz_1.py
     oss_fuzz_base_project.write_basefiles()


### PR DESCRIPTION
The original code assumes that the target project uses maven structure, but there exists quite a number of projects that actually adopt Gradle project structure instead. This PR add logic to the auto-fuzz manager and base file builder in order to accommodate gradle projects. The new code will check if the project contains pom.xml or build.gradle which are the build property files for maven and gradle project respectively and build with the corresponding builder.