### PR TITLE
Java-frontend: Fix constructor ignore option

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -123,7 +123,8 @@ def run_introspector_frontend(target_class, jar_set):
       target_class, # entry class
       "fuzzerTestOneInput", # entry method
       package_name, # target package prefix
-      "False", 
+      "<cinit>:finalize", # exclude method list
+      "False", # Auto-fuzz switch
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\
 [javax.xml.xpath.XPath].evaluate:[java.lang.Thread].run:[java.lang.Runnable].run:\

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -44,6 +44,11 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -x|--excludemethod)
+      EXCLUDEMETHOD="$2"
+      shift
+      shift
+      ;;
     -s|--sinkmethod)
       SINKMETHOD="$2"
       shift
@@ -90,6 +95,11 @@ then
     echo "No include prefix list defined, using default include prefix list"
     INCLUDEPREFIX=
 fi
+if [ -z $EXCLUDEMETHOD ]
+then
+    echo "No exclude method list defined, using default exclude method list"
+    EXCLUDEPREFIX="<cinit>:finalize"
+fi
 if [ -z $SINKMETHOD ]
 then
     echo "No sink method list defined, using default sink method list"
@@ -112,5 +122,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" $AUTOFUZZ "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" "$EXCLUDEMETHOD" $AUTOFUZZ "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
 done

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -74,7 +74,7 @@ import soot.toolkits.graph.UnitGraph;
 public class CallGraphGenerator {
   public static void main(String[] args) {
     System.out.println("[Callgraph] Running callgraph plugin");
-    if (args.length < 5 || args.length > 6) {
+    if (args.length < 6 || args.length > 7) {
       System.err.println("No jarFiles, entryClass, entryMethod and target package.");
       return;
     }
@@ -83,14 +83,15 @@ public class CallGraphGenerator {
     String entryClass = args[1];
     String entryMethod = args[2];
     String targetPackagePrefix = args[3];
-    Boolean isAutoFuzz = (args[4].equals("True")) ? true : false;
+    String excludeMethod = args[4];
+    Boolean isAutoFuzz = (args[5].equals("True")) ? true : false;
     String includePrefix = "";
     String excludePrefix = "";
     String sinkMethod = "";
-    if (args.length == 6) {
-      includePrefix = args[5].split("===")[0];
-      excludePrefix = args[5].split("===")[1];
-      sinkMethod = args[5].split("===")[2];
+    if (args.length == 7) {
+      includePrefix = args[6].split("===")[0];
+      excludePrefix = args[6].split("===")[1];
+      sinkMethod = args[6].split("===")[2];
     }
     if (jarFiles.size() < 1) {
       System.err.println("Invalid jarFiles");
@@ -106,6 +107,7 @@ public class CallGraphGenerator {
             entryClass,
             entryMethod,
             targetPackagePrefix,
+            excludeMethod,
             includePrefix,
             excludePrefix,
             sinkMethod,
@@ -188,6 +190,7 @@ class CustomSenceTransformer extends SceneTransformer {
       String entryClassStr,
       String entryMethodStr,
       String targetPackagePrefix,
+      String excludeMethodStr,
       String includePrefix,
       String excludePrefix,
       String sinkMethod) {
@@ -195,6 +198,7 @@ class CustomSenceTransformer extends SceneTransformer {
         entryClassStr,
         entryMethodStr,
         targetPackagePrefix,
+        excludeMethodStr,
         includePrefix,
         excludePrefix,
         sinkMethod,
@@ -205,6 +209,7 @@ class CustomSenceTransformer extends SceneTransformer {
       String entryClassStr,
       String entryMethodStr,
       String targetPackagePrefix,
+      String excludeMethodStr,
       String includePrefix,
       String excludePrefix,
       String sinkMethod,
@@ -242,10 +247,9 @@ class CustomSenceTransformer extends SceneTransformer {
       }
     }
 
-    // Required for auto-fuzz
-    excludeMethodList.add("<init>");
-    excludeMethodList.add("<clinit>");
-    excludeMethodList.add("finalize");
+    for (String exclude : excludeMethodStr.split(":")) {
+      excludeMethodList.add(exclude);
+    }
 
     sinkMethodMap = new HashMap<String, Set<String>>();
     for (String sink : sinkMethod.split(":")) {

--- a/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
+++ b/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
@@ -16,7 +16,7 @@ public class CustomSenceTransformerTest {
 
   @Test
   public void testBasic() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "ALL", "", "", "");
+    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "ALL", "", "", "", "");
     assertTrue(custom instanceof SceneTransformer);
     assertTrue(custom instanceof CustomSenceTransformer);
     assertEquals(custom.getIncludeList().size(), 1);
@@ -26,7 +26,7 @@ public class CustomSenceTransformerTest {
   @Test
   public void testExcludePrefix() {
     CustomSenceTransformer custom =
-        new CustomSenceTransformer("", "", "ALL", "abc:def:ghi", "jkl:mno:pqr", "");
+        new CustomSenceTransformer("", "", "ALL", "", "abc:def:ghi", "jkl:mno:pqr", "");
     assertEquals(custom.getIncludeList().size(), 4);
     assertEquals(custom.getExcludeList().size(), 3);
     Object[] eexpected = {"jkl", "mno", "pqr"};

--- a/tests/java/runTest.sh
+++ b/tests/java/runTest.sh
@@ -28,7 +28,7 @@ then
 
   # Extract data
   cd $ROOT/../../frontends/java
-  ./run.sh -j $jarfile -c $entryclass
+  ./run.sh -j $jarfile -c $entryclass -x "<init>:<cinit>:finalize"
 
   rm -rf $ROOT/result/$1
   mkdir -p $ROOT/result/$1


### PR DESCRIPTION
Some oss-fuzz project have fuzzers like https://github.com/google/oss-fuzz/blob/master/projects/jettison/JsonFuzzer.java which only call constructor of the target project. There is also some project logic are initialised from constructor. That cause problems to Java-frontend static analysis of these project because the java frontend ignore constructor when generating call graphs by default. The original reason for that is to avoid some large project call graph to be flooding with not useful data. This PR fixes that by adding options for user to include what methods to be excluded during the frontend process. By default, general constructor will not be ignored.