### PR TITLE
Auto-fuzz: Fix clean error for non-exist source folder

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -681,7 +681,10 @@ def build_and_test_single_possible_target(idx_folder,
         oss_fuzz_path = os.path.join(OSS_FUZZ_BASE, "projects",
                                      os.path.basename(auto_fuzz_proj_dir),
                                      src_dir)
-        shutil.rmtree(oss_fuzz_path)
+
+        if os.path.isdir(oss_fuzz_path):
+            shutil.rmtree(oss_fuzz_path)
+
     tick_tqdm_tracker()
 
 


### PR DESCRIPTION
For some java project, the source folder may not copy to the oss-fuzz repository. This PR fixes an error thrown when the source file path is not existed when the cleaning operation is executed.