### PR TITLE
Auto-fuzz: Fix constructor list

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -99,9 +99,8 @@ class FuzzTarget:
 
 def _is_enum_class(init_dict, classname):
     """Check if the method's class is an enum type"""
-    for key in init_dict:
-        func_elem = init_dict[key]
-        if func_elem['functionSourceFile'] == classname:
+    if classname in init_dict.keys():
+        for func_elem in init_dict[classname]:
             if func_elem['JavaMethodInfo']['classEnum']:
                 return True
 
@@ -142,7 +141,7 @@ def _handle_import(func_elem):
 
     # argTypes
     for argType in func_elem['argTypes']:
-        import_set.add(_determine_import_statement(argType))
+        import_set.add(_determine_import_statement(argType.replace('$', '.')))
 
     # exceptions
     for exception in func_elem['JavaMethodInfo']['exceptions']:
@@ -228,7 +227,7 @@ def _search_static_factory_method(classname, static_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.extend(
-                _handle_argument(argType, None, None, max_target, False))
+                _handle_argument(argType.replace('$', '.'), None, None, max_target, False))
 
         # Error in some parameters
         if len(arg_list) != len(func_elem['argTypes']):
@@ -285,13 +284,13 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
             continue
 
         func_name = func_elem['functionName'].split('(')[0].split('].')[1]
-        func_class = func_elem['functionSourceFile']
+        func_class = func_elem['functionSourceFile'].replace('$', '.')
 
         # Retrieve arguments list
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.append(
-                _handle_argument(argType, init_dict, possible_target,
+                _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
                                  max_target))
 
         if len(arg_list) != len(func_elem['argTypes']):
@@ -336,8 +335,8 @@ def _search_setting_method(method_list, target_class_name, target_method_name):
     """
     result_list = []
     for func_elem in method_list:
-        func_name = func_elem['functionName']
-        func_class = func_elem['functionSourceFile']
+        func_name = func_elem['functionName'].split('(')[0].split('].')[1]
+        func_class = func_elem['functionSourceFile'].replace('$', '.')
         if func_class != target_class_name:
             continue
         if func_name == target_method_name:
@@ -348,7 +347,7 @@ def _search_setting_method(method_list, target_class_name, target_method_name):
 
         arg_list = []
         for argType in func_elem['argTypes']:
-            arg = _handle_argument(argType, None, possible_target, max_target)
+            arg = _handle_argument(argType.replace('$', '.'), None, possible_target, max_target)
             if arg:
                 arg_list.append(arg[0])
         if len(arg_list) != len(func_elem['argTypes']):
@@ -364,26 +363,26 @@ def _search_concrete_subclass(classname,
                               handled=[],
                               result_list=[]):
     """Search concrete subclass for the target classname"""
-    for key in init_dict:
-        func_elem = init_dict[key]
-        java_info = func_elem['JavaMethodInfo']
+    if classname in init_dict.keys():
+        for func_elem in init_dict[classname]:
+            java_info = func_elem['JavaMethodInfo']
 
-        if func_elem in handled:
-            continue
+            if func_elem in handled:
+                continue
 
-        if not java_info[
-                'superClass'] == classname and classname not in java_info[
-                    'interfaces']:
-            continue
+            if not java_info[
+                    'superClass'] == classname and classname not in java_info[
+                        'interfaces']:
+                continue
 
-        if java_info['classConcrete'] and java_info['public']:
-            if func_elem not in result_list:
-                result_list.append(func_elem)
-        else:
-            for result in _search_concrete_subclass(
-                    func_elem['functionSourceFile'], init_dict, handled):
-                if result not in result_list:
-                    result_list.append(result)
+            if java_info['classConcrete'] and java_info['public']:
+                if func_elem not in result_list:
+                    result_list.append(func_elem)
+            else:
+                for result in _search_concrete_subclass(
+                        func_elem['functionSourceFile'].replace('$', '.'), init_dict, handled):
+                    if result not in result_list:
+                        result_list.append(result)
 
     return result_list
 
@@ -413,48 +412,47 @@ def _handle_object_creation(classname,
     use it as reference, otherwise the default empty constructor
     are used.
     """
-    if init_dict and classname in init_dict.keys():
-        # Process arguments for constructor
-        try:
-            arg_list = []
-            class_list = []
-            func_elem = init_dict[classname]
+    if classname in init_dict.keys():
+        result_list = []
+        for func_elem in init_dict[classname]:
+            try:
+                arg_list = []
+                class_list = []
 
-            if func_elem['JavaMethodInfo']['classConcrete']:
-                class_list.append(func_elem)
-            else:
-                class_list.extend(
-                    _search_concrete_subclass(classname, init_dict, handled))
-            if len(class_list) == 0:
-                return "new " + classname.replace("$", ".") + "()"
+                if func_elem['JavaMethodInfo']['classConcrete']:
+                    class_list.append(func_elem)
+                else:
+                    class_list.extend(
+                        _search_concrete_subclass(classname, init_dict, handled))
+                if len(class_list) == 0:
+                    return "new " + classname.replace("$", ".") + "()"
 
