### PR TITLE
Auto-fuzz: Fix primitive object array

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -158,8 +158,11 @@ do
   RUNTIME_CLASSPATH=$RUNTIME_CLASSPATH\$this_dir/$(basename $JARFILE):
 done
 
-BUILD_CLASSPATH=$BUILD_CLASSPATH:$JAZZER_API_PATH
-RUNTIME_CLASSPATH=$RUNTIME_CLASSPATH:\$this_dir
+# Retrieve apache-common-lang3 library
+wget -P $OUT/ https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar
+
+BUILD_CLASSPATH=$BUILD_CLASSPATH:$JAZZER_API_PATH:$OUT/commons-lang3-3.12.0.jar
+RUNTIME_CLASSPATH=$RUNTIME_CLASSPATH:\$this_dir/commons-lang3-3.12.0.jar:\$this_dir
 
 fuzzer="Fuzz1.java"
 fuzzer_basename="Fuzz1"
@@ -214,6 +217,7 @@ if __name__ == "__main__":
 
 def gen_base_fuzzer_jvm():
     BASE_FUZZER = """import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import org.apache.commons.lang3.ArrayUtils;
 /*IMPORTS*/
 public class Fuzz1 {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -169,24 +169,34 @@ def _handle_argument(argType,
     """Generate data creation statement for given argument type"""
     if argType == "int" or argType == "java.lang.Integer":
         return ["data.consumeInt(0,100)"]
-    elif argType == "int[]" or argType == "java.lang.Integer[]":
+    elif argType == "int[]":
         return ["data.consumeInts(100)"]
+    elif argType == "java.lang.Integer[]":
+        return ["ArrayUtils.toObject(data.consumeInts(100))"]
     elif argType == "boolean" or argType == "java.lang.Boolean":
         return ["data.consumeBoolean()"]
-    elif argType == "boolean[]" or argType == "java.lang.Boolean[]":
+    elif argType == "boolean[]":
         return ["data.consumeBooleans(100)"]
+    elif argType == "java.lang.Boolean[]":
+        return ["ArrayUtils.toObject(data.consumeBooleans(100))"]
     elif argType == "byte" or argType == "java.lang.Byte":
         return ["data.consumeByte()"]
-    elif argType == "byte[]" or argType == "java.lang.Byte[]":
+    elif argType == "byte[]":
         return ["data.consumeBytes(100)"]
+    elif argType == "java.lang.Byte[]":
+        return ["ArrayUtils.toObject(data.consumeBytes(100))"]
     elif argType == "short" or argType == "java.lang.Short":
         return ["data.consumeShort()"]
-    elif argType == "short[]" or argType == "java.lang.Short[]":
+    elif argType == "short[]":
         return ["data.consumeShorts(100)"]
+    elif argType == "java.lang.Short[]":
+        return ["ArrayUtils.toObject(data.consumeShorts(100))"]
     elif argType == "long" or argType == "java.lang.Long":
         return ["data.consumeLong()"]
-    elif argType == "long[]" or argType == "java.lang.Long[]":
+    elif argType == "long[]":
         return ["data.consumeLongs(100)"]
+    elif argType == "java.lang.Long[]":
+        return ["ArrayUtils.toObject(data.consumeLongs(100))"]
     elif argType == "float" or argType == "java.lang.Float":
         return ["data.consumeFloat()"]
     elif argType == "char" or argType == "java.lang.Character":

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -309,6 +309,12 @@ def run_static_analysis_jvm(git_repo, basedir):
     with tarfile.open("./jazzer.tar.gz") as f:
         f.extractall("./")
 
+    # Retrieve Apache Common Lang3 package
+    apache_url = "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+    response = requests.get(apache_url)
+    with open("./commons-lang3.jar", "wb") as f:
+        f.write(response.content)
+
     # Retrieve path of all jar files
     jarfiles.append(os.path.abspath("../Fuzz1.jar"))
     for root, _, files in os.walk(projectdir):

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -325,7 +325,7 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     # Compile and package fuzzer to jar file
     cmd = [
-        "javac -cp jazzer_standalone.jar:%s ../Fuzz1.java" %
+        "javac -cp jazzer_standalone.jar:commons-lang3.jar:%s ../Fuzz1.java" %
         ":".join(jarfiles), "jar cvf ../Fuzz1.jar ../Fuzz1.class"
     ]
     try:


### PR DESCRIPTION
In java, primitive types and their class objects will auto-box and auto-unbox, thus they can be used interchangeably. But an array of primitive type and array of its class object cannot be auto-boxed or auto-unboxed because that mechanism is only possible for each single primitive type. The current argument handling logic assumes those arrays are interchangeably and by default jazzer are only returning arrays of primitive types. This will cause compile error if class object array type are used. This PR fixes this error by using Apache Common Lang3 library to translate primitive type arrays to their respective class object arrays to avoid the compilation error