### PR TITLE
Auto-fuzz: Add java for merge run handling

### DIFF
--- a/tools/auto-fuzz/post_process.py
+++ b/tools/auto-fuzz/post_process.py
@@ -281,6 +281,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
     merge_parser = subparsers.add_parser(
         'merge', help="Merge all fuzzers from one run into one project")
     merge_parser.add_argument("dir", type=str)
+    merge_parser.add_argument("language", type=str, default="python")
 
     return parser
 
@@ -402,8 +403,13 @@ def main():
         extract_ranked(args.dir, args.to_rank)
     elif args.command == 'heuristics-summary':
         heuristics_summary()
-    elif args.command == "merge":
-        merge_run(args.dir)
+    elif args.command == 'merge':
+        if args.language == 'python':
+            merge_run(args.dir, 'python')
+        elif args.language == 'java':
+            merge_run(args.dir, 'jvm')
+        else:
+            print('Unsupported language: %s' % args.language)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In #956, it adds the logic for merging auto-generated java fuzzers folder into a single folder. This approach is only working as an additional action when generating the fuzzers. It forgets to handle if the post process merging is needed for those java fuzzers. This PR fixes the post process to allow merging of the fuzzers after finishing the fuzzer generation process.