### PR TITLE
Java-Frontend: Add class method status in frontend

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -355,6 +355,7 @@ class CustomSenceTransformer extends SceneTransformer {
         methodInfo.setIsPublic(m.isPublic());
         methodInfo.setIsStatic(m.isStatic());
         methodInfo.setIsClassEnum(c.isEnum());
+        methodInfo.setIsClassPublic(c.isPublic());
         for (SootClass exception : m.getExceptions()) {
           methodInfo.addException(exception.getFilePath());
         }
@@ -512,6 +513,7 @@ class CustomSenceTransformer extends SceneTransformer {
         methodInfo.setIsPublic(method.isPublic());
         methodInfo.setIsClassConcrete(sootClass.isConcrete());
         methodInfo.setIsClassEnum(sootClass.isEnum());
+        methodInfo.setIsClassPublic(sootClass.isPublic());
         if (sootClass.hasSuperclass()) {
           methodInfo.setSuperClass(sootClass.getSuperclass().getName());
         }
@@ -570,6 +572,7 @@ class CustomSenceTransformer extends SceneTransformer {
       methodInfo.setIsPublic(method.isPublic());
       methodInfo.setIsStatic(method.isStatic());
       methodInfo.setIsClassEnum(method.getDeclaringClass().isEnum());
+      methodInfo.setIsClassPublic(method.getDeclaringClass().isPublic());
       for (SootClass exception : method.getExceptions()) {
         methodInfo.addException(exception.getFilePath());
       }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
@@ -30,6 +30,7 @@ public class JavaMethodInfo {
   private Boolean isStatic;
   private Boolean isClassConcrete;
   private Boolean isClassEnum;
+  private Boolean isClassPublic;
 
   public JavaMethodInfo() {
     this.exceptions = new ArrayList<String>();
@@ -42,6 +43,7 @@ public class JavaMethodInfo {
     this.isStatic = false;
     this.isClassConcrete = true;
     this.isClassEnum = false;
+    this.isClassPublic = true;
   }
 
   public List<String> getExceptions() {
@@ -134,5 +136,13 @@ public class JavaMethodInfo {
 
   public void setIsClassEnum(Boolean isClassEnum) {
     this.isClassEnum = isClassEnum;
+  }
+
+  public Boolean isClassPublic() {
+    return this.isClassPublic;
+  }
+
+  public void setIsClassPublic(Boolean isClassPublic) {
+    this.isClassPublic = isClassPublic;
   }
 }


### PR DESCRIPTION
Some classes are not public for classes outside the package. This PR adds this information to the yaml file to determine if that method and its class is publicly accessible.