### PR TITLE
Java Frontend: Fix staticness resolution error

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -126,6 +126,12 @@ public class CallGraphGenerator {
     Options.v().set_keep_line_number(true);
     Options.v().set_no_writeout_body_releasing(true);
 
+    // Special options to ignore wrong staticness methods
+    // For example, invoking a static class method from its
+    // instance object will trigger resolve error because of
+    // wrong staticness invocation
+    Options.v().set_wrong_staticness(Options.wrong_staticness_ignore);
+
     // Load and set main class
     Options.v().set_main_class(entryClass);
     SootClass c = Scene.v().loadClass(entryClass, SootClass.BODIES);
@@ -963,24 +969,31 @@ class CustomSenceTransformer extends SceneTransformer {
    *
    * @param stmt the statement to handle
    * @param sourceFilePath the file path for the parent method
-   * @return the callsite object to store in the output yaml file
+   * @return the callsite object to store in the output yaml file, return null if Soot fails to resolve the invocation
    */
   private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath) {
     // Handle statements of a method
-    if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
-      InvokeExpr expr = stmt.getInvokeExpr();
-      Callsite callsite = new Callsite();
-      SootMethod target = expr.getMethod();
-      SootClass tClass = target.getDeclaringClass();
-      Set<String> sink = this.sinkMethodMap.getOrDefault(tClass.getName(), Collections.emptySet());
-      if (sink.contains(target.getName())) {
-        this.reachedSinkMethodList.add(target);
+    try {
+      if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
+        InvokeExpr expr = stmt.getInvokeExpr();
+        Callsite callsite = new Callsite();
+        SootMethod target = expr.getMethod();
+        SootClass tClass = target.getDeclaringClass();
+        Set<String> sink = this.sinkMethodMap.getOrDefault(tClass.getName(), Collections.emptySet());
+        if (sink.contains(target.getName())) {
+          this.reachedSinkMethodList.add(target);
+        }
+        if (!this.excludeMethodList.contains(target.getName())) {
+          callsite.setSource(sourceFilePath + ":" + stmt.getJavaSourceStartLineNumber() + ",1");
+          callsite.setMethodName("[" + tClass.getName() + "]." + target.getName());
+          return callsite;
+        }
       }
-      if (!this.excludeMethodList.contains(target.getName())) {
-        callsite.setSource(sourceFilePath + ":" + stmt.getJavaSourceStartLineNumber() + ",1");
-        callsite.setMethodName("[" + tClass.getName() + "]." + target.getName());
-        return callsite;
-      }
+    } catch (ResolutionFailedException e) {
+      // Some project may invoke method in a non-traditional way, for example
+      // invoking class static method within an object instance of that class.
+      // These invocation could cause ResolutionFailedException and they are skipped
+      // as the normal static invocation is handled in other location. So do nothing here.
     }
 
     return null;

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -42,6 +42,7 @@ import ossf.fuzz.introspector.soot.yaml.FuzzerConfig;
 import ossf.fuzz.introspector.soot.yaml.JavaMethodInfo;
 import soot.Body;
 import soot.PackManager;
+import soot.ResolutionFailedException;
 import soot.Scene;
 import soot.SceneTransformer;
 import soot.SootClass;
@@ -969,7 +970,8 @@ class CustomSenceTransformer extends SceneTransformer {
    *
    * @param stmt the statement to handle
    * @param sourceFilePath the file path for the parent method
-   * @return the callsite object to store in the output yaml file, return null if Soot fails to resolve the invocation
+   * @return the callsite object to store in the output yaml file, return null if Soot fails to
+   *     resolve the invocation
    */
   private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath) {
     // Handle statements of a method
@@ -979,7 +981,8 @@ class CustomSenceTransformer extends SceneTransformer {
         Callsite callsite = new Callsite();
         SootMethod target = expr.getMethod();
         SootClass tClass = target.getDeclaringClass();
-        Set<String> sink = this.sinkMethodMap.getOrDefault(tClass.getName(), Collections.emptySet());
+        Set<String> sink =
+            this.sinkMethodMap.getOrDefault(tClass.getName(), Collections.emptySet());
         if (sink.contains(target.getName())) {
           this.reachedSinkMethodList.add(target);
         }


### PR DESCRIPTION
Some project have non-conventional method invocation that could cause resolution error in Soot analysis. For example, invoking static class method from instance object is a non-conventional code. This PR fixes the problem by setting the analysis option of Soot to ignore resolution error and also to skip possible resolution error as those method should be already be handled when we analyse the class itself.