### PR TITLE
Auto-fuzz: Add default type for target

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -913,7 +913,10 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
                         type=str,
                         help="The languaeg of the projects",
                         default='python')
-    parser.add_argument("--targets", type=str, help="The targets to use")
+    parser.add_argument("--targets",
+                        type=str,
+                        help="The targets to use",
+                        default='constants')
     parser.add_argument(
         "--merge",
         action="store_true",


### PR DESCRIPTION
Fix a bug in #945. The newly added feature request a cli argument **_targets_** but it does not make this argument mandatory or provide a default value, thus it could be none type and run into a none type opening error. This PR fixes this by adding default value to the cli argument **_targets_**.