### PR TITLE
Auto-fuzz: Fix missing dependency commit in shallow clone

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -372,7 +372,7 @@ def run_static_analysis_jvm(git_repo, basedir):
     os.mkdir("jar")
 
     # Clone the project
-    cmd = ["git clone --depth=1", git_repo, "proj"]
+    cmd = ["git clone", git_repo, "proj"]
     try:
         subprocess.check_call(" ".join(cmd),
                               shell=True,


### PR DESCRIPTION
For some of the gradle projects build properties, there exists some self-module dependencies which are referring to older commit. So those dependencies will be missing if git shallow clone is used. This PR fixes the git clone command to avoid shallow clone and preserve the whole commit tree for those self-module dependencies.