### PR TITLE
Java Auto-fuzz: Add auto-fuzz switch

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -481,7 +481,7 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
         return False
 
     # Run the java frontend static analysis
-    cmd = ["./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz"]
+    cmd = ["./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz", "--autofuzz"]
     try:
         subprocess.check_call(" ".join(cmd),
                               shell=True,

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -481,7 +481,10 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
         return False
 
     # Run the java frontend static analysis
-    cmd = ["./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz", "--autofuzz"]
+    cmd = [
+        "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz",
+        "--autofuzz"
+    ]
     try:
         subprocess.check_call(" ".join(cmd),
                               shell=True,


### PR DESCRIPTION
The changes in #1073 add a new boolean switch for auto-fuzz. That switch controls if constructors information are needed in the resulting data.yaml profile. Those information is only needed for auto-fuzz so the default value of the switch is set to False. This PR fixes that by specifically turn on the switch in order to get the constructors information for the auto-fuzzing process. **This PR should only be merged after #1073 is merged.**