### PR TITLE
Auto-fuzz: Add missing fuzzer profile

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -347,9 +347,9 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     # Move data and data.yaml to working directory
     data_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
-                       "fuzzerLogFile-Fuzz1.data")
+                            "fuzzerLogFile-Fuzz1.data")
     yaml_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
-                       "fuzzerLogFile-Fuzz1.data.yaml")
+                            "fuzzerLogFile-Fuzz1.data.yaml")
     data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data")
     yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data.yaml")
     if os.path.isfile(data_src) and os.path.isfile(yaml_src):

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -346,13 +346,17 @@ def run_static_analysis_jvm(git_repo, basedir):
         pass
 
     # Move data and data.yaml to working directory
-    src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
+    data_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
+                       "fuzzerLogFile-Fuzz1.data")
+    yaml_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
                        "fuzzerLogFile-Fuzz1.data.yaml")
-    dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data.yaml")
-    if os.path.isfile(src):
+    data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data")
+    yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data.yaml")
+    if os.path.isfile(data_src) and os.path.isfile(yaml_src):
         ret = True
         try:
-            shutil.copy(src, dst)
+            shutil.copy(data_src, data_dst)
+            shutil.copy(yaml_src, yaml_dst)
         except:
             ret = False
     else:


### PR DESCRIPTION
In the current frontend java, the output fuzzerLogFile-XXX.data and fuzzerLogFile-XXX.data.yaml are created in the current working directory. The auto-fuzz manager for jvm will then copy the fuzzerLogFile-Fuzz1.data.yaml into the correct directory. The updated profiles data-loader logic of fuzz-introspector requires both fuzzerLogFile-Fuzz1.data and fuzzerLogFile-Fuzz1.data.yaml to read the profiles. Thus some project builds will fail and crash the batch process. This PR adds additional logic to also copy fuzzerLogFile-Fuzz1.data to the correct directory in order to accommodate the new fuzz-introspector data-loader logic.