### PR TITLE
Auto-fuzz: Change old jdk to newer one for maven project

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -153,6 +153,7 @@ do
       break
     elif test -f "pom.xml"
     then
+      sed -i 's/>1.5</>1.8</g' pom.xml
       MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
       $MVN clean package $MAVEN_ARGS
       SUCCESS=true

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -249,6 +249,21 @@ def _maven_build_project(basedir, projectdir):
     env_var['PATH'] = os.path.join(
         basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
 
+    # Patch pom.xml to use at least jdk 1.8
+    cmd = ["sed", "-i", "'s/>1.5</>1.8</g'", "pom.xml"]
+    try:
+        subprocess.check_call(" ".join(cmd),
+                              shell=True,
+                              timeout=1800,
+                              stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL,
+                              env=env_var,
+                              cwd=projectdir)
+    except subprocess.TimeoutExpired:
+        return False
+    except subprocess.CalledProcessError:
+        return False
+
     # Build project with maven
     cmd = [
         "mvn clean package", "-DskipTests", "-Djavac.src.version=15",


### PR DESCRIPTION
Some projects set the maven build source and execution target to jdk 1.5 which is too old for the maven installed in the docker. This PR patches the project's pom.xml before build to make it use jdk 1.8 instead, which is still backward compatible with code in jdk 1.5.