### PR TITLE
Auto-fuzz: Add class variable handling

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import ossf.fuzz.introspector.soot.yaml.BranchProfile;
 import ossf.fuzz.introspector.soot.yaml.BranchSide;
 import ossf.fuzz.introspector.soot.yaml.Callsite;
+import ossf.fuzz.introspector.soot.yaml.ClassField;
 import ossf.fuzz.introspector.soot.yaml.FunctionConfig;
 import ossf.fuzz.introspector.soot.yaml.FunctionElement;
 import ossf.fuzz.introspector.soot.yaml.FuzzerConfig;
@@ -44,6 +45,7 @@ import soot.PackManager;
 import soot.Scene;
 import soot.SceneTransformer;
 import soot.SootClass;
+import soot.SootField;
 import soot.SootMethod;
 import soot.Transform;
 import soot.Unit;
@@ -464,6 +466,20 @@ class CustomSenceTransformer extends SceneTransformer {
         Iterator<SootClass> interfaces = sootClass.getInterfaces().snapshotIterator();
         while (interfaces.hasNext()) {
           methodInfo.addInterface(interfaces.next().getName());
+        }
+        Iterator<SootField> fields = sootClass.getFields().snapshotIterator();
+        while (fields.hasNext()) {
+            SootField field = fields.next();
+            ClassField classField = new ClassField();
+
+            classField.setFieldName(field.getName());
+            classField.setFieldType(field.getType().toString());
+            classField.setIsConcrete(field.isDeclared());
+            classField.setIsPublic(field.isPublic());
+            classField.setIsStatic(field.isStatic());
+            classField.setIsFinal(field.isFinal());
+
+            methodInfo.addClassField(classField);
         }
 
         element.setJavaMethodInfo(methodInfo);

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -469,17 +469,17 @@ class CustomSenceTransformer extends SceneTransformer {
         }
         Iterator<SootField> fields = sootClass.getFields().snapshotIterator();
         while (fields.hasNext()) {
-            SootField field = fields.next();
-            ClassField classField = new ClassField();
+          SootField field = fields.next();
+          ClassField classField = new ClassField();
 
-            classField.setFieldName(field.getName());
-            classField.setFieldType(field.getType().toString());
-            classField.setIsConcrete(field.isDeclared());
-            classField.setIsPublic(field.isPublic());
-            classField.setIsStatic(field.isStatic());
-            classField.setIsFinal(field.isFinal());
+          classField.setFieldName(field.getName());
+          classField.setFieldType(field.getType().toString());
+          classField.setIsConcrete(field.isDeclared());
+          classField.setIsPublic(field.isPublic());
+          classField.setIsStatic(field.isStatic());
+          classField.setIsFinal(field.isFinal());
 
-            methodInfo.addClassField(classField);
+          methodInfo.addClassField(classField);
         }
 
         element.setJavaMethodInfo(methodInfo);

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/ClassField.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/ClassField.java
@@ -1,0 +1,81 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package ossf.fuzz.introspector.soot.yaml;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ClassField {
+  private String fieldName;
+  private String fieldType;
+  private Boolean isConcrete;
+  private Boolean isPublic;
+  private Boolean isStatic;
+  private Boolean isFinal;
+
+  @JsonProperty("Name")
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public void setFieldName(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  @JsonProperty("Type")
+  public String getFieldType() {
+    return fieldType;
+  }
+
+  public void setFieldType(String fieldType) {
+    this.fieldType = fieldType;
+  }
+
+  @JsonProperty("concrete")
+  public Boolean isConcrete() {
+    return isConcrete;
+  }
+
+  public void setIsConcrete(Boolean isConcrete) {
+    this.isConcrete = isConcrete;
+  }
+
+  @JsonProperty("public")
+  public Boolean isPublic() {
+    return isPublic;
+  }
+
+  public void setIsPublic(Boolean isPublic) {
+    this.isPublic = isPublic;
+  }
+
+  @JsonProperty("static")
+  public Boolean isStatic() {
+    return isStatic;
+  }
+
+  public void setIsStatic(Boolean isStatic) {
+    this.isStatic = isStatic;
+  }
+
+  @JsonProperty("final")
+  public Boolean isFinal() {
+    return isFinal;
+  }
+
+  public void setIsFinal(Boolean isFinal) {
+    this.isFinal = isFinal;
+  }
+}

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
@@ -21,6 +21,7 @@ import java.util.List;
 public class JavaMethodInfo {
   private List<String> exceptions;
   private List<String> interfaces;
+  private List<ClassField> classFields;
   private String superClass;
   private Integer methodStatus;
   private Boolean isConcrete;
@@ -33,6 +34,7 @@ public class JavaMethodInfo {
   public JavaMethodInfo() {
     this.exceptions = new ArrayList<String>();
     this.interfaces = new ArrayList<String>();
+    this.classFields = new ArrayList<ClassField>();
     this.superClass = "";
     this.isConcrete = true;
     this.isJavaLibraryMethod = false;
@@ -72,6 +74,18 @@ public class JavaMethodInfo {
 
   public void setInterfaces(List<String> interfaces) {
     this.interfaces = interfaces;
+  }
+
+  public List<ClassField> getClassFields() {
+    return this.classFields;
+  }
+
+  public void addClassField(ClassField classField) {
+    this.classFields.add(classField);
+  }
+
+  public void setClassFields(List<ClassField> classFields) {
+    this.classFields = classFields;
   }
 
   public Boolean isConcrete() {


### PR DESCRIPTION
Some of the object creation can be done by referring to public static final class variable defined in that class. This methods allow the class developer create some default settings object. This PR includes these fields in the resulting data.yaml file to help the auto-fuzzing logic to generate code that are making use of these default class objects.