### PR TITLE
python-logic: improve import handling in frontend and refine link handling

### DIFF
--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -114,7 +114,7 @@ class FuzzerVisitor(ast.NodeVisitor):
         print("- Fuzzer imports:")
         for _import in self.fuzzer_imports:
             print("  - %s" % (_import))
-            if _import.count(".") > 1:
+            if _import.count(".") > 0:
                 _import = _import.split(".")[0]
                 print("Refining import to %s" % (_import))
 
@@ -125,13 +125,12 @@ class FuzzerVisitor(ast.NodeVisitor):
                 continue
             except ImportError:
                 continue
+            print("No error")
             if specs is not None:
                 print("Spec:")
                 print(specs)
                 avoid = ['atheris', 'sys', 'os']
-                print("Hello")
                 if _import not in avoid:
-                    print("hello to")
                     if specs.submodule_search_locations:
                         for elem in specs.submodule_search_locations:
                             print("Checking --- %s" % (elem))
@@ -146,6 +145,8 @@ class FuzzerVisitor(ast.NodeVisitor):
                                 continue
                             print("Adding --- %s" % (elem))
                             self.fuzzer_packages.append(elem)
+            else:
+                print("Spec is none")
         print("Iterating")
         for pkg in self.fuzzer_packages:
             print("package: %s" % (pkg))

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -193,8 +193,9 @@ def scan_executables_for_fuzz_introspector_logs(
     return executable_to_fuzz_reports
 
 
-def approximate_python_coverage_files(src1: str, src2: str) -> bool:
-    logger.debug(f"Approximating {src1} to {src2}")
+def approximate_python_coverage_files_list(src1: str,
+                                           possible_targets,
+                                           resolve_inits=False) -> bool:
     # Remove prefixed .....
     src1 = src1.lstrip(".")
 
@@ -206,36 +207,36 @@ def approximate_python_coverage_files(src1: str, src2: str) -> bool:
     for s2 in splits:
         curr_str = curr_str + s2
         possible_candidates.append(curr_str + ".py")
-        possible_init_candidates.append("/__init__.py")
+        possible_init_candidates.append(curr_str + "/__init__.py")
         curr_str = curr_str + "/"
+    logger.info("[%s] -- Created init candidates: %s" %
+                (src1, str(possible_init_candidates)))
 
     # Start from backwards to find te longest possible candidate
-    target = None
     for candidate in reversed(possible_candidates):
-        if src2.endswith(candidate):
-            # ensure the entire filename is matched in the event of not slashes
-            if "/" not in candidate:
-                if not src2.split("/")[-1] == candidate:
-                    continue
-            target = candidate
-            break
-
-    if target is None:
-        for init_candidate in reversed(possible_init_candidates):
-            if src2.endswith(init_candidate):
+        for fl, src2 in possible_targets:
+            if src2.endswith(candidate):
                 # ensure the entire filename is matched in the event of not slashes
-                if "/" not in init_candidate:
-                    if not src2.split("/")[-1] == init_candidate:
+                if "/" not in candidate:
+                    if not src2.split("/")[-1] == candidate:
                         continue
-                target = init_candidate
-                break
+                logger.info("Found target: %s" % (candidate))
+                return fl
 
-    if target is not None:
-        logger.debug(f"Found target {target}")
-        return True
-    else:
-        logger.debug("Found no target")
-        return False
+    # Will only get to hear if none of the above candidates matched. This
+    # means the match is either in an __init__.py file or there is no match.
+    if resolve_inits:
+        for init_candidate in reversed(possible_init_candidates):
+            for fl, src2 in possible_targets:
+                if src2.endswith(init_candidate):
+                    # ensure the entire filename is matched in the event of not slashes
+                    if "/" not in init_candidate:
+                        if not src2.split("/")[-1] == init_candidate:
+                            continue
+                    logger.info("Found target: %s" % (init_candidate))
+                    return fl
+    logger.info("Could not find target")
+    return None
 
 
 def get_target_coverage_url(coverage_url: str, target_name: str,
@@ -297,13 +298,15 @@ def resolve_coverage_link(cov_url: str, source_file: str, lineno: int,
             html_idx = html_summaries[0]
             with open(html_idx, "r") as jf:
                 data = json.load(jf)
+            possible_targets = []
             for fl in data['files']:
-                found_target = approximate_python_coverage_files(
-                    function_name,
-                    data['files'][fl]['index']['relative_filename'],
-                )
-                if found_target:
-                    result = fl + ".html" + "#t" + str(lineno)
+                possible_targets.append(
+                    (fl, data['files'][fl]['index']['relative_filename']))
+
+            found_target = approximate_python_coverage_files_list(
+                function_name, possible_targets, True)
+            if found_target:
+                result = found_target + ".html" + "#t" + str(lineno)
         else:
             logger.info("Could not find any html_status.json file")
     elif (target_lang == "jvm"):

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -193,9 +193,10 @@ def scan_executables_for_fuzz_introspector_logs(
     return executable_to_fuzz_reports
 
 
-def approximate_python_coverage_files_list(src1: str,
-                                           possible_targets,
-                                           resolve_inits=False) -> bool:
+def approximate_python_coverage_files_list(
+        src1: str,
+        possible_targets: List[Tuple[str, str]],
+        resolve_inits=False) -> Optional[str]:
     # Remove prefixed .....
     src1 = src1.lstrip(".")
 
@@ -305,7 +306,7 @@ def resolve_coverage_link(cov_url: str, source_file: str, lineno: int,
 
             found_target = approximate_python_coverage_files_list(
                 function_name, possible_targets, True)
-            if found_target:
+            if found_target is not None:
                 result = found_target + ".html" + "#t" + str(lineno)
         else:
             logger.info("Could not find any html_status.json file")

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -25,6 +25,7 @@ from typing import (
     List,
     Dict,
     Optional,
+    Tuple,
 )
 
 from fuzz_introspector import constants

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -211,8 +211,8 @@ def approximate_python_coverage_files_list(
         possible_candidates.append(curr_str + ".py")
         possible_init_candidates.append(curr_str + "/__init__.py")
         curr_str = curr_str + "/"
-    logger.info("[%s] -- Created init candidates: %s" %
-                (src1, str(possible_init_candidates)))
+    logger.debug("[%s] -- Created init candidates: %s" %
+                 (src1, str(possible_init_candidates)))
 
     # Start from backwards to find te longest possible candidate
     for candidate in reversed(possible_candidates):
@@ -222,7 +222,7 @@ def approximate_python_coverage_files_list(
                 if "/" not in candidate:
                     if not src2.split("/")[-1] == candidate:
                         continue
-                logger.info("Found target: %s" % (candidate))
+                logger.debug("Found target: %s" % (candidate))
                 return fl
 
     # Will only get to hear if none of the above candidates matched. This
@@ -235,9 +235,9 @@ def approximate_python_coverage_files_list(
                     if "/" not in init_candidate:
                         if not src2.split("/")[-1] == init_candidate:
                             continue
-                    logger.info("Found target: %s" % (init_candidate))
+                    logger.debug("Found target: %s" % (init_candidate))
                     return fl
-    logger.info("Could not find target")
+    logger.debug("Could not find target")
     return None
 
 


### PR DESCRIPTION


A number of projects are failing to have any code analysed from the giving libraries they represent. This includes e.g. netaddr-py https://storage.googleapis.com/oss-fuzz-introspector/netaddr-py/inspector-report/20230423/fuzz_report.html

This PR addresses the above issue due to a bug in limiting the python modules when running the fuzz introspector frontend logic. The problem is, in order to identify what code to anlyse we rely on some AST parsing for capturing relevant import modules, and there was an issue in this code which limited the modules we'd include.

Also improves the way we create links in HTML reports for python projects.

This fix will likely have impact on https://github.com/ossf/fuzz-introspector/issues/973 since Fuzz Introspector will have an improved way of including relevant functions in the analysis, whereas before some projects (in particular those with 100% code coverage shown) had only fuzzer entrypoint functions included, whereas now they'll have all the functions from the modules included.