### PR TITLE
auto-fuzz: extend post processing

### DIFF
--- a/tools/auto-fuzz/post_process.py
+++ b/tools/auto-fuzz/post_process.py
@@ -35,32 +35,33 @@ def get_heuristics_from_trial(dirname):
     return result.get('heuristics-used')
 
 
-def get_max_code_cov_from_trial(dirname):
+def get_code_cov_from_trial(dirname):
     """Returns the max edge coverage of a specific OSS-Fuzz run. Return -1
     if the build or run was unsuccessful.
     """
     result = get_result_json(dirname)
     if result is None:
-        return -1
+        return None
 
     if result.get('auto-build') != 'True' or result.get('auto-run') != 'True':
-        return -1
+        return None
 
     # Read coverage log
     oss_fuzz_run_log = os.path.join(dirname, "autofuzz-log",
                                     "oss-fuzz-run.out")
     if not os.path.isfile(oss_fuzz_run_log):
-        return
+        return None
     with open(oss_fuzz_run_log, "r") as orf:
         oss_run_out = orf.read()
 
     max_cov = -1
+    cov_data = []
     for line in oss_run_out.split("\n"):
         if "cov: " in line:
             line_cov = int(line.split("cov:")[1].lstrip().split(" ")[0])
-            if line_cov > max_cov:
-                max_cov = line_cov
-    return max_cov
+            cov_data.append(line_cov)
+
+    return cov_data
 
 
 def interpret_autofuzz_run(dirname: str, only_report_max: bool = False):
@@ -87,8 +88,15 @@ def interpret_autofuzz_run(dirname: str, only_report_max: bool = False):
             continue
         trial_runs[trial_run_dir] = {'max_cov': -2}
         subpath = os.path.join(dirname, trial_run_dir)
-        max_cov = get_max_code_cov_from_trial(subpath)
+        cov_data = get_code_cov_from_trial(subpath)
+        if cov_data is None:
+            max_cov = -1
+            min_cov = -1
+        else:
+            min_cov = cov_data[0]
+            max_cov = cov_data[-1]
         trial_runs[trial_run_dir]['max_cov'] = max_cov
+        trial_runs[trial_run_dir]['min_cov'] = min_cov
         trial_runs[trial_run_dir]['name'] = trial_run_dir
         trial_runs[trial_run_dir][
             'heuristics-used'] = get_heuristics_from_trial(subpath)
@@ -114,9 +122,10 @@ def _print_summary_of_trial_run(trial_run,
         fuzz_path = python_fuzz_path
     elif os.path.isfile(jvm_fuzz_path):
         fuzz_path = jvm_fuzz_path
-    print("%s :: %15s ::  %21s :: %5s :: %s :: %s" %
+    print("%s :: %15s ::  %21s :: [%5s : %5s] :: %s :: %s" %
           (proj_name, autofuzz_project_dir, trial_name,
-           str(trial_run['max_cov']), fuzz_path, trial_run['heuristics-used']))
+           str(trial_run['max_cov']), str(trial_run['min_cov']),
+           fuzz_path, trial_run['heuristics-used']))
 
 
 def get_top_trial_run(trial_runs):

--- a/tools/auto-fuzz/post_process.py
+++ b/tools/auto-fuzz/post_process.py
@@ -124,8 +124,8 @@ def _print_summary_of_trial_run(trial_run,
         fuzz_path = jvm_fuzz_path
     print("%s :: %15s ::  %21s :: [%5s : %5s] :: %s :: %s" %
           (proj_name, autofuzz_project_dir, trial_name,
-           str(trial_run['max_cov']), str(trial_run['min_cov']),
-           fuzz_path, trial_run['heuristics-used']))
+           str(trial_run['max_cov']), str(
+               trial_run['min_cov']), fuzz_path, trial_run['heuristics-used']))
 
 
 def get_top_trial_run(trial_runs):


### PR DESCRIPTION
This is needed to identify the increase in coverage that a given fuzzer has been achieved.

For example, auto-fuzz generates the following fuzzer for the `glom` project:
```python
import sys
import atheris
# Auto-fuzz heuristics used: py-autofuzz-heuristics-1
# Imports by the generated code
import glom

@atheris.instrument_func
def TestOneInput(data):
  fdp = atheris.FuzzedDataProvider(data)
  val_1 = fdp.ConsumeUnicodeNoSurrogates(24)
  try:
    glom.reduction.flatten(val_1)
  except (glom.matching.Check._ValidationError,glom.core.GlomError,):
    pass

def main():
  atheris.instrument_all()
  atheris.Setup(sys.argv, TestOneInput)
  atheris.Fuzz()


if __name__ == "__main__":
  main()
```

The output from running the fuzzer is:
```
INFO: A corpus is not provided, starting from an empty corpus
#2	INITED cov: 235 ft: 235 corp: 1/1b exec/s: 0 rss: 88Mb
#2048	pulse  cov: 235 ft: 235 corp: 1/1b lim: 21 exec/s: 1024 rss: 91Mb
INFO: libFuzzer disabled leak detection after every mutation.
      Most likely the target function accumulates allocated
      memory in a global state w/o actually leaking it.
      You may try running this binary with -trace_malloc=[12]      to get a trace of mallocs and frees.
      If LeakSanitizer is enabled in this process it will still
      run on the process shutdown.
#4096	pulse  cov: 235 ft: 235 corp: 1/1b lim: 43 exec/s: 1024 rss: 91Mb
#8192	pulse  cov: 235 ft: 235 corp: 1/1b lim: 80 exec/s: 910 rss: 91Mb
#10009	DONE   cov: 235 ft: 235 corp: 1/1b lim: 98 exec/s: 909 rss: 91Mb
```

Overall, 235 is decent and currently the top fuzzer generated for the `glom` project. However, to get better clarity on the performance of the fuzzer we need to have the amount of newly explored code, i.e. code explored by the fuzzer from mutating the input.

For reference, an updated version of the fuzzer is submitted to OSS-Fuzz here: https://github.com/google/oss-fuzz/pull/9837 (`fuzz_reduction.py`) -- let's see if it achieves higher coverage over time.