### PR TITLE
frontend: python: catch possible exception

### DIFF
--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -81,7 +81,7 @@ class FuzzerVisitor(ast.NodeVisitor):
             if lhs_obj is not None:
                 try:
                     lhs = lhs_obj.id + lhs
-                except:
+                except AttributeError:
                     lhs = ""
             print(" [C] %s" % (lhs))
 

--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -79,7 +79,10 @@ class FuzzerVisitor(ast.NodeVisitor):
                     self.visit_Call(lhs_obj)
                     lhs_obj = None
             if lhs_obj is not None:
-                lhs = lhs_obj.id + lhs
+                try:
+                    lhs = lhs_obj.id + lhs
+                except:
+                    lhs = ""
             print(" [C] %s" % (lhs))
 
             # Check if we have atheris.Setup


### PR DESCRIPTION
Fixes some broken builds with stack traces:
```
[Call(func=Attribute(value=Call(func=Attribute(value=Attribute(value=Name(id='traceback', ctx=Load()), attr='TracebackException', ctx=Load()), attr='from_exception', ctx=Load()), args=[Name(id='e', ctx=Load())], keywords=[]), attr='format', ctx=Load()), args=[], keywords=[])], keywords=[])
Step #6 - "compile-libfuzzer-introspector-x86_64": Inside of call instruction -- TestOneInput
Step #6 - "compile-libfuzzer-introspector-x86_64": <_ast.Attribute object at 0x7f5006849e20>
Step #6 - "compile-libfuzzer-introspector-x86_64": Traceback (most recent call last):
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 173, in <module>
Step #6 - "compile-libfuzzer-introspector-x86_64":     fuzz_packages = get_package_paths(filename)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 161, in get_package_paths
Step #6 - "compile-libfuzzer-introspector-x86_64":     fuzz_visitor.analyze()
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 104, in analyze
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.visit(self.ast_content)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 363, in visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     return visitor(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 35, in visit_Module
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.generic_visit(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 371, in generic_visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.visit(item)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 363, in visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     return visitor(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 100, in visit_FunctionDef
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.generic_visit(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 371, in generic_visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.visit(item)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 363, in visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     return visitor(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 371, in generic_visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.visit(item)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 363, in visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     return visitor(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 371, in generic_visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.visit(item)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 363, in visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     return visitor(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 373, in generic_visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     self.visit(value)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/usr/local/lib/python3.8/ast.py", line 363, in visit
Step #6 - "compile-libfuzzer-introspector-x86_64":     return visitor(node)
Step #6 - "compile-libfuzzer-introspector-x86_64":   File "/fuzz-introspector/frontends/python/prepare_fuzz_imports.py", line 82, in visit_Call
Step #6 - "compile-libfuzzer-introspector-x86_64":     lhs = lhs_obj.id + lhs
Step #6 - "compile-libfuzzer-introspector-x86_64": AttributeError: 'Constant' object has no attribute 'id'
```

Such as:
https://oss-fuzz-build-logs.storage.googleapis.com/log-da4b9eda-c7e2-4c68-a96d-44cab23dbd6f.txt