### PR TITLE
Auto-fuzz / JVM frontend: Add enum class support

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -453,6 +453,7 @@ class CustomSenceTransformer extends SceneTransformer {
         methodInfo.setIsConcrete(method.isConcrete());
         methodInfo.setIsPublic(method.isPublic());
         methodInfo.setIsClassConcrete(sootClass.isConcrete());
+        methodInfo.setIsClassEnum(sootClass.isEnum());
         if (sootClass.hasSuperclass()) {
           methodInfo.setSuperClass(sootClass.getSuperclass().getName());
         }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -297,6 +297,7 @@ class CustomSenceTransformer extends SceneTransformer {
         methodInfo.setIsJavaLibraryMethod(m.isJavaLibraryMethod());
         methodInfo.setIsPublic(m.isPublic());
         methodInfo.setIsStatic(m.isStatic());
+        methodInfo.setIsClassEnum(c.isEnum());
         for (SootClass exception : m.getExceptions()) {
           methodInfo.addException(exception.getFilePath());
         }
@@ -497,6 +498,7 @@ class CustomSenceTransformer extends SceneTransformer {
       methodInfo.setIsJavaLibraryMethod(method.isJavaLibraryMethod());
       methodInfo.setIsPublic(method.isPublic());
       methodInfo.setIsStatic(method.isStatic());
+      methodInfo.setIsClassEnum(method.getDeclaringClass().isEnum());
       for (SootClass exception : method.getExceptions()) {
         methodInfo.addException(exception.getFilePath());
       }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
@@ -28,6 +28,7 @@ public class JavaMethodInfo {
   private Boolean isPublic;
   private Boolean isStatic;
   private Boolean isClassConcrete;
+  private Boolean isClassEnum;
 
   public JavaMethodInfo() {
     this.exceptions = new ArrayList<String>();
@@ -38,6 +39,7 @@ public class JavaMethodInfo {
     this.isPublic = true;
     this.isStatic = false;
     this.isClassConcrete = true;
+    this.isClassEnum = false;
   }
 
   public List<String> getExceptions() {
@@ -110,5 +112,13 @@ public class JavaMethodInfo {
 
   public void setIsClassConcrete(Boolean isClassConcrete) {
     this.isClassConcrete = isClassConcrete;
+  }
+
+  public Boolean isClassEnum() {
+    return this.isClassEnum;
+  }
+
+  public void setIsClassEnum(Boolean isClassEnum) {
+    this.isClassEnum = isClassEnum;
   }
 }


### PR DESCRIPTION
For some of the existing java fuzzer, it requires using enum values as parameters parameters. Normal constructor or factory method fails to create an enum object with random fuzzing data. One of the solutions is creating an array of all possible values of the target enum and using the jazzer fuzzer to randomly pick one of them as parameters during fuzzing. For example in https://github.com/google/oss-fuzz/blob/master/projects/checker-framework/UtilCheckerFuzzer.java#L41-L49, it uses this approach to create random fuzzing enum values. This PR adds an additional boolean field `enum` to the .data.yaml file for jvm frontend to allow the auto fuzzer generator determine which parameters are enum type and use above mentioned special handling to create random enum value for fuzzing. This matches heuristic 8 of the Auto-fuzz for java.