### PR TITLE
auto-tools: clean up docker build cache after X runs

### DIFF
--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -16,6 +16,8 @@ MAX_FUZZERS_PER_PROJECT = 10
 MAX_TARGET_PER_PROJECT_HEURISTIC = 100
 MAX_THREADS = 4
 
+BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
+
 git_repos = {
     'python': [
         # 'https://github.com/davidhalter/parso',

--- a/tools/auto-fuzz/oss_fuzz_manager.py
+++ b/tools/auto-fuzz/oss_fuzz_manager.py
@@ -104,7 +104,9 @@ def cleanup_project(proj_name, oss_fuzz_base):
     # Remove the OSS-Fuzz docker image itself
     oss_fuzz_docker_tag = f'gcr.io/oss-fuzz/{proj_name}'
     try:
-        subprocess.check_call(['docker', 'rmi', oss_fuzz_docker_tag])
+        subprocess.check_call(['docker', 'rmi', oss_fuzz_docker_tag],
+                              stderr=subprocess.DEVNULL,
+                              stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
         pass
     return True


### PR DESCRIPTION
This is needed as otherwise the disk is quickly exhausted when doing large-scale runs.