### PR TITLE
JVM Integration: Fix logic to allow specifying target package prefix 

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -72,14 +72,7 @@ def find_fuzz_targets(path):
 
       # If wrapper script exists, retrieve the java class with package name
       classname = content.split("--target_class=")[1].split(" ")[0]
-
-      # If wrapper script exists, retrieve target analysing package name if exists
-      # If ##PACKAGE_NAME##[package]##PACKAGE_NAME## exists, java frontend will
-      # only handle classes in that package, plus all the sink classes
-      if "##PACKAGE_NAME##" in content:
-        packagename = content.split("##PACKAGE_NAME##")[1]
-
-      targets.append((classname, packagename))
+      targets.append(classname)
 
       # If classfile exists, pack it to jar file
       for root, _, files in os.walk(path):
@@ -111,13 +104,15 @@ def get_all_jar_files(path):
   return jar_files
 
 
-def run_introspector_frontend(target, jar_set):
+def run_introspector_frontend(target_class, jar_set):
   """Call into the frontend for analysing java targets. The output of this
   is a set of *.data and *.data.yaml files in the current directory.
   """
-  target_class, package = target
   print("Running introspector frontend on %s :: %s" % (target_class, jar_set))
   jarfile_str = ":".join(jar_set)
+  package_name = os.getenv("TARGET_PACKAGE_PREFIX")
+  if not package_name:
+    package_name = "ALL"
   cmd = [
       "java",
       "-Xmx6144M",
@@ -126,7 +121,7 @@ def run_introspector_frontend(target, jar_set):
       CGRAPH_STR,
       jarfile_str,
       target_class,
-      package,
+      package_name,
       "fuzzerTestOneInput", # entrymethod
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -94,7 +94,7 @@ fi
 if [ -z $PACKAGEPREFIX ]
 then
     echo "No target package prefix defined, analysing all packages"
-    PACKAGEPREFIX="*"
+    PACKAGEPREFIX="ALL"
 fi
 
 # Build and execute the call graph generator

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -49,6 +49,11 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -p|--package)
+      PACKAGEPREFIX="$2"
+      shift
+      shift
+      ;;
     *)
       echo "Unknown option $1"
       exit 1
@@ -86,6 +91,11 @@ then
     echo "No sink method list defined, using default sink method list"
     SINKMETHOD="[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:[javax.xml.xpath.XPath].evaluate:[java.lang.Thread].run:[java.lang.Runnable].run:[java.util.concurrent.Executor].execute:[java.util.concurrent.Callable].call:[java.lang.System].console:[java.lang.System].load:[java.lang.System].loadLibrary:[java.lang.System].apLibraryName:[java.lang.System].runFinalization:[java.lang.System].setErr:[java.lang.System].setIn:[java.lang.System].setOut:[java.lang.System].setProperties:[java.lang.System].setProperty:[java.lang.System].setSecurityManager:[java.lang.ProcessBuilder].directory:[java.lang.ProcessBuilder].inheritIO:[java.lang.ProcessBuilder].command:[java.lang.ProcessBuilder].redirectError:[java.lang.ProcessBuilder].redirectErrorStream:[java.lang.ProcessBuilder].redirectInput:[java.lang.ProcessBuilder].redirectOutput:[java.lang.ProcessBuilder].start"
 fi
+if [ -z $PACKAGEPREFIX ]
+then
+    echo "No target package prefix defined, analysing all packages"
+    PACKAGEPREFIX="*"
+fi
 
 # Build and execute the call graph generator
 mvn clean package -Dmaven.test.skip
