### PR TITLE
auto-fuzz: refine python heuristic

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_python.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_python.py
@@ -402,9 +402,6 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             if init_name == elem['functionName']:
                 init_elem = elem
 
-        if init_elem is None:
-            continue
-
         # Strip some prefixes off
         try:
             class_path = give_right_path(class_path)


### PR DESCRIPTION
Not all classes have `__init__` functions and we should limit ourselves to this.