### PR TITLE
Auto-fuzz: Fix non-serializable set for json

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -468,7 +468,8 @@ def build_and_test_single_possible_target(idx_folder,
     summary['auto-run'] = str(run_success)
     summary['target function'] = possible_target.function_target
     summary['imports_to_add'] = list(possible_target.imports_to_add)
-    summary['exceptions_to_handle'] = list(possible_target.exceptions_to_handle)
+    summary['exceptions_to_handle'] = list(
+        possible_target.exceptions_to_handle)
     summary['heuristics-used'] = list()
     for heuristic in possible_target.heuristics_used:
         summary['heuristics-used'].append(heuristic)

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -467,8 +467,8 @@ def build_and_test_single_possible_target(idx_folder,
     summary['auto-build'] = str(build_success)
     summary['auto-run'] = str(run_success)
     summary['target function'] = possible_target.function_target
-    summary['imports_to_add'] = possible_target.imports_to_add
-    summary['exceptions_to_handle'] = possible_target.exceptions_to_handle
+    summary['imports_to_add'] = list(possible_target.imports_to_add)
+    summary['exceptions_to_handle'] = list(possible_target.exceptions_to_handle)
     summary['heuristics-used'] = list()
     for heuristic in possible_target.heuristics_used:
         summary['heuristics-used'].append(heuristic)


### PR DESCRIPTION
To ensure only unique lines of import statement and exception handling statement are added to each possible target for java auto fuzzing, the type of these two object variables are set to set instead of list. But set objects are not json serializable and cause some errors in writing the summary file. This PR adds an extra list() call to the object to ensure the return variables must be a list object for the json serialise process.