-            result_list = []
-            for elem in class_list:
-                elem_classname = elem['functionSourceFile']
-                if elem in handled:
-                    continue
-                handled.append(elem)
-                for argType in elem['argTypes']:
-                    arg = _handle_argument(argType, init_dict, possible_target,
-                                           max_target, True, handled)
-                    if arg:
-                        arg_list.append(arg)
-                if len(arg_list) != len(elem['argTypes']):
-                    continue
-                possible_target.exceptions_to_handle.update(
-                    elem['JavaMethodInfo']['exceptions'])
-                possible_target.imports_to_add.update(
-                    _handle_import(func_elem))
-                for args_item in list(itertools.product(*arg_list)):
-                    result_list.append("new " +
-                                       elem_classname.replace("$", ".") + "(" +
-                                       ",".join(args_item) + ")")
-                    if len(result_list) > max_target:
-                        return result_list
-            return result_list
-        except RecursionError:
-            # Fail to create constructor code with parameters, using default constructor
-            return ["new " + classname.replace("$", ".") + "()"]
+                for elem in class_list:
+                    elem_classname = elem['functionSourceFile'].replace('$', '.')
+                    if elem in handled:
+                        continue
+                    handled.append(elem)
+                    for argType in elem['argTypes']:
+                        arg = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
+                                               max_target, True, handled)
+                        if arg:
+                            arg_list.append(arg)
+                    if len(arg_list) != len(elem['argTypes']):
+                        continue
+                    possible_target.exceptions_to_handle.update(
+                        elem['JavaMethodInfo']['exceptions'])
+                    possible_target.imports_to_add.update(
+                        _handle_import(func_elem))
+                    for args_item in list(itertools.product(*arg_list)):
+                        result_list.append("new " +
+                                           elem_classname.replace("$", ".") + "(" +
+                                           ",".join(args_item) + ")")
+                        if len(result_list) > max_target:
+                            return result_list
+            except RecursionError:
+                # Fail to create constructor code with parameters, using default constructor
+                return ["new " + classname.replace("$", ".") + "()"]
+        return result_list
     else:
         return ["new " + classname.replace("$", ".") + "()"]
 
@@ -467,7 +465,12 @@ def _extract_method(yaml_dict):
     static_method_list = []
     for func_elem in yaml_dict['All functions']['Elements']:
         if "<init>" in func_elem['functionName']:
-            init_dict[func_elem['functionSourceFile']] = func_elem
+            init_list = []
+            func_class = func_elem['functionSourceFile'].replace('$', '.')
+            if func_class in init_dict.keys():
+                init_list = init_dict[func_class]
+            init_list.append(func_elem)
+            init_dict[func_class] = init_list
             continue
 
         # Skip excluded methods
@@ -522,7 +525,7 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType, None, possible_target,
+            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
                                         max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
@@ -574,7 +577,7 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
 
         # Get all possible argument lists with different possible object creation combination
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType, init_dict, possible_target,
+            arg_list = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
                                         max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
@@ -646,7 +649,7 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType, None, possible_target,
+            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
                                         max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
@@ -713,7 +716,7 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType, None, possible_target,
+            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
                                         max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
@@ -783,9 +786,9 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
         # enum object as parameter
         enum_argument = False
         for argType in func_elem['argTypes']:
-            if _is_enum_class(init_dict, argType):
+            if _is_enum_class(init_dict, argType.replace('$', '.')):
                 enum_argument = True