@@ -94,5 +104,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
 done

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -86,12 +86,11 @@ public class CallGraphGenerator {
     String includePrefix = "";
     String excludePrefix = "";
     String sinkMethod = "";
-    if (args.length == 4) {
+    if (args.length == 5) {
       includePrefix = args[4].split("===")[0];
       excludePrefix = args[4].split("===")[1];
       sinkMethod = args[4].split("===")[2];
     }
-
     if (jarFiles.size() < 1) {
       System.err.println("Invalid jarFiles");
     }
@@ -197,7 +196,7 @@ class CustomSenceTransformer extends SceneTransformer {
     sinkMethodMap = new HashMap<String, Set<String>>();
     methodList = new FunctionConfig();
 
-    if (!targetPackagePrefix.equals("*")) {
+    if (!targetPackagePrefix.equals("ALL")) {
       for (String targetPackage : targetPackagePrefix.split(":")) {
         if (!targetPackage.equals("")) {
           targetPackageList.add(targetPackage);
@@ -209,6 +208,7 @@ class CustomSenceTransformer extends SceneTransformer {
         includeList.add(include);
       }
     }
+    includeList.add(entryClassStr);
     for (String exclude : excludePrefix.split(":")) {
       if (!exclude.equals("")) {
         excludeList.add(exclude);
@@ -279,7 +279,7 @@ class CustomSenceTransformer extends SceneTransformer {
       // of the target package
       // If target package prefix has been specified and the
       // classes are not in those package, ignore it
-      if (!isIgnore && !isSinkClass) {
+      if (!isIgnore && !isSinkClass && !isInclude && this.hasTargetPackage()) {
         boolean targetPackage = false;
         for (String prefix : targetPackageList) {
           if (cname.startsWith(prefix.replace("*", ""))) {

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -74,21 +74,22 @@ import soot.toolkits.graph.UnitGraph;
 public class CallGraphGenerator {
   public static void main(String[] args) {
     System.out.println("[Callgraph] Running callgraph plugin");
-    if (args.length < 3 || args.length > 4) {
-      System.err.println("No jarFiles, entryClass or entryMethod.");
+    if (args.length < 4 || args.length > 5) {
+      System.err.println("No jarFiles, entryClass, entryMethod and target package.");
       return;
     }
     List<String> jarFiles =
         CallGraphGenerator.handleJarFilesWildcard(Arrays.asList(args[0].split(":")));
     String entryClass = args[1];
     String entryMethod = args[2];
+    String targetPackagePrefix = args[3];
     String includePrefix = "";
     String excludePrefix = "";
     String sinkMethod = "";
     if (args.length == 4) {
-      includePrefix = args[3].split("===")[0];
-      excludePrefix = args[3].split("===")[1];
-      sinkMethod = args[3].split("===")[2];
+      includePrefix = args[4].split("===")[0];
+      excludePrefix = args[4].split("===")[1];
+      sinkMethod = args[4].split("===")[2];
     }
 
     if (jarFiles.size() < 1) {
@@ -102,7 +103,7 @@ public class CallGraphGenerator {
     // Add an custom analysis phase to Soot
     CustomSenceTransformer custom =
         new CustomSenceTransformer(
-            entryClass, entryMethod, includePrefix, excludePrefix, sinkMethod);
+            entryClass, entryMethod, targetPackagePrefix, includePrefix, excludePrefix, sinkMethod);
     PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
 
     // Set basic settings for the call graph generation
@@ -164,6 +165,7 @@ public class CallGraphGenerator {
 }
 
 class CustomSenceTransformer extends SceneTransformer {
+  private List<String> targetPackageList;
   private List<String> includeList;
   private List<String> excludeList;
   private List<String> excludeMethodList;
@@ -178,6 +180,7 @@ class CustomSenceTransformer extends SceneTransformer {
   public CustomSenceTransformer(
       String entryClassStr,
       String entryMethodStr,
+      String targetPackagePrefix,
       String includePrefix,
       String excludePrefix,
       String sinkMethod) {
@@ -185,6 +188,7 @@ class CustomSenceTransformer extends SceneTransformer {
     this.entryMethodStr = entryMethodStr;
     this.entryMethod = null;
 
+    targetPackageList = new LinkedList<String>();
     includeList = new LinkedList<String>();
     excludeList = new LinkedList<String>();
     excludeMethodList = new LinkedList<String>();
@@ -193,6 +197,13 @@ class CustomSenceTransformer extends SceneTransformer {
     sinkMethodMap = new HashMap<String, Set<String>>();
     methodList = new FunctionConfig();
 
+    if (!targetPackagePrefix.equals("*")) {
+      for (String targetPackage : targetPackagePrefix.split(":")) {
+        if (!targetPackage.equals("")) {
+          targetPackageList.add(targetPackage);
+        }
+      }
+    }
     for (String include : includePrefix.split(":")) {
       if (!include.equals("")) {
         includeList.add(include);
@@ -239,12 +250,18 @@ class CustomSenceTransformer extends SceneTransformer {
       SootClass c = classIterator.next();
       String cname = c.getName();
 
+      // Check for a list of classes of prefixes that must handled
       for (String prefix : includeList) {
-        if (cname.startsWith(prefix)) {
+        if (cname.startsWith(prefix.replace("*", ""))) {
           isInclude = true;
           break;
         }
       }
+
+      // Check if remaining classes are in the exclude list
+      // Or if it is a class contains sink method
+      // If the class is in the exclude list and are not classes
+      // that contains sink method, ignore it
       if (!isInclude) {
         for (String prefix : excludeList) {
           if (cname.startsWith(prefix.replace("*", ""))) {
@@ -255,6 +272,23 @@ class CustomSenceTransformer extends SceneTransformer {
             }
             break;
           }
+        }
+      }
+
+      // Check if the remaining classes have a prefix of one
+      // of the target package
+      // If target package prefix has been specified and the
+      // classes are not in those package, ignore it
+      if (!isIgnore && !isSinkClass) {
+        boolean targetPackage = false;
+        for (String prefix : targetPackageList) {
+          if (cname.startsWith(prefix.replace("*", ""))) {
+            targetPackage = true;
+            break;
+          }
+        }
+        if (!targetPackage) {
+          isIgnore = true;
         }
       }
 
@@ -909,6 +943,10 @@ class CustomSenceTransformer extends SceneTransformer {
     branchSide.setBranchSideFuncs(getFunctionCallInTargetLine(functionLineMap, start, end));
 
     return branchSide;
+  }
+
+  public Boolean hasTargetPackage() {
+    return (targetPackageList.size() > 0);
   }
 
   public List<String> getIncludeList() {

--- a/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
+++ b/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
@@ -16,21 +16,21 @@ public class CustomSenceTransformerTest {
 
   @Test
   public void testBasic() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "", "", "", "");
+    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "ALL", "", "", "");
     assertTrue(custom instanceof SceneTransformer);
     assertTrue(custom instanceof CustomSenceTransformer);
-    assertEquals(custom.getIncludeList().size(), 0);
+    assertEquals(custom.getIncludeList().size(), 1);
     assertEquals(custom.getExcludeList().size(), 0);
   }
 
   @Test
   public void testExcludePrefix() {
     CustomSenceTransformer custom =
-        new CustomSenceTransformer("", "", "", "abc:def:ghi", "jkl:mno:pqr", "");
-    assertEquals(custom.getIncludeList().size(), 3);
+        new CustomSenceTransformer("", "", "ALL", "abc:def:ghi", "jkl:mno:pqr", "");
+    assertEquals(custom.getIncludeList().size(), 4);
     assertEquals(custom.getExcludeList().size(), 3);
     Object[] eexpected = {"jkl", "mno", "pqr"};
-    Object[] iexpected = {"abc", "def", "ghi"};
+    Object[] iexpected = {"abc", "def", "ghi", ""};
     assertArrayEquals(custom.getIncludeList().toArray(), iexpected);
     assertArrayEquals(custom.getExcludeList().toArray(), eexpected);
   }

--- a/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
+++ b/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
@@ -16,7 +16,7 @@ public class CustomSenceTransformerTest {
 
   @Test
   public void testBasic() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "", "", "");
+    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "", "", "", "");
     assertTrue(custom instanceof SceneTransformer);
     assertTrue(custom instanceof CustomSenceTransformer);
     assertEquals(custom.getIncludeList().size(), 0);
@@ -26,7 +26,7 @@ public class CustomSenceTransformerTest {
   @Test
   public void testExcludePrefix() {
     CustomSenceTransformer custom =
-        new CustomSenceTransformer("", "", "abc:def:ghi", "jkl:mno:pqr", "");
+        new CustomSenceTransformer("", "", "", "abc:def:ghi", "jkl:mno:pqr", "");
     assertEquals(custom.getIncludeList().size(), 3);
     assertEquals(custom.getExcludeList().size(), 3);
     Object[] eexpected = {"jkl", "mno", "pqr"};


### PR DESCRIPTION
In the current logic, the fuzz-introspector will gather all jar files built and analyse all classes in them and exclude some well known library classes. If there is some java based oss-fuzz project that generates a large list of dependencies and include them as jar files in the output directory, those dependencies are also analysed by fuzz-introspector if their package name is not specifically excluded. This setting actually creates a large overhead by analysing classes which are not part of the target project itself. Indeed, may project runs into OOM or timeout during fuzz-introspector processing because of this reason. This PR aims to decrease the overhead by allowing the project specifying its package prefix and fuzz-introspector will only go through classes with the specified package prefix. If no package prefix has been specified, then it will work like before, in which the fuzz-introspector will analyse all classes in all jar files. This setting is used to be backward compatible for projects which do not specify the package prefix.
In order to apply the new package prefix specification, an environment variable TARGET_PACKAGE_PREFIX is needed to specify a list of target package prefix, the list should be separated by : if more than one target package prefix is used.