### PR TITLE
Auto-fuzz Replace old java version

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -153,7 +153,12 @@ do
       break
     elif test -f "pom.xml"
     then
-      sed -i 's/>1.5</>1.8</g' pom.xml
+      find ./ -name pom.xml -exec sed -i 's/>1.5</>1.8</g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/>1.6</>1.8</g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/java15/java18/g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
       MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15 --update-snapshots"
       $MVN clean package $MAVEN_ARGS
       if [[ $? != "0" ]]

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -248,7 +248,8 @@ def _maven_build_project(basedir, projectdir):
         basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
 
     # Patch pom.xml to use at least jdk 1.8
-    cmd = ["find ./ -name pom.xml -exec sed -i 's/>1.5</>1.8</g' {} \;",
+    cmd = [
+        "find ./ -name pom.xml -exec sed -i 's/>1.5</>1.8</g' {} \;",
         "find ./ -name pom.xml -exec sed -i 's/>1.6</>1.8</g' {} \;",
         "find ./ -name pom.xml -exec sed -i 's/java15/java18/g' {} \;",
         "find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;",

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -248,9 +248,15 @@ def _maven_build_project(basedir, projectdir):
         basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
 
     # Patch pom.xml to use at least jdk 1.8
-    cmd = ["sed", "-i", "'s/>1.5</>1.8</g'", "pom.xml"]
+    cmd = ["find ./ -name pom.xml -exec sed -i 's/>1.5</>1.8</g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/>1.6</>1.8</g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/java15/java18/g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;"
+    ]
     try:
-        subprocess.check_call(" ".join(cmd),
+        subprocess.check_call(";".join(cmd),
                               shell=True,
                               timeout=1800,
                               stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Some legacy projects configure their maven pom.xml to use java 1.7 or prior version to build the project. But maven has already desupport java 1.7 or before and so this PR adds logic to replace that settings in the project pom.xml to force the project build using java 1.8+.