### PR TITLE
Fix bug: Fix parameter for frontend call

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -119,10 +119,10 @@ def run_introspector_frontend(target_class, jar_set):
       "-cp",
       FI_JVM_BASE + "/" + PLUGIN_PATH,
       CGRAPH_STR,
-      jarfile_str,
-      target_class,
-      package_name,
-      "fuzzerTestOneInput", # entrymethod
+      jarfile_str, # jar files path
+      target_class, # entry class
+      "fuzzerTestOneInput", # entry method
+      package_name, # target package prefix
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\
 [javax.xml.xpath.XPath].evaluate:[java.lang.Thread].run:[java.lang.Runnable].run:\


### PR DESCRIPTION
The parameter list for calling the java frontend in oss-fuzz-main is in wrong order after adding a new parameter. This PR fixes it by changing the parameter list to correct order.