### PR TITLE
code-coverage: fix issue in all functions table

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -375,6 +375,8 @@ class CoverageProfile:
             fuzz_key = funcname
         elif utils.demangle_cpp_func(funcname) in self.covmap:
             fuzz_key = utils.demangle_cpp_func(funcname)
+        elif utils.normalise_str(funcname) in self.covmap:
+            fuzz_key = utils.normalise_str(funcname)
 
         if fuzz_key is None:
             return None, None

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -84,7 +84,7 @@ def create_all_function_table(
     for fd_k, fd in proj_profile.get_all_functions_with_source().items():
         demangled_func_name = utils.demangle_cpp_func(fd.function_name)
         hit_percentage = proj_profile.get_func_hit_percentage(
-            demangled_func_name)
+            fd.function_name)
 
         func_cov_url = proj_profile.resolve_coverage_report_link(
             coverage_url, fd.function_source_file, fd.function_linenumber,

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -83,8 +83,7 @@ def create_all_function_table(
 
     for fd_k, fd in proj_profile.get_all_functions_with_source().items():
         demangled_func_name = utils.demangle_cpp_func(fd.function_name)
-        hit_percentage = proj_profile.get_func_hit_percentage(
-            fd.function_name)
+        hit_percentage = proj_profile.get_func_hit_percentage(fd.function_name)
 
         func_cov_url = proj_profile.resolve_coverage_report_link(
             coverage_url, fd.function_source_file, fd.function_linenumber,


### PR DESCRIPTION
For C++ targets sometimes the function table would show wrong data, specifically functions that would have code coverage was not sometimes set to 0.0%. This fixes this issue by giving proper naming arguments to the code coverage lookup logic.