-            arg_list = _handle_argument(argType,
+            arg_list = _handle_argument(argType.replace('$', '.'),
                                         init_dict,
                                         possible_target,
                                         max_target,
@@ -865,9 +868,9 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
         # enum object as parameter
         enum_argument = False
         for argType in func_elem['argTypes']:
-            if _is_enum_class(init_dict, argType):
+            if _is_enum_class(init_dict, argType.replace('$', '.')):
                 enum_argument = True
-            arg_list = _handle_argument(argType,
+            arg_list = _handle_argument(argType.replace('$', '.'),
                                         init_dict,
                                         possible_target,
                                         max_target,

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -28,7 +28,14 @@ class FuzzTarget:
     imports_to_add: Set[str]
     heuristics_used: List[str]
 
-    def __init__(self, orig=None):
+    def __init__(self, orig=None, func_elem=None):
+        self.function_target = ""
+        self.function_class = ""
+        self.exceptions_to_handle = set()
+        self.fuzzer_source_code = ""
+        self.variables_to_add = []
+        self.imports_to_add = set()
+        self.heuristics_used = []
         if orig:
             self.function_target = orig.function_target
             self.function_class = orig.function_class
@@ -37,14 +44,13 @@ class FuzzTarget:
             self.variables_to_add = orig.variables_to_add
             self.imports_to_add = orig.imports_to_add
             self.heuristics_used = orig.heuristics_used
-        else:
-            self.function_target = ""
-            self.function_class = ""
-            self.exceptions_to_handle = set()
-            self.fuzzer_source_code = ""
-            self.variables_to_add = []
-            self.imports_to_add = set()
-            self.heuristics_used = []
+        elif func_elem:
+            # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
+            self.function_target = func_elem['functionName'].split('].')[1].split('(')[0]
+            self.function_class = func_elem['functionSourceFile'].replace('$', '.')
+            self.exceptions_to_handle.update(func_elem['JavaMethodInfo']['exceptions'])
+            self.imports_to_add.update(_handle_import(func_elem))
+
 
     def __dict__(self):
         return {"function": self.function_target}
@@ -451,6 +457,43 @@ def _handle_object_creation(classname,
         return ["new " + classname.replace("$", ".") + "()"]
 
 
+def _extract_method(yaml_dict):
+    """Extract method and group them into list for heuristic processing"""
+    init_dict = {}
+    method_list = []
+    instance_method_list = []
+    static_method_list = []
+    for func_elem in yaml_dict['All functions']['Elements']:
+        if "<init>" in func_elem['functionName']:
+            init_dict[func_elem['functionSourceFile']] = func_elem
+            continue
+
+        # Skip excluded methods
+        if func_elem['JavaMethodInfo']['static']:
+            continue
+        if not func_elem['JavaMethodInfo']['public']:
+            continue
+        if not func_elem['JavaMethodInfo']['concrete']:
+            continue
+        if len(func_elem['argTypes']) > 20:
+            continue
+        if "test" in func_elem['functionName']:
+            continue
+        if "jazzer" in func_elem[
+            'functionName'] or "fuzzerTestOneInput" in func_elem[
+                'functionName']:
+            continue
+
+        # Add candidates to result lists
+        if func_elem['JavaMethodInfo']['static']:
+            static_method_list.append(func_elem)
+        else:
+            instance_method_list.append(func_elem)
+            method_list.append(func_elem)
+
+    return init_dict, method_list, instance_method_list, static_method_list
+
+
 def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
     """Heuristic 1.
     Creates a FuzzTarget for each method that satisfy all:
@@ -464,47 +507,16 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
     provided by the frontend code.
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-1"
-    for func_elem in yaml_dict['All functions']['Elements']:
+
+    _, _, _, static_method_list = _extract_method(yaml_dict)
+    for func_elem in static_method_list:
         if len(possible_targets) > max_target:
             return
 
-        java_method_info = func_elem['JavaMethodInfo']
-
-        # Skip method which doese not match this heuristic
-        if not java_method_info['static']:
-            continue
-        if not java_method_info['public']:
-            continue
-        if not java_method_info['concrete']:
-            continue
-        if java_method_info['javaLibraryMethod']:
-            continue
-        if len(func_elem['argTypes']) > 20:
-            continue
-        if "test" in func_elem['functionName']:
-            continue
-        if "jazzer" in func_elem[
-                'functionName'] or "fuzzerTestOneInput" in func_elem[
-                    'functionName']:
-            continue
-
-        possible_target = FuzzTarget()
-
-        # Store target method name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
-        possible_target.function_target = func_name
-
-        # Store function class
-        func_class = func_elem['functionSourceFile'].replace('$', '.')
-        possible_target.function_class = func_class
-
-        # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(
-            java_method_info['exceptions'])
-
-        # Store java import statement
-        possible_target.imports_to_add.update(_handle_import(func_elem))
+        # Initialize base possible_target object
+        possible_target = FuzzTarget(func_elem=func_elem)
+        func_name = possible_target.function_target
+        func_class = possible_target.function_class
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
@@ -547,56 +559,16 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
     provided by the frontend code.
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-2"
-    # Retrieve <init> method definition for all classes
-    init_dict = {}
-    method_list = []
-    for func_elem in yaml_dict['All functions']['Elements']:
-        if "<init>" in func_elem['functionName']:
-            init_dict[func_elem['functionSourceFile']] = func_elem
-        else:
-            method_list.append(func_elem)
 
+    init_dict, method_list, _, _ = _extract_method(yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
 
-        java_method_info = func_elem['JavaMethodInfo']
-
-        # Skip method which doese not match this heuristic
-        if java_method_info['static']:
-            continue
-        if not java_method_info['public']:
-            continue
-        if not java_method_info['concrete']:
-            continue
-        if java_method_info['javaLibraryMethod']:
-            continue
-        if len(func_elem['argTypes']) > 20:
-            continue
-        if "test" in func_elem['functionName']:
-            continue
-        if "jazzer" in func_elem[
-                'functionName'] or "fuzzerTestOneInput" in func_elem[
-                    'functionName']:
-            continue
-
-        possible_target = FuzzTarget()
-
-        # Store target method name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
-        possible_target.function_target = func_name
-
-        # Store function class
-        func_class = func_elem['functionSourceFile'].replace('$', '.')
-        possible_target.function_class = func_class
-
-        # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(
-            java_method_info['exceptions'])
-
-        # Store java import statement
-        possible_target.imports_to_add.update(_handle_import(func_elem))
+        # Initialize base possible_target object
+        possible_target = FuzzTarget(func_elem=func_elem)
+        func_name = possible_target.function_target
+        func_class = possible_target.function_class
 
         # Get all possible argument lists with different possible object creation combination
         for argType in func_elem['argTypes']:
@@ -615,7 +587,7 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
         for object_creation_item in object_creation_list:
             # Create possible target for all possible object creation statement
             # Clone the base target object
-            cloned_possible_target = FuzzTarget(possible_target)
+            cloned_possible_target = FuzzTarget(orig=possible_target)
 
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -660,56 +632,15 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-3"
 
-    init_dict = {}
-    static_method_list = []
-    method_list = []
-    for func_elem in yaml_dict['All functions']['Elements']:
-        if "<init>" in func_elem['functionName']:
-            init_dict[func_elem['functionSourceFile']] = func_elem
-        elif func_elem['JavaMethodInfo']['static']:
-            static_method_list.append(func_elem)
-        else:
-            method_list.append(func_elem)
-
+    init_dict, method_list, _, static_method_list = _extract_method(yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
 
-        java_method_info = func_elem['JavaMethodInfo']
-
-        # Skip method which doese not match this heuristic
-        if not java_method_info['public']:
-            continue
-        if not java_method_info['concrete']:
-            continue
-        if java_method_info['javaLibraryMethod']:
-            continue
-        if len(func_elem['argTypes']) > 20:
-            continue
-        if "test" in func_elem['functionName']:
-            continue
-        if "jazzer" in func_elem[
-                'functionName'] or "fuzzerTestOneInput" in func_elem[
-                    'functionName']:
-            continue
-
-        possible_target = FuzzTarget()
-
-        # Store target method name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
-        possible_target.function_target = func_name
-
-        # Store function class
-        func_class = func_elem['functionSourceFile'].replace('$', '.')
-        possible_target.function_class = func_class
-
-        # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(
-            java_method_info['exceptions'])
-
-        # Store java import statement
-        possible_target.imports_to_add.update(_handle_import(func_elem))
+        # Initialize base possible_target object
+        possible_target = FuzzTarget(func_elem=func_elem)
+        func_name = possible_target.function_target
+        func_class = possible_target.function_class
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
@@ -727,7 +658,7 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
         for factory_method in factory_method_list:
             # Create possible target for all possible factory method
             # Clone the base target object
-            cloned_possible_target = FuzzTarget(possible_target)
+            cloned_possible_target = FuzzTarget(orig=possible_target)
 
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -767,58 +698,15 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-4"
 
-    init_dict = {}
-    method_list = []
-    instance_method_list = []
-    static_method_list = []
-    for func_elem in yaml_dict['All functions']['Elements']:
-        if "<init>" in func_elem['functionName']:
-            init_dict[func_elem['functionSourceFile']] = func_elem
-        elif func_elem['JavaMethodInfo']['static']:
-            static_method_list.append(func_elem)
-        else:
-            instance_method_list.append(func_elem)
-            method_list.append(func_elem)
-
+    init_dict, method_list, instance_method_list, static_method_list = _extract_method(yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
 
-        java_method_info = func_elem['JavaMethodInfo']
-
-        # Skip method which doese not match this heuristic
-        if not java_method_info['public']:
-            continue
-        if not java_method_info['concrete']:
-            continue
-        if java_method_info['javaLibraryMethod']:
-            continue
-        if len(func_elem['argTypes']) > 20:
-            continue
-        if "test" in func_elem['functionName']:
-            continue
-        if "jazzer" in func_elem[
-                'functionName'] or "fuzzerTestOneInput" in func_elem[
-                    'functionName']:
-            continue
-
-        possible_target = FuzzTarget()
-
-        # Store target method name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
-        possible_target.function_target = func_name
-
-        # Store function class
-        func_class = func_elem['functionSourceFile'].replace('$', '.')
-        possible_target.function_class = func_class
-
-        # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(
-            java_method_info['exceptions'])
-
-        # Store java import statement
-        possible_target.imports_to_add.update(_handle_import(func_elem))
+        # Initialize base possible_target object
+        possible_target = FuzzTarget(func_elem=func_elem)
+        func_name = possible_target.function_target
+        func_class = possible_target.function_class
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
@@ -839,7 +727,7 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
         for factory_method in factory_method_list:
             # Create possible target for all possible factory method
             # Clone the base target object
-            cloned_possible_target = FuzzTarget(possible_target)
+            cloned_possible_target = FuzzTarget(orig=possible_target)
 
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -876,58 +764,15 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-6"
 
-    init_dict = {}
-    method_list = []
-    instance_method_list = []
-    static_method_list = []
-    for func_elem in yaml_dict['All functions']['Elements']:
-        if "<init>" in func_elem['functionName']:
-            init_dict[func_elem['functionSourceFile']] = func_elem
-        elif func_elem['JavaMethodInfo']['static']:
-            static_method_list.append(func_elem)
-        else:
-            instance_method_list.append(func_elem)
-            method_list.append(func_elem)
-
+    init_dict, method_list, instance_method_list, static_method_list = _extract_method(yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
 
-        java_method_info = func_elem['JavaMethodInfo']
-
-        # Skip method which doese not match this heuristic
-        if not java_method_info['public']:
-            continue
-        if not java_method_info['concrete']:
-            continue
-        if java_method_info['javaLibraryMethod']:
-            continue
-        if len(func_elem['argTypes']) > 20:
-            continue
-        if "test" in func_elem['functionName']:
-            continue
-        if "jazzer" in func_elem[
-                'functionName'] or "fuzzerTestOneInput" in func_elem[
-                    'functionName']:
-            continue
-
-        possible_target = FuzzTarget()
-
-        # Store target method name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
-        possible_target.function_target = func_name
-
-        # Store function class
-        func_class = func_elem['functionSourceFile'].replace('$', '.')
-        possible_target.function_class = func_class
-
-        # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(
-            java_method_info['exceptions'])
-
-        # Store java import statement
-        possible_target.imports_to_add.update(_handle_import(func_elem))
+        # Initialize base possible_target object
+        possible_target = FuzzTarget(func_elem=func_elem)
+        func_name = possible_target.function_target
+        func_class = possible_target.function_class
 
         # Store function parameter list
         # Skip this method is it does not take at least one
@@ -962,7 +807,7 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
         for factory_method in factory_method_list:
             # Create possible target for all possible factory method
             # Clone the base target object
-            cloned_possible_target = FuzzTarget(possible_target)
+            cloned_possible_target = FuzzTarget(orig=possible_target)
 
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
@@ -1000,58 +845,15 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-8"
 
-    init_dict = {}
-    method_list = []
-    instance_method_list = []
-    static_method_list = []
-    for func_elem in yaml_dict['All functions']['Elements']:
-        if "<init>" in func_elem['functionName']:
-            init_dict[func_elem['functionSourceFile']] = func_elem
-        elif func_elem['JavaMethodInfo']['static']:
-            static_method_list.append(func_elem)
-        else:
-            instance_method_list.append(func_elem)
-            method_list.append(func_elem)
-
+    init_dict, method_list, instance_method_list, static_method_list = _extract_method(yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
 
-        java_method_info = func_elem['JavaMethodInfo']
-
-        # Skip method which doese not match this heuristic
-        if not java_method_info['public']:
-            continue
-        if not java_method_info['concrete']:
-            continue
-        if java_method_info['javaLibraryMethod']:
-            continue
-        if len(func_elem['argTypes']) > 20:
-            continue
-        if "test" in func_elem['functionName']:
-            continue
-        if "jazzer" in func_elem[
-                'functionName'] or "fuzzerTestOneInput" in func_elem[
-                    'functionName']:
-            continue
-
-        possible_target = FuzzTarget()
-
-        # Store target method name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-        func_name = func_elem['functionName'].split('].')[1].split('(')[0]
-        possible_target.function_target = func_name
-
-        # Store function class
-        func_class = func_elem['functionSourceFile'].replace('$', '.')
-        possible_target.function_class = func_class
-
-        # Store exceptions thrown by the target method
-        possible_target.exceptions_to_handle.update(
-            java_method_info['exceptions'])
-
-        # Store java import statement
-        possible_target.imports_to_add.update(_handle_import(func_elem))
+        # Initialize base possible_target object
+        possible_target = FuzzTarget(func_elem=func_elem)
+        func_name = possible_target.function_target
+        func_class = possible_target.function_class
 
         # Store function parameter list
         # Skip this method is it does not take at least one
@@ -1086,7 +888,7 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
         for factory_method in factory_method_list:
             # Create possible target for all possible factory method
             # Clone the base target object
-            cloned_possible_target = FuzzTarget(possible_target)
+            cloned_possible_target = FuzzTarget(orig=possible_target)
 
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -227,7 +227,8 @@ def _search_static_factory_method(classname, static_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.extend(
-                _handle_argument(argType.replace('$', '.'), None, None, max_target, False))
+                _handle_argument(argType.replace('$', '.'), None, None,
+                                 max_target, False))
 
         # Error in some parameters
         if len(arg_list) != len(func_elem['argTypes']):
@@ -290,8 +291,8 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.append(
-                _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
-                                 max_target))
+                _handle_argument(argType.replace('$', '.'), init_dict,
+                                 possible_target, max_target))
 
         if len(arg_list) != len(func_elem['argTypes']):
             continue
@@ -347,7 +348,8 @@ def _search_setting_method(method_list, target_class_name, target_method_name):
 
         arg_list = []
         for argType in func_elem['argTypes']:
-            arg = _handle_argument(argType.replace('$', '.'), None, possible_target, max_target)
+            arg = _handle_argument(argType.replace('$', '.'), None,
+                                   possible_target, max_target)
             if arg:
                 arg_list.append(arg[0])
         if len(arg_list) != len(func_elem['argTypes']):
@@ -380,7 +382,8 @@ def _search_concrete_subclass(classname,
                     result_list.append(func_elem)
             else:
                 for result in _search_concrete_subclass(
-                        func_elem['functionSourceFile'].replace('$', '.'), init_dict, handled):
+                        func_elem['functionSourceFile'].replace('$', '.'),
+                        init_dict, handled):
                     if result not in result_list:
                         result_list.append(result)
 
@@ -423,17 +426,20 @@ def _handle_object_creation(classname,
                     class_list.append(func_elem)
                 else:
                     class_list.extend(
-                        _search_concrete_subclass(classname, init_dict, handled))
+                        _search_concrete_subclass(classname, init_dict,
+                                                  handled))
                 if len(class_list) == 0:
                     return "new " + classname.replace("$", ".") + "()"
 
                 for elem in class_list:
-                    elem_classname = elem['functionSourceFile'].replace('$', '.')
+                    elem_classname = elem['functionSourceFile'].replace(
+                        '$', '.')
                     if elem in handled:
                         continue
                     handled.append(elem)
                     for argType in elem['argTypes']:
-                        arg = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
+                        arg = _handle_argument(argType.replace('$', '.'),
+                                               init_dict, possible_target,
                                                max_target, True, handled)
                         if arg:
                             arg_list.append(arg)
@@ -445,8 +451,8 @@ def _handle_object_creation(classname,
                         _handle_import(func_elem))
                     for args_item in list(itertools.product(*arg_list)):
                         result_list.append("new " +
-                                           elem_classname.replace("$", ".") + "(" +
-                                           ",".join(args_item) + ")")
+                                           elem_classname.replace("$", ".") +
+                                           "(" + ",".join(args_item) + ")")
                         if len(result_list) > max_target:
                             return result_list
             except RecursionError:
@@ -525,8 +531,8 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -577,8 +583,8 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
 
         # Get all possible argument lists with different possible object creation combination
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), init_dict,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -649,8 +655,8 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -716,8 +722,8 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -227,7 +227,8 @@ def _search_static_factory_method(classname, static_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.extend(
-                _handle_argument(argType.replace('$', '.'), None, None, max_target, False))
+                _handle_argument(argType.replace('$', '.'), None, None,
+                                 max_target, False))
 
         # Error in some parameters
         if len(arg_list) != len(func_elem['argTypes']):
@@ -290,8 +291,8 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.append(
-                _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
-                                 max_target))
+                _handle_argument(argType.replace('$', '.'), init_dict,
+                                 possible_target, max_target))
 
         if len(arg_list) != len(func_elem['argTypes']):
             continue
@@ -347,7 +348,8 @@ def _search_setting_method(method_list, target_class_name, target_method_name):
 
         arg_list = []
         for argType in func_elem['argTypes']:
-            arg = _handle_argument(argType.replace('$', '.'), None, possible_target, max_target)
+            arg = _handle_argument(argType.replace('$', '.'), None,
+                                   possible_target, max_target)
             if arg:
                 arg_list.append(arg[0])
         if len(arg_list) != len(func_elem['argTypes']):
@@ -380,7 +382,8 @@ def _search_concrete_subclass(classname,
                     result_list.append(func_elem)
             else:
                 for result in _search_concrete_subclass(
-                        func_elem['functionSourceFile'].replace('$', '.'), init_dict, handled):
+                        func_elem['functionSourceFile'].replace('$', '.'),
+                        init_dict, handled):
                     if result not in result_list:
                         result_list.append(result)
 
@@ -423,17 +426,20 @@ def _handle_object_creation(classname,
                     class_list.append(func_elem)
                 else:
                     class_list.extend(
-                        _search_concrete_subclass(classname, init_dict, handled))
+                        _search_concrete_subclass(classname, init_dict,
+                                                  handled))
                 if len(class_list) == 0:
                     return "new " + classname.replace("$", ".") + "()"
 
                 for elem in class_list:
-                    elem_classname = elem['functionSourceFile'].replace('$', '.')
+                    elem_classname = elem['functionSourceFile'].replace(
+                        '$', '.')
                     if elem in handled:
                         continue
                     handled.append(elem)
                     for argType in elem['argTypes']:
-                        arg = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
+                        arg = _handle_argument(argType.replace('$', '.'),
+                                               init_dict, possible_target,
                                                max_target, True, handled)
                         if arg:
                             arg_list.append(arg)
@@ -445,8 +451,8 @@ def _handle_object_creation(classname,
                         _handle_import(func_elem))
                     for args_item in list(itertools.product(*arg_list)):
                         result_list.append("new " +
-                                           elem_classname.replace("$", ".") + "(" +
-                                           ",".join(args_item) + ")")
+                                           elem_classname.replace("$", ".") +
+                                           "(" + ",".join(args_item) + ")")
                         if len(result_list) > max_target:
                             return result_list
             except RecursionError:
@@ -525,8 +531,8 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -577,8 +583,8 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
 
         # Get all possible argument lists with different possible object creation combination
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), init_dict,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -649,8 +655,8 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -716,8 +722,8 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -785,10 +791,8 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
         # Skip this method if it does not take at least one
         # enum object as parameter
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'),
-                                        init_dict,
-                                        possible_target,
-                                        max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), init_dict,
+                                        possible_target, max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
 
@@ -804,7 +808,9 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
         object_creation_list.append(
             _search_static_factory_method(func_class, static_method_list,
                                           possible_target, max_target))
-        object_creation_list.append(_handle_object_creation(func_class, init_dict, possile_target, max_target))
+        object_creation_list.append(
+            _handle_object_creation(func_class, init_dict, possile_target,
+                                    max_target))
 
         for object_creation in object_creation_list:
             # Create possible target for all possible factory method
@@ -887,7 +893,9 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
         object_creation_list.append(
             _search_static_factory_method(func_class, static_method_list,
                                           possible_target, max_target))
-        object_creation_list.append(_handle_object_creation(func_class, init_dict, possile_target, max_target))
+        object_creation_list.append(
+            _handle_object_creation(func_class, init_dict, possile_target,
+                                    max_target))
 
         for object_creation in object_creation_list:
             # Create possible target for all possible factory method

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -227,8 +227,7 @@ def _search_static_factory_method(classname, static_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.extend(
-                _handle_argument(argType.replace('$', '.'), None, None,
-                                 max_target, False))
+                _handle_argument(argType.replace('$', '.'), None, None, max_target, False))
 
         # Error in some parameters
         if len(arg_list) != len(func_elem['argTypes']):
@@ -291,8 +290,8 @@ def _search_factory_method(classname, static_method_list, possible_method_list,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.append(
-                _handle_argument(argType.replace('$', '.'), init_dict,
-                                 possible_target, max_target))
+                _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
+                                 max_target))
 
         if len(arg_list) != len(func_elem['argTypes']):
             continue
@@ -348,8 +347,7 @@ def _search_setting_method(method_list, target_class_name, target_method_name):
 
         arg_list = []
         for argType in func_elem['argTypes']:
-            arg = _handle_argument(argType.replace('$', '.'), None,
-                                   possible_target, max_target)
+            arg = _handle_argument(argType.replace('$', '.'), None, possible_target, max_target)
             if arg:
                 arg_list.append(arg[0])
         if len(arg_list) != len(func_elem['argTypes']):
@@ -382,8 +380,7 @@ def _search_concrete_subclass(classname,
                     result_list.append(func_elem)
             else:
                 for result in _search_concrete_subclass(
-                        func_elem['functionSourceFile'].replace('$', '.'),
-                        init_dict, handled):
+                        func_elem['functionSourceFile'].replace('$', '.'), init_dict, handled):
                     if result not in result_list:
                         result_list.append(result)
 
@@ -426,20 +423,17 @@ def _handle_object_creation(classname,
                     class_list.append(func_elem)
                 else:
                     class_list.extend(
-                        _search_concrete_subclass(classname, init_dict,
-                                                  handled))
+                        _search_concrete_subclass(classname, init_dict, handled))
                 if len(class_list) == 0:
                     return "new " + classname.replace("$", ".") + "()"
 
                 for elem in class_list:
-                    elem_classname = elem['functionSourceFile'].replace(
-                        '$', '.')
+                    elem_classname = elem['functionSourceFile'].replace('$', '.')
                     if elem in handled:
                         continue
                     handled.append(elem)
                     for argType in elem['argTypes']:
-                        arg = _handle_argument(argType.replace('$', '.'),
-                                               init_dict, possible_target,
+                        arg = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
                                                max_target, True, handled)
                         if arg:
                             arg_list.append(arg)
@@ -451,8 +445,8 @@ def _handle_object_creation(classname,
                         _handle_import(func_elem))
                     for args_item in list(itertools.product(*arg_list)):
                         result_list.append("new " +
-                                           elem_classname.replace("$", ".") +
-                                           "(" + ",".join(args_item) + ")")
+                                           elem_classname.replace("$", ".") + "(" +
+                                           ",".join(args_item) + ")")
                         if len(result_list) > max_target:
                             return result_list
             except RecursionError:
@@ -531,8 +525,8 @@ def _generate_heuristic_1(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None,
-                                        possible_target, max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
+                                        max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -583,8 +577,8 @@ def _generate_heuristic_2(yaml_dict, possible_targets, max_target):
 
         # Get all possible argument lists with different possible object creation combination
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), init_dict,
-                                        possible_target, max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), init_dict, possible_target,
+                                        max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -655,8 +649,8 @@ def _generate_heuristic_3(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None,
-                                        possible_target, max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
+                                        max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -722,8 +716,8 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
 
         # Store function parameter list
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), None,
-                                        possible_target, max_target)
+            arg_list = _handle_argument(argType.replace('$', '.'), None, possible_target,
+                                        max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
@@ -788,36 +782,31 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
         func_class = possible_target.function_class
 
         # Store function parameter list
-        # Skip this method is it does not take at least one
+        # Skip this method if it does not take at least one
         # enum object as parameter
-        enum_argument = False
         for argType in func_elem['argTypes']:
-            if _is_enum_class(init_dict, argType.replace('$', '.')):
-                enum_argument = True
             arg_list = _handle_argument(argType.replace('$', '.'),
                                         init_dict,
                                         possible_target,
-                                        max_target,
-                                        enum_object=True)
+                                        max_target)
             if arg_list:
                 possible_target.variables_to_add.append(arg_list[0])
 
         if len(possible_target.variables_to_add) != len(func_elem['argTypes']):
             continue
-        if not enum_argument:
-            continue
 
-        # Retrieve list of factory method for the target object
-        factory_method_list = _search_factory_method(func_class,
-                                                     static_method_list,
-                                                     instance_method_list,
-                                                     possible_target,
-                                                     init_dict, max_target)
-        factory_method_list.append(
+        # Retrieve list of factory method or constructor for the target object
+        object_creation_list = _search_factory_method(func_class,
+                                                      static_method_list,
+                                                      instance_method_list,
+                                                      possible_target,
+                                                      init_dict, max_target)
+        object_creation_list.append(
             _search_static_factory_method(func_class, static_method_list,
                                           possible_target, max_target))
+        object_creation_list.append(_handle_object_creation(func_class, init_dict, possile_target, max_target))
 
-        for factory_method in factory_method_list:
+        for object_creation in object_creation_list:
             # Create possible target for all possible factory method
             # Clone the base target object
             cloned_possible_target = FuzzTarget(orig=possible_target)
@@ -825,7 +814,7 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
             fuzzer_source_code += "  %s obj = %s;\n" % (func_class,
-                                                        factory_method)
+                                                        object_creation)
             for settings in _search_setting_method(instance_method_list,
                                                    func_class, func_name):
                 fuzzer_source_code += "  %s;\n" % (settings)
@@ -870,7 +859,7 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
         func_class = possible_target.function_class
 
         # Store function parameter list
-        # Skip this method is it does not take at least one
+        # Skip this method if it does not take at least one
         # enum object as parameter
         enum_argument = False
         for argType in func_elem['argTypes']:
@@ -890,16 +879,17 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
             continue
 
         # Retrieve list of factory method for the target object
-        factory_method_list = _search_factory_method(func_class,
-                                                     static_method_list,
-                                                     instance_method_list,
-                                                     possible_target,
-                                                     init_dict, max_target)
-        factory_method_list.append(
+        object_creation_list = _search_factory_method(func_class,
+                                                      static_method_list,
+                                                      instance_method_list,
+                                                      possible_target,
+                                                      init_dict, max_target)
+        object_creation_list.append(
             _search_static_factory_method(func_class, static_method_list,
                                           possible_target, max_target))
+        object_creation_list.append(_handle_object_creation(func_class, init_dict, possile_target, max_target))
 
-        for factory_method in factory_method_list:
+        for object_creation in object_creation_list:
             # Create possible target for all possible factory method
             # Clone the base target object
             cloned_possible_target = FuzzTarget(orig=possible_target)
@@ -907,7 +897,7 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
             # Create the actual source
             fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
             fuzzer_source_code += "  %s obj = %s;\n" % (func_class,
-                                                        factory_method)
+                                                        object_creation)
             fuzzer_source_code += "  obj.%s($VARIABLE$);\n" % (func_name)
             if len(cloned_possible_target.exceptions_to_handle) > 0:
                 fuzzer_source_code = "  try {\n" + fuzzer_source_code

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -46,11 +46,13 @@ class FuzzTarget:
             self.heuristics_used = orig.heuristics_used
         elif func_elem:
             # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
-            self.function_target = func_elem['functionName'].split('].')[1].split('(')[0]
-            self.function_class = func_elem['functionSourceFile'].replace('$', '.')
-            self.exceptions_to_handle.update(func_elem['JavaMethodInfo']['exceptions'])
+            self.function_target = func_elem['functionName'].split(
+                '].')[1].split('(')[0]
+            self.function_class = func_elem['functionSourceFile'].replace(
+                '$', '.')
+            self.exceptions_to_handle.update(
+                func_elem['JavaMethodInfo']['exceptions'])
             self.imports_to_add.update(_handle_import(func_elem))
-
 
     def __dict__(self):
         return {"function": self.function_target}
@@ -480,8 +482,8 @@ def _extract_method(yaml_dict):
         if "test" in func_elem['functionName']:
             continue
         if "jazzer" in func_elem[
-            'functionName'] or "fuzzerTestOneInput" in func_elem[
-                'functionName']:
+                'functionName'] or "fuzzerTestOneInput" in func_elem[
+                    'functionName']:
             continue
 
         # Add candidates to result lists
@@ -698,7 +700,8 @@ def _generate_heuristic_4(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-4"
 
-    init_dict, method_list, instance_method_list, static_method_list = _extract_method(yaml_dict)
+    init_dict, method_list, instance_method_list, static_method_list = _extract_method(
+        yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
@@ -764,7 +767,8 @@ def _generate_heuristic_6(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-6"
 
-    init_dict, method_list, instance_method_list, static_method_list = _extract_method(yaml_dict)
+    init_dict, method_list, instance_method_list, static_method_list = _extract_method(
+        yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return
@@ -845,7 +849,8 @@ def _generate_heuristic_8(yaml_dict, possible_targets, max_target):
     """
     HEURISTIC_NAME = "jvm-autofuzz-heuristics-8"
 
-    init_dict, method_list, instance_method_list, static_method_list = _extract_method(yaml_dict)
+    init_dict, method_list, instance_method_list, static_method_list = _extract_method(
+        yaml_dict)
     for func_elem in method_list:
         if len(possible_targets) > max_target:
             return


### PR DESCRIPTION
Currently, if a class have multiple constructors, only one of them are picked for object creation. This setting limits the possible choice of fuzzer generation. This PR change the logic to include all possible constructor choice for the target class.