### PR TITLE
Auto-fuzz: Fix bug for illegal java class name

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -202,7 +202,7 @@ wget -P $OUT/ https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.
 BUILD_CLASSPATH=$BUILD_CLASSPATH:$JAZZER_API_PATH:$OUT/commons-lang3-3.12.0.jar
 RUNTIME_CLASSPATH=$RUNTIME_CLASSPATH:\$this_dir/commons-lang3-3.12.0.jar:\$this_dir
 
-for fuzzer in $(find $SRC -name 'Fuzz1*.java')
+for fuzzer in $(find $SRC -name 'Fuzz*.java')
 do
   fuzzer_basename=$(basename -s .java $fuzzer)
   javac -cp $BUILD_CLASSPATH $fuzzer
@@ -259,7 +259,7 @@ def gen_base_fuzzer_jvm():
     BASE_FUZZER = """import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.apache.commons.lang3.ArrayUtils;
 /*IMPORTS*/
-public class Fuzz1/*COUNTER*/ {
+public class Fuzz/*COUNTER*/ {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
 /*STATIC_OBJECT_CHOICE*/
 /*CODE*/

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -1393,7 +1393,7 @@ def generate_possible_targets(proj_folder, max_target, param_combination):
 
     # Read the Fuzz Introspector generated data
     yaml_file = os.path.join(proj_folder, "work",
-                             "fuzzerLogFile-Fuzz1.data.yaml")
+                             "fuzzerLogFile-Fuzz.data.yaml")
     with open(yaml_file, "r") as stream:
         yaml_dict = yaml.safe_load(stream)
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -97,7 +97,7 @@ class OSS_FUZZ_PROJECT:
         if self.language == "python":
             return self.project_folder + "/fuzz_1.py"
         elif self.language == "jvm":
-            return self.project_folder + "/Fuzz1.java"
+            return self.project_folder + "/Fuzz.java"
         else:
             # Temporary fail safe logic
             return self.project_folder + "/fuzz_1.py"
@@ -451,7 +451,7 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
         f.write(response.content)
 
     # Retrieve path of all jar files
-    jarfiles.append(os.path.abspath("../Fuzz1.jar"))
+    jarfiles.append(os.path.abspath("../Fuzz.jar"))
     jarfiles.append("%s/*.jar" % jardir)
     if project_type == "ant":
         for file in os.listdir(os.path.join(builddir, "build", "jar")):
@@ -467,8 +467,8 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
 
     # Compile and package fuzzer to jar file
     cmd = [
-        "javac -cp jazzer_standalone.jar:commons-lang3.jar:%s ../Fuzz1.java" %
-        ":".join(jarfiles), "jar cvf ../Fuzz1.jar ../Fuzz1.class"
+        "javac -cp jazzer_standalone.jar:commons-lang3.jar:%s ../Fuzz.java" %
+        ":".join(jarfiles), "jar cvf ../Fuzz.jar ../Fuzz.class"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),
@@ -477,12 +477,12 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.DEVNULL)
     except subprocess.TimeoutExpired:
-        print("Fail to compile Fuzz1.java.\n")
+        print("Fail to compile Fuzz.java.\n")
         return False
 
     # Run the java frontend static analysis
     cmd = [
-        "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz1"
+        "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz"
     ]
     try:
         subprocess.check_call(" ".join(cmd),
@@ -500,11 +500,11 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
 
     # Move data and data.yaml to working directory
     data_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
-                            "fuzzerLogFile-Fuzz1.data")
+                            "fuzzerLogFile-Fuzz.data")
     yaml_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
-                            "fuzzerLogFile-Fuzz1.data.yaml")
-    data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data")
-    yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz1.data.yaml")
+                            "fuzzerLogFile-Fuzz.data.yaml")
+    data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data")
+    yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data.yaml")
     if os.path.isfile(data_src) and os.path.isfile(yaml_src):
         ret = True
         try:

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -481,9 +481,7 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
         return False
 
     # Run the java frontend static analysis
-    cmd = [
-        "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz"
-    ]
+    cmd = ["./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz"]
     try:
         subprocess.check_call(" ".join(cmd),
                               shell=True,

--- a/tools/auto-fuzz/post_process.py
+++ b/tools/auto-fuzz/post_process.py
@@ -319,8 +319,8 @@ def _merge_runs(trial_dir, successful_runs, language):
             shutil.copyfile(src_file, dst_file)
         elif language == "jvm":
             # Copy over the fuzzer for java project
-            src_file = os.path.join(trial_dir, run['name'], "Fuzz1.java")
-            dst_file = os.path.join(next_merged_dir, "Fuzz1-%d.java" % (idx))
+            src_file = os.path.join(trial_dir, run['name'], "Fuzz.java")
+            dst_file = os.path.join(next_merged_dir, "Fuzz%d.java" % (idx))
 
             # Read in the content of the original Fuzz1.java, changing
             # the class name to the new one and write the content to
@@ -328,7 +328,7 @@ def _merge_runs(trial_dir, successful_runs, language):
             with open(src_file, "r") as fin:
                 with open(dst_file, "w") as fout:
                     for line in fin:
-                        fout.write(line.replace('/*COUNTER*/', '-%d' % (idx)))
+                        fout.write(line.replace('/*COUNTER*/', '%d' % (idx)))
 
             idx += 1
 


### PR DESCRIPTION
Java does not accepted hyphen as part of the class identifier. This PR fixes the bug to avoid the hyphen when merging successfully generated fuzzers.