### PR TITLE
Auto-fuzz: Fix empty static method list bug

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -603,8 +603,6 @@ def _extract_method(yaml_dict):
             continue
 
         # Skip excluded methods
-        if func_elem['JavaMethodInfo']['static']:
-            continue
         if not func_elem['JavaMethodInfo']['public']:
             continue
         if not func_elem['JavaMethodInfo']['concrete']:


### PR DESCRIPTION
Fix the bug where static method list are empty because of a wrong skipping of static methods.