### PR TITLE
java-frontend: Fix frontend logic

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -123,6 +123,7 @@ def run_introspector_frontend(target_class, jar_set):
       target_class, # entry class
       "fuzzerTestOneInput", # entry method
       package_name, # target package prefix
+      "False", 
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\
 [javax.xml.xpath.XPath].evaluate:[java.lang.Thread].run:[java.lang.Runnable].run:\

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -54,6 +54,10 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -a|--autofuzz)
+      AUTOFUZZ="True"
+      shift
+      ;;
     *)
       echo "Unknown option $1"
       exit 1
@@ -96,6 +100,10 @@ then
     echo "No target package prefix defined, analysing all packages"
     PACKAGEPREFIX="ALL"
 fi
+if [ -z $AUTOFUZZ ]
+then
+    AUTOFUZZ="False"
+fi
 
 # Build and execute the call graph generator
 mvn clean package -Dmaven.test.skip
@@ -104,5 +112,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" $AUTOFUZZ "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
 done

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -83,7 +83,7 @@ public class CallGraphGenerator {
     String entryClass = args[1];
     String entryMethod = args[2];
     String targetPackagePrefix = args[3];
-    Boolean isAutoFuzz = (args[4].equals("True"))? true : false;
+    Boolean isAutoFuzz = (args[4].equals("True")) ? true : false;
     String includePrefix = "";
     String excludePrefix = "";
     String sinkMethod = "";
@@ -103,7 +103,13 @@ public class CallGraphGenerator {
     // Add an custom analysis phase to Soot
     CustomSenceTransformer custom =
         new CustomSenceTransformer(
-            entryClass, entryMethod, targetPackagePrefix, includePrefix, excludePrefix, sinkMethod, isAutoFuzz);
+            entryClass,
+            entryMethod,
+            targetPackagePrefix,
+            includePrefix,
+            excludePrefix,
+            sinkMethod,
+            isAutoFuzz);
     PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
 
     // Set basic settings for the call graph generation
@@ -185,7 +191,14 @@ class CustomSenceTransformer extends SceneTransformer {
       String includePrefix,
       String excludePrefix,
       String sinkMethod) {
-      this(entryClassStr, entryMethodStr, targetPackagePrefix, includePrefix, excludePrefix, sinkMethod, false);
+    this(
+        entryClassStr,
+        entryMethodStr,
+        targetPackagePrefix,
+        includePrefix,
+        excludePrefix,
+        sinkMethod,
+        false);
   }
 
   public CustomSenceTransformer(
@@ -617,7 +630,6 @@ class CustomSenceTransformer extends SceneTransformer {
       this.methodList.addFunctionElement(element);
     }
   }
-
 
   // Shorthand for extractCallTree from top
   private String extractCallTree(CallGraph cg, SootMethod method, Integer depth, Integer line) {

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -74,7 +74,7 @@ import soot.toolkits.graph.UnitGraph;
 public class CallGraphGenerator {
   public static void main(String[] args) {
     System.out.println("[Callgraph] Running callgraph plugin");
-    if (args.length < 4 || args.length > 5) {
+    if (args.length < 5 || args.length > 6) {
       System.err.println("No jarFiles, entryClass, entryMethod and target package.");
       return;
     }
@@ -83,13 +83,14 @@ public class CallGraphGenerator {
     String entryClass = args[1];
     String entryMethod = args[2];
     String targetPackagePrefix = args[3];
+    Boolean isAutoFuzz = (args[4].equals("True"))? true : false;
     String includePrefix = "";
     String excludePrefix = "";
     String sinkMethod = "";
-    if (args.length == 5) {
-      includePrefix = args[4].split("===")[0];
-      excludePrefix = args[4].split("===")[1];
-      sinkMethod = args[4].split("===")[2];
+    if (args.length == 6) {
+      includePrefix = args[5].split("===")[0];
+      excludePrefix = args[5].split("===")[1];
+      sinkMethod = args[5].split("===")[2];
     }
     if (jarFiles.size() < 1) {
       System.err.println("Invalid jarFiles");
@@ -102,7 +103,7 @@ public class CallGraphGenerator {
     // Add an custom analysis phase to Soot
     CustomSenceTransformer custom =
         new CustomSenceTransformer(
-            entryClass, entryMethod, targetPackagePrefix, includePrefix, excludePrefix, sinkMethod);
+            entryClass, entryMethod, targetPackagePrefix, includePrefix, excludePrefix, sinkMethod, isAutoFuzz);
     PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
 
     // Set basic settings for the call graph generation
@@ -175,6 +176,7 @@ class CustomSenceTransformer extends SceneTransformer {
   private String entryMethodStr;
   private SootMethod entryMethod;
   private FunctionConfig methodList;
+  private Boolean isAutoFuzz;
 
   public CustomSenceTransformer(
       String entryClassStr,
@@ -183,8 +185,20 @@ class CustomSenceTransformer extends SceneTransformer {
       String includePrefix,
       String excludePrefix,
       String sinkMethod) {
+      this(entryClassStr, entryMethodStr, targetPackagePrefix, includePrefix, excludePrefix, sinkMethod, false);
+  }
+
+  public CustomSenceTransformer(
+      String entryClassStr,
+      String entryMethodStr,
+      String targetPackagePrefix,
+      String includePrefix,
+      String excludePrefix,
+      String sinkMethod,
+      Boolean isAutoFuzz) {
     this.entryClassStr = entryClassStr;
     this.entryMethodStr = entryMethodStr;
+    this.isAutoFuzz = isAutoFuzz;
     this.entryMethod = null;
 
     targetPackageList = new LinkedList<String>();
@@ -311,7 +325,9 @@ class CustomSenceTransformer extends SceneTransformer {
       } else {
         System.out.println("[Callgraph] [SKIP] class: " + cname);
       }
-      this.includeConstructor(c);
+      if (isAutoFuzz) {
+        this.includeConstructor(c);
+      }
     }
     System.out.println("[Callgraph] Finished going through classes");
 
@@ -323,14 +339,14 @@ class CustomSenceTransformer extends SceneTransformer {
       mList.addAll(classMethodMap.get(c));
       for (SootMethod m : mList) {
         if (this.excludeMethodList.contains(m.getName())) {
-          System.out.println("[Callgraph] Skipping method: " + m.getName());
+          // System.out.println("[Callgraph] Skipping method: " + m.getName());
           continue;
         }
         if (isSinkClass) {
-          System.out.println("[Callgraph] Skipping sink method: " + m.getName());
+          // System.out.println("[Callgraph] Skipping sink method: " + m.getName());
           continue;
         }
-        System.out.println("[Callgraph] Analysing method: " + m.getName());
+        // System.out.println("[Callgraph] Analysing method: " + m.getName());
 
         // Discover method related information
         FunctionElement element = new FunctionElement();
@@ -349,17 +365,19 @@ class CustomSenceTransformer extends SceneTransformer {
         for (soot.Type type : m.getParameterTypes()) {
           element.addArgType(type.toString());
         }
-        JavaMethodInfo methodInfo = new JavaMethodInfo();
-        methodInfo.setIsConcrete(m.isConcrete());
-        methodInfo.setIsJavaLibraryMethod(m.isJavaLibraryMethod());
-        methodInfo.setIsPublic(m.isPublic());
-        methodInfo.setIsStatic(m.isStatic());
-        methodInfo.setIsClassEnum(c.isEnum());
-        methodInfo.setIsClassPublic(c.isPublic());
-        for (SootClass exception : m.getExceptions()) {
-          methodInfo.addException(exception.getFilePath());
+        if (isAutoFuzz) {
+          JavaMethodInfo methodInfo = new JavaMethodInfo();
+          methodInfo.setIsConcrete(m.isConcrete());
+          methodInfo.setIsJavaLibraryMethod(m.isJavaLibraryMethod());
+          methodInfo.setIsPublic(m.isPublic());
+          methodInfo.setIsStatic(m.isStatic());
+          methodInfo.setIsClassEnum(c.isEnum());
+          methodInfo.setIsClassPublic(c.isPublic());
+          for (SootClass exception : m.getExceptions()) {
+            methodInfo.addException(exception.getFilePath());
+          }
+          element.setJavaMethodInfo(methodInfo);
         }
-        element.setJavaMethodInfo(methodInfo);
 
         // Identify in / out edges of each method.
         int methodEdges = 0;
@@ -417,7 +435,7 @@ class CustomSenceTransformer extends SceneTransformer {
           element.setBBCount(0);
           element.setiCount(0);
           element.setCyclomaticComplexity(0);
-          methodList.addFunctionElement(element);
+          this.addMethodElement(element);
           // System.err.println("Source code for " + m + " not found.");
           continue;
         }
@@ -449,7 +467,7 @@ class CustomSenceTransformer extends SceneTransformer {
         UnitGraph unitGraph = new BriefUnitGraph(methodBody);
         element.setCyclomaticComplexity(calculateCyclomaticComplexity(unitGraph));
 
-        methodList.addFunctionElement(element);
+        this.addMethodElement(element);
       }
     }
     try {
@@ -541,7 +559,7 @@ class CustomSenceTransformer extends SceneTransformer {
 
         element.setJavaMethodInfo(methodInfo);
 
-        methodList.addFunctionElement(element);
+        this.addMethodElement(element);
       }
     }
   }
@@ -566,19 +584,21 @@ class CustomSenceTransformer extends SceneTransformer {
       element.setiCount(0);
       element.setCyclomaticComplexity(0);
 
-      JavaMethodInfo methodInfo = new JavaMethodInfo();
-      methodInfo.setIsConcrete(method.isConcrete());
-      methodInfo.setIsJavaLibraryMethod(method.isJavaLibraryMethod());
-      methodInfo.setIsPublic(method.isPublic());
-      methodInfo.setIsStatic(method.isStatic());
-      methodInfo.setIsClassEnum(method.getDeclaringClass().isEnum());
-      methodInfo.setIsClassPublic(method.getDeclaringClass().isPublic());
-      for (SootClass exception : method.getExceptions()) {
-        methodInfo.addException(exception.getFilePath());
+      if (isAutoFuzz) {
+        JavaMethodInfo methodInfo = new JavaMethodInfo();
+        methodInfo.setIsConcrete(method.isConcrete());
+        methodInfo.setIsJavaLibraryMethod(method.isJavaLibraryMethod());
+        methodInfo.setIsPublic(method.isPublic());
+        methodInfo.setIsStatic(method.isStatic());
+        methodInfo.setIsClassEnum(method.getDeclaringClass().isEnum());
+        methodInfo.setIsClassPublic(method.getDeclaringClass().isPublic());
+        for (SootClass exception : method.getExceptions()) {
+          methodInfo.addException(exception.getFilePath());
+        }
+        element.setJavaMethodInfo(methodInfo);
       }
-      element.setJavaMethodInfo(methodInfo);
 
-      methodList.addFunctionElement(element);
+      this.addMethodElement(element);
     }
   }
 
@@ -590,6 +610,14 @@ class CustomSenceTransformer extends SceneTransformer {
     }
     return null;
   }
+
+  // Add method element to the method list, ignoring method already added to the list
+  private void addMethodElement(FunctionElement element) {
+    if (this.searchElement(element.getFunctionName()) == null) {
+      this.methodList.addFunctionElement(element);
+    }
+  }
+
 
   // Shorthand for extractCallTree from top
   private String extractCallTree(CallGraph cg, SootMethod method, Integer depth, Integer line) {
@@ -829,19 +857,15 @@ class CustomSenceTransformer extends SceneTransformer {
       }
 
       if (!excluded) {
-        if (cg.edgesOutOf(edge.tgt()).hasNext()) {
-          edgeList.add(edge);
+        Set<String> classNameSet;
+        if (this.edgeClassMap.containsKey(matchStr)) {
+          classNameSet = new HashSet<String>(this.edgeClassMap.get(matchStr));
         } else {
-          Set<String> classNameSet;
-          if (this.edgeClassMap.containsKey(matchStr)) {
-            classNameSet = new HashSet<String>(this.edgeClassMap.get(matchStr));
-          } else {
-            classNameSet = new HashSet<String>();
-            edgeList.add(edge);
-          }
-          classNameSet.add(className);
-          this.edgeClassMap.put(matchStr, classNameSet);
+          classNameSet = new HashSet<String>();
+          edgeList.add(edge);
         }
+        classNameSet.add(className);
+        this.edgeClassMap.put(matchStr, classNameSet);
       }
     }
 
@@ -854,6 +878,7 @@ class CustomSenceTransformer extends SceneTransformer {
     for (String key : keySet) {
       this.edgeClassMap.remove(key);
     }
+
     return this.sortEdgeByLineNumber(edgeList.iterator());
   }
 


### PR DESCRIPTION
Fix the following logic for java frontend in order to reduce the resulting callgraph and method profile.

1. Add a boolean switch for auto-fuzz, constructors and details java method information will only be included when the frontend is called with the auto-fuzz switch on. This could prevent too much unnecessary information in the method profiles.
2. Add logic to avoid adding duplicate method in the method profile.
3. Fix logic in the mergePolymorphism method.