### PR TITLE
Auto-fuzz: Move maven and gradle properties to constants

### DIFF
--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -18,6 +18,13 @@ MAX_THREADS = 4
 
 BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
 
+MAVEN_URL = "https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
+GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"
+
+MAVEN_PATH = "apache-maven-3.6.3/bin"
+GRADLE_HOME = "gradle-7.4.2"
+GRADLE_PATH = f"{GRADLE_HOME}/bin"
+
 git_repos = {
     'python': [
         # 'https://github.com/davidhalter/parso',

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -206,8 +206,7 @@ def _maven_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['PATH'] = os.path.join(basedir, "apache-maven-3.6.3",
-                                   "bin") + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = [
@@ -236,9 +235,8 @@ def _gradle_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['GRADLE_HOME'] = os.path.join(basedir, "gradle-7.4.2")
-    env_var['PATH'] = os.path.join(basedir, "gradle-7.4.2",
-                                   "bin") + ":" + env_var['PATH']
+    env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
+    env_var['PATH'] = os.path.join(basedir, constants.GRADLE_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = [
@@ -607,18 +605,16 @@ def autofuzz_project_from_github(github_url,
     # have to do it for each proejct.
     if language == "jvm":
         # Download Maven
-        MAVEN_URL = "https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
         target_maven_path = os.path.join(oss_fuzz_base_project.project_folder,
                                          "maven.zip")
         with open(target_maven_path, 'wb') as mf:
-            mf.write(requests.get(MAVEN_URL).content)
+            mf.write(requests.get(constants.MAVEN_URL).content)
 
         # Download Gradle
-        GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"
         target_gradle_path = os.path.join(oss_fuzz_base_project.project_folder,
                                           "gradle.zip")
         with open(target_gradle_path, 'wb') as gf:
-            gf.write(requests.get(GRADLE_URL).content)
+            gf.write(requests.get(constants.GRADLE_URL).content)
 
     # Generate the base Dockerfile, build.sh, project.yaml and fuzz_1.py
     oss_fuzz_base_project.write_basefiles()

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -206,7 +206,8 @@ def _maven_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['PATH'] = os.path.join(basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(
+        basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = [
@@ -236,7 +237,8 @@ def _gradle_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
-    env_var['PATH'] = os.path.join(basedir, constants.GRADLE_PATH) + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(
+        basedir, constants.GRADLE_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = [


### PR DESCRIPTION
Move the maven and gradle properties to constants.py, this could make it easier to udpate the path and download links.