### PR TITLE
Java-frontend: Update soot dependency version

### DIFF
--- a/frontends/java/pom.xml
+++ b/frontends/java/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.soot-oss</groupId>
 			<artifactId>soot</artifactId>
-			<version>4.3.0</version>
+			<version>4.4.1</version>
 		</dependency>
 		<dependency>
 	    		<groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
The Soot library used in the Java frontend only support Jar file compiled with JDK 18 or before. Recently, there are java projects in OSS-FUZZ started to create Jar file with JDK 19+, that make the current Soot library (depends on ASM library) fails to handle them and cause error. This PR updates the Soot dependency version to the newest (v4.4.1) (which supports newest ASM library that could handle JDK 20 or before).