### PR TITLE
Auto-fuzz: Add build support to ant based project

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -106,10 +106,13 @@ WORKDIR $SRC/%s
 def gen_dockerfile_jvm(github_url, project_name):
     DOCKER_STEPS = """FROM gcr.io/oss-fuzz-base/base-builder-jvm
 #RUN curl -L https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
+COPY ant.zip $SRC/ant.zip
 COPY maven.zip $SRC/maven.zip
 COPY gradle.zip $SRC/gradle.zip
+RUN unzip ant.zip -d $SRC/ant && rm ./ant.zip
 RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
 RUN unzip gradle.zip -d $SRC/gradle && rm ./gradle.zip
+ENV ANT $SRC/ant/apache-ant-1.9.16/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
 ENV PATH="$SRC/gradle/gradle-7.4.2/bin:$PATH"
@@ -143,9 +146,12 @@ elif test -f "pom.xml"
 then
   MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
   $MVN clean package $MAVEN_ARGS
+elif test -f "build.xml"
+then
+  $ANT
 else
   echo "Unknown project type"
-  return 127
+  exit 127
 fi
 
 BUILD_CLASSPATH=

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -18,9 +18,11 @@ MAX_THREADS = 4
 
 BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
 
+ANT_URL = "https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip"
 MAVEN_URL = "https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
 GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"
 
+ANT_PATH = "apache-ant-1.9.16/bin"
 MAVEN_PATH = "apache-maven-3.6.3/bin"
 GRADLE_HOME = "gradle-7.4.2"
 GRADLE_PATH = f"{GRADLE_HOME}/bin"

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -41,6 +41,7 @@ git_repos = {
     ],
     'jvm': [
         # 'https://github.com/eclipse-ee4j/angus-mail',
-        'https://github.com/jboss-javassist/javassist'
+        # 'https://github.com/jboss-javassist/javassist'
+        'https://github.com/tukaani-project/xz-java'
     ]
 }

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -206,6 +206,35 @@ def run_static_analysis_python(git_repo, basedir):
     return ret
 
 
+def _ant_build_project(basedir, projectdir):
+    """Helper method to build project using ant"""
+    # Prepare maven
+    with zipfile.ZipFile(os.path.join(basedir, "ant.zip"), "r") as af:
+        af.extractall(basedir)
+
+    # Set environment variable
+    env_var = os.environ.copy()
+    env_var['PATH'] = os.path.join(
+        basedir, constants.ANT_PATH) + ":" + env_var['PATH']
+
+    # Build project with maven
+    cmd = ["ant"]
+    try:
+        subprocess.check_call(" ".join(cmd),
+                              shell=True,
+                              timeout=1800,
+                              stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL,
+                              env=env_var,
+                              cwd=projectdir)
+    except subprocess.TimeoutExpired:
+        return False
+    except subprocess.CalledProcessError:
+        return False
+
+    return True
+
+
 def _maven_build_project(basedir, projectdir):
     """Helper method to build project using maven"""
     # Prepare maven
@@ -292,13 +321,19 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     projectdir = os.path.join(basedir, "work", "proj")
 
-    if os.path.exists(os.path.join(projectdir, "pom.xml")):
+    if os.path.exists(os.path.join(projectdir, "build.xml")):
+        # Ant project
+        build_ret = _ant_build_project(basedir, projectdir)
+        project_type = "ant"
+    elif os.path.exists(os.path.join(projectdir, "pom.xml")):
         # Maven project
         build_ret = _maven_build_project(basedir, projectdir)
+        project_type = "maven"
     elif os.path.exists(os.path.join(projectdir, "build.gradle")):
         # Gradle project
         build_ret = _gradle_build_project(basedir, projectdir)
         jarfiles.append(os.path.join(projectdir, "proj.jar"))
+        project_type = "gradle"
     else:
         # Unknown project type
         print("Unknown project type.\n")
@@ -327,11 +362,16 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     # Retrieve path of all jar files
     jarfiles.append(os.path.abspath("../Fuzz1.jar"))
-    for root, _, files in os.walk(projectdir):
-        if "target" in root:
-            for file in files:
-                if file.endswith(".jar"):
-                    jarfiles.append(os.path.abspath(os.path.join(root, file)))
+    if project_type == "ant":
+        for file in os.listdir(os.path.join(projectdir, "build", "jar")):
+            if file.endswith(".jar"):
+                jarfiles.append(os.path.join(projectdir, "build", "jar", file))
+    else:
+        for root, _, files in os.walk(projectdir):
+            if "target" in root:
+                for file in files:
+                    if file.endswith(".jar"):
+                        jarfiles.append(os.path.abspath(os.path.join(root, file)))
 
     # Compile and package fuzzer to jar file
     cmd = [
@@ -353,6 +393,7 @@ def run_static_analysis_jvm(git_repo, basedir):
         "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz1"
     ]
     try:
+        print(cmd)
         subprocess.check_call(" ".join(cmd),
                               shell=True,
                               timeout=1800,
@@ -448,6 +489,10 @@ def build_and_test_single_possible_target(idx_folder,
     copy_core_oss_fuzz_project_files(oss_fuzz_base_project,
                                      dst_oss_fuzz_project)
     if language == "jvm":
+        ant_path = os.path.join(oss_fuzz_base_project.project_folder,
+                                "ant.zip")
+        ant_dst = os.path.join(dst_oss_fuzz_project.project_folder,
+                               "ant.zip")
         maven_path = os.path.join(oss_fuzz_base_project.project_folder,
                                   "maven.zip")
         maven_dst = os.path.join(dst_oss_fuzz_project.project_folder,
@@ -456,6 +501,7 @@ def build_and_test_single_possible_target(idx_folder,
                                    "gradle.zip")
         gradle_dst = os.path.join(dst_oss_fuzz_project.project_folder,
                                   "gradle.zip")
+        shutil.copy(ant_path, ant_dst)
         shutil.copy(maven_path, maven_dst)
         shutil.copy(gradle_path, gradle_dst)
 
@@ -521,7 +567,7 @@ def build_and_test_single_possible_target(idx_folder,
         if not os.path.isdir(full_path):
             continue
 
-        files_to_cleanup = ['maven.zip', 'gradle.zip']
+        files_to_cleanup = ['ant.zip', 'maven.zip', 'gradle.zip']
         for filename in files_to_cleanup:
             # Auto-fuzz path
             autofuzz_filename_path = os.path.join(auto_fuzz_proj_dir, filename)
@@ -642,9 +688,15 @@ def autofuzz_project_from_github(github_url,
                          oss_fuzz_base_project.project_name)):
         return False
 
-    # If this is a jvm target download maven and gradle once so we don't
+    # If this is a jvm target download ant, maven and gradle once so we don't
     # have to do it for each proejct.
     if language == "jvm":
+        # Download Ant
+        target_ant_path = os.path.join(oss_fuzz_base_project.project_folder,
+                                       "ant.zip")
+        with open(target_ant_path, 'wb') as mf:
+            mf.write(requests.get(constants.ANT_URL).content)
+
         # Download Maven
         target_maven_path = os.path.join(oss_fuzz_base_project.project_folder,
                                          "maven.zip")

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -321,11 +321,7 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     projectdir = os.path.join(basedir, "work", "proj")
 
-    if os.path.exists(os.path.join(projectdir, "build.xml")):
-        # Ant project
-        build_ret = _ant_build_project(basedir, projectdir)
-        project_type = "ant"
-    elif os.path.exists(os.path.join(projectdir, "pom.xml")):
+    if os.path.exists(os.path.join(projectdir, "pom.xml")):
         # Maven project
         build_ret = _maven_build_project(basedir, projectdir)
         project_type = "maven"
@@ -334,6 +330,10 @@ def run_static_analysis_jvm(git_repo, basedir):
         build_ret = _gradle_build_project(basedir, projectdir)
         jarfiles.append(os.path.join(projectdir, "proj.jar"))
         project_type = "gradle"
+    elif os.path.exists(os.path.join(projectdir, "build.xml")):
+        # Ant project
+        build_ret = _ant_build_project(basedir, projectdir)
+        project_type = "ant"
     else:
         # Unknown project type
         print("Unknown project type.\n")
@@ -393,7 +393,6 @@ def run_static_analysis_jvm(git_repo, basedir):
         "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz1"
     ]
     try:
-        print(cmd)
         subprocess.check_call(" ".join(cmd),
                               shell=True,
                               timeout=1800,

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -214,8 +214,8 @@ def _ant_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['PATH'] = os.path.join(
-        basedir, constants.ANT_PATH) + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(basedir,
+                                   constants.ANT_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = ["ant"]
@@ -371,7 +371,8 @@ def run_static_analysis_jvm(git_repo, basedir):
             if "target" in root:
                 for file in files:
                     if file.endswith(".jar"):
-                        jarfiles.append(os.path.abspath(os.path.join(root, file)))
+                        jarfiles.append(
+                            os.path.abspath(os.path.join(root, file)))
 
     # Compile and package fuzzer to jar file
     cmd = [
@@ -490,8 +491,7 @@ def build_and_test_single_possible_target(idx_folder,
     if language == "jvm":
         ant_path = os.path.join(oss_fuzz_base_project.project_folder,
                                 "ant.zip")
-        ant_dst = os.path.join(dst_oss_fuzz_project.project_folder,
-                               "ant.zip")
+        ant_dst = os.path.join(dst_oss_fuzz_project.project_folder, "ant.zip")
         maven_path = os.path.join(oss_fuzz_base_project.project_folder,
                                   "maven.zip")
         maven_dst = os.path.join(dst_oss_fuzz_project.project_folder,


### PR DESCRIPTION
Some projects are found to be using ant project environment instead of maven or gradle. This PR adds build support to those project. When build.xml (ant project build property) is found, ant building logic are used.