### PR TITLE
Optional language param for print_function_details

### DIFF
--- a/tools/oss-fuzz-scanner/function_inspector.py
+++ b/tools/oss-fuzz-scanner/function_inspector.py
@@ -15,10 +15,12 @@
 
 import sys
 import scanner
+import typing
 
 
-def print_function_details(project_name, functions_to_analyse):
-    report_generator = scanner.get_all_reports([project_name], 2)
+def print_function_details(project_name, functions_to_analyse: typing.List[str],
+    language: str = 'c-cpp'):
+    report_generator = scanner.get_all_reports([project_name], 2, language=language)
 
     project, date_as_str, introspector_project = next(report_generator)
     all_functions = introspector_project.proj_profile.get_all_functions()
@@ -41,10 +43,15 @@ def print_function_details(project_name, functions_to_analyse):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
+    if len(sys.argv) < 3:
         print(
-            "Usage: python3 function_inspector.py project_name function_name")
+            "Usage: python3 function_inspector.py project_name function_name language")
         sys.exit(0)
     project_name = sys.argv[1]
     function_name = sys.argv[2]
-    print_function_details(project_name, [function_name])
+    language = None
+    try:
+        language = sys.argv[3]
+    except IndexError:
+        language = 'c-cpp'
+    print_function_details(project_name, [function_name], language=language)

--- a/tools/oss-fuzz-scanner/scanner.py
+++ b/tools/oss-fuzz-scanner/scanner.py
@@ -112,11 +112,11 @@ def download_project_introspector_artifacts(project_name,
 
 
 def run_fuzz_introspector_on_dir(
-        artifact_dir) -> Optional[analysis.IntrospectionProject]:
+        artifact_dir, language: str = 'c-cpp') -> Optional[analysis.IntrospectionProject]:
     """Runs introspector on the files in artifact_dir."""
     try:
         introspector_proj = analysis.IntrospectionProject(
-            language='c-cpp', target_folder=artifact_dir, coverage_url="")
+            language=language, target_folder=artifact_dir, coverage_url="")
         introspector_proj.load_data_files(correlation_file="")
     except exceptions.FuzzIntrospectorError:
         return None
@@ -138,7 +138,8 @@ def get_next_workdir():
 
 def get_all_reports(project_names: List[str],
                     days_to_analyse=10,
-                    interval_size=10):
+                    interval_size=10,
+                    language: str='c-cpp'):
     for project in project_names:
         complexities = []
         for i in range(1, days_to_analyse):
@@ -155,7 +156,7 @@ def get_all_reports(project_names: List[str],
                 #print("Could not download artifacts")
                 continue
 
-            introspector_project = run_fuzz_introspector_on_dir(workdir)
+            introspector_project = run_fuzz_introspector_on_dir(workdir, language)
             if introspector_project is None:
                 continue
 


### PR DESCRIPTION
I ran into an issue running some tests with the introspector tool `function_inspector` `print_function_details`. I traced the issue down to a problem in `run_fuzz_introspector_on_dir` where `IntrospectionProject` is always being called with language `c-cpp`. When this is called with `python` instead it runs correctly.

I've added an optional language param. Try

``` python
# Doesn't work
import function_inspector

function_inspector.print_function_details("croniter", ["croniter.croniter.croniter.get_next"])

# Now works
function_inspector.print_function_details("croniter", ["croniter.croniter.croniter.get_next"], language="python")
```

I also added a type hint to the `functions_to_analyse` param as it look me a while to realise it only accepts a list of strings.

