### PR TITLE
Java frontend: Fix wrong variable and method name

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -123,7 +123,7 @@ def run_introspector_frontend(target_class, jar_set):
       target_class, # entry class
       "fuzzerTestOneInput", # entry method
       package_name, # target package prefix
-      "<cinit>:finalize", # exclude method list
+      "<clinit>:finalize", # exclude method list
       "False", # Auto-fuzz switch
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -98,7 +98,7 @@ fi
 if [ -z $EXCLUDEMETHOD ]
 then
     echo "No exclude method list defined, using default exclude method list"
-    EXCLUDEPREFIX="<cinit>:finalize"
+    EXCLUDEMETHOD="<clinit>:finalize"
 fi
 if [ -z $SINKMETHOD ]
 then


### PR DESCRIPTION
The newly added method ignoring switch in #1055 have a slight typo for the variable name and the name of the default method to be excluded. This PR fixes it.