### PR TITLE
Auto-fuzz: Fix java classpath too long problem

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -78,7 +78,7 @@ public class CallGraphGenerator {
       System.err.println("No jarFiles, entryClass or entryMethod.");
       return;
     }
-    List<String> jarFiles = Arrays.asList(args[0].split(":"));
+    List<String> jarFiles = CallGraphGenerator.handleJarFilesWildcard(Arrays.asList(args[0].split(":")));
     String entryClass = args[1];
     String entryMethod = args[2];
     String includePrefix = "";
@@ -139,6 +139,26 @@ public class CallGraphGenerator {
 
     // Start the generation
     PackManager.v().runPacks();
+  }
+
+  public static List<String> handleJarFilesWildcard(List<String> jarFiles) {
+    List<String> resultList = new LinkedList<String>();
+    for (String jarFile : jarFiles) {
+      if (jarFile.endsWith("*.jar")) {
+        File dir = new File(jarFile.substring(0, jarFile.lastIndexOf("/")));
+        if (dir.isDirectory()) {
+          for (File file : dir.listFiles()) {
+            String fileName = file.getAbsolutePath();
+            if (fileName.endsWith(".jar")) {
+              resultList.add(fileName);
+            }
+          }
+        }
+      } else {
+        resultList.add(jarFile);
+      }
+    }
+    return resultList;
   }
 }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -78,7 +78,8 @@ public class CallGraphGenerator {
       System.err.println("No jarFiles, entryClass or entryMethod.");
       return;
     }
-    List<String> jarFiles = CallGraphGenerator.handleJarFilesWildcard(Arrays.asList(args[0].split(":")));
+    List<String> jarFiles =
+        CallGraphGenerator.handleJarFilesWildcard(Arrays.asList(args[0].split(":")));
     String entryClass = args[1];
     String entryMethod = args[2];
     String includePrefix = "";

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -402,13 +402,18 @@ def run_static_analysis_jvm(git_repo, basedir):
     if project_type == "ant":
         for file in os.listdir(os.path.join(builddir, "build", "jar")):
             if file.endswith(".jar"):
-                shutil.copyfile(os.path.join(builddir, "build", "jar", file), os.path.join(jardir, file))
+                shutil.copyfile(os.path.join(builddir, "build", "jar", file),
+                                os.path.join(jardir, file))
     else:
         for root, _, files in os.walk(builddir):
             if "target" in root:
                 for file in files:
-                    if file.endswith(".jar") and "SNAPSHOT" not in file and "sources" not in file:
-                        shutil.copyfile(os.path.abspath(os.path.join(root, file)), os.path.join(jardir, file))
+                    if file.endswith(
+                            ".jar"
+                    ) and "SNAPSHOT" not in file and "sources" not in file:
+                        shutil.copyfile(
+                            os.path.abspath(os.path.join(root, file)),
+                            os.path.join(jardir, file))
 
     # Compile and package fuzzer to jar file
     cmd = [

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -356,6 +356,7 @@ def run_static_analysis_jvm(git_repo, basedir):
     os.chdir(basedir)
     os.mkdir("work")
     os.chdir("work")
+    os.mkdir("jar")
 
     # Clone the project
     cmd = ["git clone --depth=1", git_repo, "proj"]
@@ -368,6 +369,7 @@ def run_static_analysis_jvm(git_repo, basedir):
     except subprocess.TimeoutExpired:
         pass
 
+    jardir = os.path.join(basedir, "work", "jar")
     projectdir = os.path.join(basedir, "work", "proj")
 
     project_type, build_ret, builddir, jarfiles = build_jvm_project(
@@ -396,17 +398,17 @@ def run_static_analysis_jvm(git_repo, basedir):
 
     # Retrieve path of all jar files
     jarfiles.append(os.path.abspath("../Fuzz1.jar"))
+    jarfiles.append("%s/*.jar" % jardir)
     if project_type == "ant":
         for file in os.listdir(os.path.join(builddir, "build", "jar")):
             if file.endswith(".jar"):
-                jarfiles.append(os.path.join(builddir, "build", "jar", file))
+                shutil.copyfile(os.path.join(builddir, "build", "jar", file), os.path.join(jardir, file))
     else:
         for root, _, files in os.walk(builddir):
             if "target" in root:
                 for file in files:
-                    if file.endswith(".jar"):
-                        jarfiles.append(
-                            os.path.abspath(os.path.join(root, file)))
+                    if file.endswith(".jar") and "SNAPSHOT" not in file and "sources" not in file:
+                        shutil.copyfile(os.path.abspath(os.path.join(root, file)), os.path.join(jardir, file))
 
     # Compile and package fuzzer to jar file
     cmd = [


### PR DESCRIPTION
Some project build a lot of jar files and the long list of jar files path make the shell fail to run because it exceeds the argument length setting of the bash shell. This PR fixes the arguments by introducing wildcard for the class path to decrease the length of the frontend execution command.