### PR TITLE
Auto-fuzz: Fix javac version

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -156,6 +156,11 @@ do
       sed -i 's/>1.5</>1.8</g' pom.xml
       MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
       $MVN clean package $MAVEN_ARGS
+      if [[ $? != "0" ]]
+      then
+        MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=8 -Djavac.target.version=8 --update-snapshots"
+        $MVN clean package $MAVEN_ARGS
+      fi
       SUCCESS=true
       break
     elif test -f "build.xml"
@@ -166,6 +171,12 @@ do
     fi
   fi
 done
+
+if [[ $? != "0" ]]
+then
+  echo "Unknown project type"
+  exit 127
+fi
 
 if [ "$SUCCESS" = false ]
 then

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -264,7 +264,7 @@ def _maven_build_project(basedir, projectdir):
     except subprocess.CalledProcessError:
         return False
 
-    # Build project with maven
+    # Build project with maven with javac version 15
     cmd = [
         "mvn clean package", "-DskipTests", "-Djavac.src.version=15",
         "-Djavac.target.version=15", "-Dmaven.javadoc.skip=true"
@@ -280,7 +280,25 @@ def _maven_build_project(basedir, projectdir):
     except subprocess.TimeoutExpired:
         return False
     except subprocess.CalledProcessError:
-        return False
+        # Fail to build project with javac version 15,
+        # try javac version 8 instead
+        cmd = [
+            "mvn clean package", "-DskipTests", "-Djavac.src.version=8",
+            "-Djavac.target.version=8", "-Dmaven.javadoc.skip=true",
+            "--update-snapshots"
+        ]
+        try:
+            subprocess.check_call(" ".join(cmd),
+                                  shell=True,
+                                  timeout=1800,
+                                  stdout=subprocess.DEVNULL,
+                                  stderr=subprocess.DEVNULL,
+                                  env=env_var,
+                                  cwd=projectdir)
+        except subprocess.TimeoutExpired:
+            return False
+        except subprocess.CalledProcessError:
+            return False
 
     return True
 


### PR DESCRIPTION
Some projects may be based on older java versions, thus forcing it to build with javac version 15 in maven may result in error. The auto-fuzz module can support as old as java version 1.8. This PR fixes the logic for maven build by using javac version 1.8 in the maven argument to build the project if the project failed to build with javac version 15.