### PR TITLE
Auto-fuzz: Fix logic to include concrete class

### DIFF
--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -25,6 +25,10 @@ MAVEN_PATH = "apache-maven-3.6.3/bin"
 GRADLE_HOME = "gradle-7.4.2"
 GRADLE_PATH = f"{GRADLE_HOME}/bin"
 
+# This is an user-controlled optios. If this is set to True, it will always
+# search for all subclasses of a target class when the auto-fuzz generation
+# handles object creation of the target class. Otherwise, the searching of
+# subclasses will only happen when the the target class is not concrete.
 SEARCH_SUBCLASS_FOR_OBJECT_CREATION = False
 
 git_repos = {

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -25,6 +25,8 @@ MAVEN_PATH = "apache-maven-3.6.3/bin"
 GRADLE_HOME = "gradle-7.4.2"
 GRADLE_PATH = f"{GRADLE_HOME}/bin"
 
+SEARCH_SUBCLASS_FOR_OBJECT_CREATION = False
+
 git_repos = {
     'python': [
         # 'https://github.com/davidhalter/parso',

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -491,10 +491,10 @@ def _handle_object_creation(classname,
 
                 if func_elem['JavaMethodInfo']['classConcrete']:
                     class_list.append(func_elem)
-                else:
-                    class_list.extend(
-                        _search_concrete_subclass(classname, init_dict,
-                                                  handled))
+
+                class_list.extend(
+                    _search_concrete_subclass(classname, init_dict,
+                                              handled))
                 if len(class_list) == 0:
                     return "new " + classname.replace("$", ".") + "()"
 

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -14,6 +14,7 @@
 
 import os
 import yaml
+import constants
 import itertools
 
 from typing import List, Set, Any
@@ -489,12 +490,14 @@ def _handle_object_creation(classname,
                 arg_list = []
                 class_list = []
 
+                concrete = False
                 if func_elem['JavaMethodInfo']['classConcrete']:
                     class_list.append(func_elem)
-
-                class_list.extend(
-                    _search_concrete_subclass(classname, init_dict,
-                                              handled))
+                    concrete = True
+                if not concrete or constants.SEARCH_SUBCLASS_FOR_OBJECT_CREATION:
+                    class_list.extend(
+                        _search_concrete_subclass(classname, init_dict,
+                                                  handled))
                 if len(class_list) == 0:
                     return "new " + classname.replace("$", ".") + "()"
 


### PR DESCRIPTION
Current logic will only search for possible subclasses if the target class is not concrete. This setting limits the options if the target class is concrete. This PR fixes this logic by adding an additional boolean constant to allow the user to choose if this searching is needed. If the new constant is true, the logic will search for subclasses no matter if the target class is concrete or not. Otherwise, it will remain the same as the current logic which only searches for subclasses if the target class is not concrete. This increases the possible combination for object creation under the polymorphism scheme of java.
This refers to jvm-autofuzz-heuristics-2-SP in the documentation.