### PR TITLE
Auto-fuzz: Fix recursion

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -266,7 +266,8 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.append(
-                _handle_argument(argType, init_dict, possible_target, max_target))
+                _handle_argument(argType, init_dict, possible_target,
+                                 max_target))
 
         if len(arg_list) != len(func_elem['argTypes']):
             continue
@@ -546,7 +547,8 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
 
         # Get all object creation statement for each possible concrete classes of the object
         object_creation_list = _handle_object_creation(func_class, init_dict,
-                                                       possible_target, max_target)
+                                                       possible_target,
+                                                       max_target)
 
         for object_creation_item in object_creation_list:
             # Create possible target for all possible object creation statement

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -135,7 +135,6 @@ def _handle_import(func_elem):
 def _handle_argument(argType,
                      init_dict,
                      possible_target,
-                     recursion_count,
                      max_target,
                      obj_creation=True,
                      handled=[]):
@@ -168,7 +167,7 @@ def _handle_argument(argType,
         return ["data.consumeString(100)"]
     elif obj_creation:
         return _handle_object_creation(argType, init_dict, possible_target,
-                                       recursion_count, max_target, handled)
+                                       max_target, handled)
     else:
         return []
 
@@ -267,16 +266,14 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.append(
-                _handle_argument(argType, init_dict, possible_target, 0,
-                                 max_target))
+                _handle_argument(argType, init_dict, possible_target, max_target))
 
         if len(arg_list) != len(func_elem['argTypes']):
             continue
 
         # Create possible factory method invoking statements with constructor or static factory
         for creation in _handle_object_creation(func_class, init_dict,
-                                                possible_target, 0,
-                                                max_target):
+                                                possible_target, max_target):
             if creation and len(result_list) > max_target:
                 return result_list
 
@@ -337,7 +334,6 @@ def _search_concrete_subclass(classname,
 def _handle_object_creation(classname,
                             init_dict,
                             possible_target,
-                            recursion_count,
                             max_target,
                             handled=[]):
     """
@@ -346,8 +342,7 @@ def _handle_object_creation(classname,
     use it as reference, otherwise the default empty constructor
     are used.
     """
-    recursion_count += 1
-    if init_dict and classname in init_dict.keys() and recursion_count <= 5:
+    if init_dict and classname in init_dict.keys():
         # Process arguments for constructor
         try:
             arg_list = []
@@ -370,8 +365,7 @@ def _handle_object_creation(classname,
                 handled.append(elem)
                 for argType in elem['argTypes']:
                     arg = _handle_argument(argType, init_dict, possible_target,
-                                           recursion_count, max_target, True,
-                                           handled)
+                                           max_target, True, handled)
                     if arg:
                         arg_list.append(arg)
                 if len(arg_list) != len(elem['argTypes']):
@@ -552,8 +546,7 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
 
         # Get all object creation statement for each possible concrete classes of the object
         object_creation_list = _handle_object_creation(func_class, init_dict,
-                                                       possible_target, 0,
-                                                       max_target)
+                                                       possible_target, max_target)
 
         for object_creation_item in object_creation_list:
             # Create possible target for all possible object creation statement


### PR DESCRIPTION
In the Java auto fuzzing, there is a temporary measure added before to limit the number of recursion. When the maximum number of recursion is reached, the searching of possible constructor will stop and return an empty constructor as a fail safe option. This setting could eliminate the maximum recursion count reached problem, but it also makes some of the fuzzers fail to use the fuzzing data because empty constructor are used. 
With the fix in #862 It eliminates the error on repeat process of the same method. This will limit the number of recursion and the needs of the recursion count, thus this PR aims to remove the recursion count feature to allow a better fuzzer generation process with random fuzz data.
