### PR TITLE
Sink analyser: Handle empty line number

### DIFF
--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -313,7 +313,10 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
         linenumber = function.function_linenumber
 
         if target_name and target_name in function.callsite.keys():
-            linenumber = int(function.callsite[target_name][0].split(':')[1])
+            try:
+                linenumber = int(function.callsite[target_name][0].split(':')[1])
+            except ValueError:
+                linenumber = -1
 
         link = proj_profile.resolve_coverage_report_link(
             proj_profile.coverage_url,

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -314,7 +314,8 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
 
         if target_name and target_name in function.callsite.keys():
             try:
-                linenumber = int(function.callsite[target_name][0].split(':')[1])
+                linenumber = int(
+                    function.callsite[target_name][0].split(':')[1])
             except ValueError:
                 linenumber = -1
 


### PR DESCRIPTION
The code will throw and ValueError if line number string are not included for a given method in the profile. This PR fixes it by setting the line number to -1 as default for those method which does not provide line number information.