### PR TITLE
Auto-fuzz: Add method filtering

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -697,6 +697,22 @@ def _extract_method(yaml_dict):
             # or not and filter out unrelated methods
             # from dependencies or libraries
             if _is_project_class(func_elem['functionSourceFile']):
+                # Exclude possible getters and setters
+                if func_elem['functionName'].startswith("get") and len(func_elem['argTypes']) == 0:
+                    continue
+                if func_elem['functionName'].startswith("is") and len(func_elem['argTypes']) == 0:
+                    continue
+                if func_elem['functionName'].startswith("set") and len(func_elem['argTypes']) == 1:
+                    continue
+
+                # Exclude general Object methods
+                object_methods = ['clone()', 'equals(java.lang.Object)', 'finalize()', 'getClass()',
+                                  'hashCode()', 'notify()', 'notifyAll()', 'toString()', 'wait()',
+                                  'wait(long)', 'wait(long,int)']
+                for object_method in object_methods:
+                    if object_method in func_elem['functionName']:
+                        continue
+
                 method_list.append(func_elem)
 
     return init_dict, method_list, instance_method_list, static_method_list

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -698,17 +698,22 @@ def _extract_method(yaml_dict):
             # from dependencies or libraries
             if _is_project_class(func_elem['functionSourceFile']):
                 # Exclude possible getters and setters
-                if func_elem['functionName'].startswith("get") and len(func_elem['argTypes']) == 0:
+                if func_elem['functionName'].startswith("get") and len(
+                        func_elem['argTypes']) == 0:
                     continue
-                if func_elem['functionName'].startswith("is") and len(func_elem['argTypes']) == 0:
+                if func_elem['functionName'].startswith("is") and len(
+                        func_elem['argTypes']) == 0:
                     continue
-                if func_elem['functionName'].startswith("set") and len(func_elem['argTypes']) == 1:
+                if func_elem['functionName'].startswith("set") and len(
+                        func_elem['argTypes']) == 1:
                     continue
 
                 # Exclude general Object methods
-                object_methods = ['clone()', 'equals(java.lang.Object)', 'finalize()', 'getClass()',
-                                  'hashCode()', 'notify()', 'notifyAll()', 'toString()', 'wait()',
-                                  'wait(long)', 'wait(long,int)']
+                object_methods = [
+                    'clone()', 'equals(java.lang.Object)', 'finalize()',
+                    'getClass()', 'hashCode()', 'notify()', 'notifyAll()',
+                    'toString()', 'wait()', 'wait(long)', 'wait(long,int)'
+                ]
                 for object_method in object_methods:
                     if object_method in func_elem['functionName']:
                         continue


### PR DESCRIPTION
General methods inherit from base Object class, or getter and setter methods don't have much values in fuzzing thus it maybe better to filter them out for the auto fuzzer generation process. This could help to decrease the number of possible targets. This PR applies the filtering during the data.yaml file processing.