### PR TITLE
Auto-fuzz: Fix check error

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -138,7 +138,7 @@ def gen_builder_1_jvm():
     BUILD_SCRIPT = """if test -f "build.gradle"
 then
   chmod +x ./gradlew
-  ./gradlew clean build -x test
+  ./gradlew clean build -x test -x :checker:javadoc -x :framework-test:spotlessJavaCheck
 elif test -f "pom.xml"
 then
   MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -250,7 +250,8 @@ def _gradle_build_project(basedir, projectdir):
 
     # Build project with maven
     cmd = [
-        "./gradlew clean build -x test",
+        "chmod +x gradlew",
+        "./gradlew clean build -x test -x :checker:javadoc -x :framework-test:spotlessJavaCheck",
         "jar cvf proj.jar -C build/classes/java/main/ ."
     ]
     try:


### PR DESCRIPTION
Some gradle project build will fail for spotless java check target. The main reason of that is the use of deprecated API which are legal java statement but not allowed by the check. This PR excludes the spotless java check and javadoc check to avoid the error and to increase speed from skipping the check. 
Also, a minor fix in manager.py to give execution permission to gradle wrapper is included in this PR.