### PR TITLE
Auto-fuzz: Fix maven dependency

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -154,7 +154,7 @@ do
     elif test -f "pom.xml"
     then
       sed -i 's/>1.5</>1.8</g' pom.xml
-      MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
+      MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15 --update-snapshots"
       $MVN clean package $MAVEN_ARGS
       SUCCESS=true
       break

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -267,7 +267,8 @@ def _maven_build_project(basedir, projectdir):
     # Build project with maven
     cmd = [
         "mvn clean package", "-DskipTests", "-Djavac.src.version=15",
-        "-Djavac.target.version=15", "-Dmaven.javadoc.skip=true"
+        "-Djavac.target.version=15", "-Dmaven.javadoc.skip=true",
+        "--update-snapshots"
     ]
     try:
         subprocess.check_call(" ".join(cmd),


### PR DESCRIPTION
In some cases, the maven dependencies may fail to download from the maven repository for some reason. By default, those fail are cached and the maven logic won't retry until changes occur in the project or designated time period has been passed. That may block a normal project on retrieving the dependency if previous attempts fail because of any reason unrelated to the code itself. This PR fixes this problem by adding parameters to force maven to update dependency when building the project.