### PR TITLE
webapp: extend and refactor

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/.gitignore
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/.gitignore
@@ -1,3 +1,4 @@
 *.json
 backup
 outdir*
+oss-fuzz-clone

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -116,7 +116,9 @@ def get_projects_build_status():
 
 def get_introspector_summary():
     introspector_summary_url = OSS_FUZZ_BUILD_STATUS_URL + '/' + INTROSPECTOR_BUILD_JSON
+    #logger.info("Requesting %s"%(introspector_summary_url))
     r = requests.get(introspector_summary_url, timeout=20)
+    #logger.info("Got content")
     return json.loads(r.text)
 
 
@@ -170,6 +172,10 @@ def get_introspector_report_url_report(project_name, datestr):
     return get_introspector_report_url_base(project_name,
                                             datestr) + "fuzz_report.html"
 
+def get_code_coverage_summary_url(project_name, datestr):
+    base_url = 'https://storage.googleapis.com/oss-fuzz-coverage/{0}/reports/{1}/linux/summary.json'
+    project_url = base_url.format(project_name, datestr)
+    return project_url
 
 def get_coverage_report_url(project_name, datestr, language):
     if language == 'java' or language == 'python':
@@ -180,14 +186,19 @@ def get_coverage_report_url(project_name, datestr, language):
     project_url = base_url.format(project_name, datestr, file_report)
     return project_url
 
+def get_code_coverage_summary(project_name, datestr):
+    cov_summary_url = get_code_coverage_summary_url(project_name, datestr)
+    #logger.info("Getting coverage summary: %s"%(cov_summary_url))
+    coverage_summary_raw = requests.get(cov_summary_url, timeout=20).text
+    #logger.info("Got coverage report")
+    try:
+        json_dict = json.loads(coverage_summary_raw)
+        #print(json.dumps(json_dict, indent=4))
+        return json_dict
+    except:
+        return None
 
-def get_all_functions_for_project(project_name, date_str,
-                                  should_include_details, manager_return_dict):
-    """For a given project and date gets a list of function profiles for
-    the project on the givne date, and also creates a project time stamp.
-    The list of function profiles and the project timestamp is returned
-    as a tuple.
-    """
+def extract_introspector_report(project_name, date_str):
     introspector_summary_url = get_introspector_report_url_summary(
         project_name, date_str.replace("-", ""))
     introspector_report_url = get_introspector_report_url_report(
@@ -195,173 +206,301 @@ def get_all_functions_for_project(project_name, date_str,
 
     # Read the introspector atifact
     try:
-        json_raw = requests.get(introspector_summary_url, timeout=10)
+        logger.info("Extracting all functions from: %s"%(introspector_summary_url))
+        raw_introspector_json_request = requests.get(introspector_summary_url, timeout=10)
+        logger.info("Got all functions")
     except:
-        return
+        return None
     try:
-        json_dict = json.loads(json_raw.text)
+        introspector_report = json.loads(raw_introspector_json_request.text)
     except:
-        return
+        return None
 
-    # Access all functions
-    all_function_list = json_dict['MergedProjectProfile']['all-functions']
-    project_stats = json_dict['MergedProjectProfile']['stats']
-    amount_of_fuzzers = len(json_dict) - 2
-    number_of_functions = len(all_function_list)
+    return introspector_report
 
-    functions_covered_estimate = int(number_of_functions * float(0.01 * project_stats['code-coverage-function-percentage']))
-    project_timestamp = {
-        "project_name": project_name,
-        "date": date_str,
-        "coverage_lines": project_stats['code-coverage-function-percentage'],
-        "static_reachability": project_stats['reached-complexity-percentage'],
-        "fuzzer_count": amount_of_fuzzers,
-        "function_count": len(all_function_list),
-        "introspector_report_url": introspector_report_url,
-        "functions_covered_estimate": functions_covered_estimate,
-    }
 
-    refined_proj_list = list()
-    if should_include_details:
-        for func in all_function_list:
-            refined_proj_list.append({
-                'name':
-                func['Func name'],
-                'code_coverage_url':
-                func['func_url'],
-                'function_filename':
-                func['Functions filename'],
-                'runtime_code_coverage':
-                float(func['Func lines hit %'].replace("%", "")),
-                'is_reached':
-                len(func['Reached by Fuzzers']) > 1,
-                'project':
-                project_name,
-                'accumulated_cyclomatic_complexity':
-                func['Accumulated cyclomatic complexity'],
-                'llvm-instruction-count':
-                func['I Count'],
-                'undiscovered-complexity':
-                func['Undiscovered complexity'],
-            })
+def extract_project_data(project_name, date_str,
+                                  should_include_details, manager_return_dict):
+    """
+    Extracts data about a given project on a given date. The data will be placed
+    in manager_return dict.
 
-    # Get all branch blockers
-    branch_pairs = list()
-    if should_include_details:
-        for key in json_dict:
-            # We look for dicts with fuzzer-specific content. The following two
-            # are not such keys, so skip them.
-            if key == "analyses" or key == "MergedProjectProfile":
-                continue
+    The data that will be exracted include:
+    - Details extracted from introspector reports
+        - Function profiles
+        - Static reachability
+        - Number of fuzzers
+    - Details extracted from code coverage reports
+        - Lines of code totally in the project
+        - Lines of code covered at runtime
 
-            # Fuzzer-specific dictionary, get the contents of it.
-            val = json_dict[key]
-            if not isinstance(val, dict):
-                continue
+    OLD: For a given project and date gets a list of function profiles for
+    the project on the given date, and also creates a project time stamp.
+    The list of function profiles and the project timestamp is returned
+    as a tuple.
+    OLD END.
+    """
 
-            branch_blockers = val.get('branch_blockers', None)
-            if branch_blockers == None or not isinstance(
-                    branch_blockers, list):
-                continue
+    # TODO (David): handle the case where there is neither code coverage or introspector reports.
+    # In this case we should simply return an error so it will not be included. This is also useful
+    # for creating history 
 
-            for branch_blocker in branch_blockers:
-                function_blocked = branch_blocker.get('function_name', None)
-                blocked_unique_not_covered_complexity = branch_blocker.get(
-                    'blocked_unique_not_covered_complexity', None)
-                if function_blocked == None:
-                    continue
-                if blocked_unique_not_covered_complexity == None:
-                    continue
-
-                branch_pairs.append({
-                    'project':
-                    project_name,
-                    'function-name':
-                    function_blocked,
-                    'blocked-runtime-coverage':
-                    blocked_unique_not_covered_complexity
-                })
-
+    # Extract programming language of the project
     # The previous techniques we used to set language was quite heuristically.
     # Here, we make a more precise effort by reading the project yaml file.
     try:
-        lang = try_to_get_project_language(project_name)
-        if lang == 'jvm':
-            lang = 'java'
-        project_timestamp['language'] = lang
+        project_language = try_to_get_project_language(project_name)
+        if project_language == 'jvm':
+            project_language = 'java'
     except:
         # Default set to c++ as this is OSS-Fuzz's default.
-        project_timestamp['language'] = 'c++'
+        project_language = 'c++'
 
-    coverage_url = get_coverage_report_url(project_name,
-                                           date_str.replace("-", ""),
-                                           project_timestamp['language'])
-    project_timestamp["coverage_url"] = coverage_url
+    # Extract introspect report.
+    introspector_report = extract_introspector_report(project_name, date_str)
+    introspector_report_url = get_introspector_report_url_report(
+        project_name, date_str.replace("-", ""))
+    if introspector_report == None:
+        return
+    else:
+        # Access all functions
+        all_function_list = introspector_report['MergedProjectProfile']['all-functions']
+        project_stats = introspector_report['MergedProjectProfile']['stats']
+        amount_of_fuzzers = len(introspector_report) - 2
+        number_of_functions = len(all_function_list)
+
+        #functions_covered_estimate = int(number_of_functions * float(0.01 * project_stats['code-coverage-function-percentage']))
+        functions_covered_estimate = project_stats['code-coverage-function-percentage']
+        refined_proj_list = list()
+        if should_include_details:
+            for func in all_function_list:
+                refined_proj_list.append({
+                    'name':
+                    func['Func name'],
+                    'code_coverage_url':
+                    func['func_url'],
+                    'function_filename':
+                    func['Functions filename'],
+                    'runtime_code_coverage':
+                    float(func['Func lines hit %'].replace("%", "")),
+                    'is_reached':
+                    len(func['Reached by Fuzzers']) > 1,
+                    'project':
+                    project_name,
+                    'accumulated_cyclomatic_complexity':
+                    func['Accumulated cyclomatic complexity'],
+                    'llvm-instruction-count':
+                    func['I Count'],
+                    'undiscovered-complexity':
+                    func['Undiscovered complexity'],
+                })
+
+        # Get all branch blockers
+        branch_pairs = list()
+        if should_include_details:
+            for key in introspector_report:
+                # We look for dicts with fuzzer-specific content. The following two
+                # are not such keys, so skip them.
+                if key == "analyses" or key == "MergedProjectProfile":
+                    continue
+
+                # Fuzzer-specific dictionary, get the contents of it.
+                val = introspector_report[key]
+                if not isinstance(val, dict):
+                    continue
+
+                branch_blockers = val.get('branch_blockers', None)
+                if branch_blockers == None or not isinstance(
+                        branch_blockers, list):
+                    continue
+
+                for branch_blocker in branch_blockers:
+                    function_blocked = branch_blocker.get('function_name', None)
+                    blocked_unique_not_covered_complexity = branch_blocker.get(
+                        'blocked_unique_not_covered_complexity', None)
+                    if function_blocked == None:
+                        continue
+                    if blocked_unique_not_covered_complexity == None:
+                        continue
+
+                    branch_pairs.append({
+                        'project':
+                        project_name,
+                        'function-name':
+                        function_blocked,
+                        'blocked-runtime-coverage':
+                        blocked_unique_not_covered_complexity
+                    })
+        introspector_data_dict = {
+            "introspector_report_url": introspector_report_url,
+            "coverage_lines": project_stats['code-coverage-function-percentage'],
+            "static_reachability": project_stats['reached-complexity-percentage'],
+            "fuzzer_count": amount_of_fuzzers,
+            "function_count": len(all_function_list),
+            "functions_covered_estimate": functions_covered_estimate,
+            'refined_proj_list': refined_proj_list,
+            'branch_pairs': branch_pairs,
+        }
+
+
+    # Extract data from the code coverage reports
+    code_coverage_summary = get_code_coverage_summary(project_name, date_str.replace("-", ""))
+    if code_coverage_summary == None:
+        code_coverage_data_dict = None
+    else:
+        if code_coverage_summary != None:
+            line_total_summary = code_coverage_summary['data'][0]['totals']['lines']
+            #line_total_summary['percent']
+            # For the sake of consistency, we re-calculate the percentage. This is because
+            # some of the implentations have a value 0 <= p <= 1 and some have 0 <= p <= 100.
+            try:
+                line_total_summary['percent'] = round(100.0*(float(line_total_summary['covered']) / float(line_total_summary['count'])),2) 
+            except:
+                pass
+        else:
+            line_total_summary = {
+                'count': 0,
+                'covered': 0,
+                'percent': 0,
+            }
+
+        coverage_url = get_coverage_report_url(project_name,
+                                               date_str.replace("-", ""),
+                                               project_language)
+        code_coverage_data_dict = {
+            'coverage_url': coverage_url,
+            'line_coverage': line_total_summary
+        }
+
+    project_timestamp = {
+        "project_name": project_name,
+        "date": date_str,
+        'language': project_language,
+        'coverage-data': code_coverage_data_dict,
+        'introspector-data': introspector_data_dict,
+        #"coverage_lines": project_stats['code-coverage-function-percentage'],
+        #"static_reachability": project_stats['reached-complexity-percentage'],
+        #"fuzzer_count": amount_of_fuzzers,
+        #"function_count": len(all_function_list),
+        #"introspector_report_url": introspector_report_url,
+        #"functions_covered_estimate": functions_covered_estimate,
+    }
+
+
+    # The previous techniques we used to set language was quite heuristically.
+    # Here, we make a more precise effort by reading the project yaml file.
+    #try:
+    #    lang = try_to_get_project_language(project_name)
+    #    if lang == 'jvm':
+    #        lang = 'java'
+    #    project_timestamp['language'] = lang
+    #except:
+    #    # Default set to c++ as this is OSS-Fuzz's default.
+    #    project_timestamp['language'] = 'c++'
+
+
     dictionary_key = '%s###%s' % (project_name, date_str)
     manager_return_dict[dictionary_key] = {
-        'refined_proj_list': refined_proj_list,
-        'branch_pairs': branch_pairs,
-        'project_timestamp': project_timestamp
+        #'refined_proj_list': refined_proj_list,
+        #'branch_pairs': branch_pairs,
+        'project_timestamp': project_timestamp,
+        "introspector-data-dict": introspector_data_dict,
+        "coverage-data-dict": code_coverage_data_dict,
     }
     return
 
 
 def analyse_list_of_projects(date, projects_to_analyse,
                              should_include_details):
-    """Creates a DB snapshot of a list of projects for a given date."""
+    """Creates a DB snapshot of a list of projects for a given date.
+
+    Returns:
+    - A db timestamp, which holds overall stats about the database on a given date.
+    - A list of all functions for this date if `should_include_details` is True.
+    - A list of all branch blockers on this given date if `should_include_details` is True.
+    - A list of project timestamps with information about each project.
+      - This holds data relative to whether coverage and introspector builds succeeds.
+
+    """
     function_list = list()
     fuzz_branch_blocker_list = list()
     project_timestamps = list()
     accummulated_fuzzer_count = 0
     accummulated_function_count = 0
     accummulated_covered_functions = 0
+    accummulated_lines_total = 0
+    accummulated_lines_covered = 0
+
+    # Create a DB timestamp
+    db_timestamp = {
+        "date": date,
+        "project_count": -1,
+        "fuzzer_count": 0,
+        "function_count": 0,
+        "function_coverage_estimate": 0,
+        "accummulated_lines_total": 0,
+        "accummulated_lines_covered": 0,
+    }
+
     idx = 0
     jobs = []
-    return_dict = dict()
+    analyses_dictionary = dict()
+
+    project_name_list = list(projects_to_analyse.keys())
 
     batch_size = 20 if not should_include_details else 5
     all_batches = [
-        projects_to_analyse[x:x + batch_size]
-        for x in range(0, len(projects_to_analyse), batch_size)
+        project_name_list[x:x + batch_size]
+        for x in range(0, len(project_name_list), batch_size)
     ]
 
+    # Extract data from all of the projects using multi-threaded approach.
     for batch in all_batches:
         for project_name in batch:
             idx += 1
             logger.debug("%d" % (len(function_list)))
-            t = Thread(target=get_all_functions_for_project,
+            t = Thread(target=extract_project_data,
                        args=(project_name, date, should_include_details,
-                             return_dict))
+                             analyses_dictionary))
             jobs.append(t)
             t.start()
 
         for proc in jobs:
             proc.join()
 
-    # Accummulate data
+    # Accummulate the data from all the projects.
+    for project_key in analyses_dictionary:
+        # Append project timestamp to the list of timestamps
+        project_timestamp = analyses_dictionary[project_key]['project_timestamp']
+        project_timestamps.append(project_timestamp)        
 
-    for key in return_dict:
-        project_function_list = return_dict[key]['refined_proj_list']
-        branch_pairs = return_dict[key]['branch_pairs']
-        project_timestamp = return_dict[key]['project_timestamp']
+        # Accummulate all function list and branch blockers
+        introspector_dictionary = project_timestamp.get('introspector-data', None)
+        if introspector_dictionary != None:
+            function_list += introspector_dictionary['refined_proj_list']
+            # Remove the function list because we don't want it anymore.
+            introspector_dictionary.pop('refined_proj_list')
+            fuzz_branch_blocker_list += introspector_dictionary['branch_pairs']
 
-        function_list += project_function_list
-        fuzz_branch_blocker_list += branch_pairs
-        project_timestamps.append(project_timestamp)
+            # Accummulate various stats for the DB timestamp.
+            db_timestamp['fuzzer_count'] += introspector_dictionary['fuzzer_count']
+            db_timestamp['function_count'] += introspector_dictionary['function_count']
+            db_timestamp['function_coverage_estimate'] += introspector_dictionary['functions_covered_estimate']
 
-        accummulated_fuzzer_count += project_timestamp['fuzzer_count']
-        accummulated_function_count += project_timestamp['function_count']
+        coverage_dictionary = analyses_dictionary[project_key].get('coverage-data-dict', None)
+        if coverage_dictionary != None:
+            # Accummulate various stats for the DB timestamp.
+            db_timestamp["accummulated_lines_total"] += coverage_dictionary['line_coverage']['count']
+            db_timestamp["accummulated_lines_covered"] += coverage_dictionary['line_coverage']['covered']
 
-        accummulated_covered_functions += project_timestamp['functions_covered_estimate']
+            # We include in project count if coverage is in here
+            db_timestamp["project_count"] += 1
 
-    # Create a DB timestamp
-    db_timestamp = {
-        "date": date,
-        "project_count": len(project_timestamps),
-        "fuzzer_count": accummulated_fuzzer_count,
-        "function_count": accummulated_function_count,
-        "function_coverage_estimate": accummulated_covered_functions,
-    }
+    # Return:
+    # - all functions
+    # - all branch blockers
+    # - a list of project timestamps
+    # - the DB timestamp
     return function_list, fuzz_branch_blocker_list, project_timestamps, db_timestamp
 
 
@@ -443,6 +582,7 @@ def update_db_files(db_timestamp, project_timestamps, function_list,
     extend_db_json_files(project_timestamps, output_directory)
     extend_db_timestamps(db_timestamp, output_directory)
 
+
 def update_build_status(build_dict):
     with open(DB_BUILD_STATUS_JSON, "w") as f:
         json.dump(build_dict, f)
@@ -501,6 +641,23 @@ def setup_folders(input_directory, output_directory):
         os.mkdir(output_directory)
 
 
+def extract_oss_fuzz_build_status(output_directory):
+    """Extracts fuzz/coverage/introspector build status from OSS-Fuzz stats."""
+    global OSS_FUZZ_CLONE
+
+    # Extract the build status of all OSS-Fuzz projects
+    # Create a local clone of OSS-Fuzz. This is used for checking language of a project easily.
+    oss_fuzz_local_clone = os.path.join(output_directory, "oss-fuzz-clone")
+    if os.path.isdir(oss_fuzz_local_clone):
+        shutil.rmtree(oss_fuzz_local_clone)
+    git_clone_project("https://github.com/google/oss-fuzz", oss_fuzz_local_clone)
+
+    OSS_FUZZ_CLONE = oss_fuzz_local_clone
+    build_status_dict = get_projects_build_status()
+    update_build_status(build_status_dict)
+    return build_status_dict
+
+
 def create_date_range(day_offset, days_to_analyse):
     date_range = []
     range_to_analyse = range(day_offset + days_to_analyse, day_offset, -1)
@@ -511,11 +668,31 @@ def create_date_range(day_offset, days_to_analyse):
 
 def create_db(max_projects, days_to_analyse, output_directory, input_directory,
               day_offset, to_cleanup, since_date):
-    global OSS_FUZZ_CLONE
     setup_folders(input_directory, output_directory)
-    project_list = get_latest_valid_reports()
-    if max_projects > 0 and len(project_list) > max_projects:
-        project_list = project_list[0:max_projects]
+
+    # Extract fuzz/coverage/introspector build status of each project and extract
+    projects_list_build_status = extract_oss_fuzz_build_status(output_directory)
+    projects_to_analyse = dict()
+    for p in projects_list_build_status:
+        if projects_list_build_status[p]['introspector-build'] == True and projects_list_build_status[p]['cov-build'] == True:
+            projects_to_analyse[p] = projects_list_build_status[p]
+    #for project_name in projects_list_build_status:
+    #    print("project: %s"%(project_name))
+
+    # Reduce the amount of projects if needed.
+    if max_projects > 0 and len(projects_to_analyse) > max_projects:
+        tmp_dictionary = dict()
+        idx = 0
+        for k in projects_to_analyse:
+            if idx > max_projects:
+                break
+            tmp_dictionary[k] = projects_to_analyse[k]
+            idx += 1
+        projects_to_analyse = tmp_dictionary
+
+    #project_list = get_latest_valid_reports()
+    #if max_projects > 0 and len(project_list) > max_projects:
+    #    project_list = project_list[0:max_projects]
 
     if to_cleanup:
         cleanup(output_directory)
@@ -532,21 +709,13 @@ def create_db(max_projects, days_to_analyse, output_directory, input_directory,
     logger.info("Creating a DB with the specifications:")
     logger.info("- Date range: [%s : %s]" %
                 (str(date_range[0]), str(date_range[-1])))
-    logger.info("- Total of %d projects to analyse" % (len(project_list)))
+    logger.info("- Total of %d projects to analyse" % (len(projects_to_analyse)))
     if input_directory is not None:
         logger.info("- Extending upon the DB in %s" % (str(input_directory)))
     else:
         logger.info("-Creating the DB from scratch")
 
-    oss_fuzz_local_clone = os.path.join(output_directory, "oss-fuzz-clone")
-    if os.path.isdir(oss_fuzz_local_clone):
-        shutil.rmtree(oss_fuzz_local_clone)
-    git_clone_project("https://github.com/google/oss-fuzz", oss_fuzz_local_clone)
-
-    OSS_FUZZ_CLONE = oss_fuzz_local_clone
-    build_status_dict = get_projects_build_status()
-    update_build_status(build_status_dict)
-    analyse_set_of_dates(date_range, project_list, output_directory)
+    analyse_set_of_dates(date_range, projects_to_analyse, output_directory)
 
 
 def get_cmdline_parser():

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -66,6 +66,7 @@ def git_clone_project(github_url, destination):
         return False
     return True
 
+
 def get_projects_build_status():
     fuzz_build_url = OSS_FUZZ_BUILD_STATUS_URL + '/' + FUZZ_BUILD_JSON
     coverage_build_url = OSS_FUZZ_BUILD_STATUS_URL + '/' + COVERAGE_BUILD_JSON
@@ -73,7 +74,8 @@ def get_projects_build_status():
 
     fuzz_build_raw = requests.get(fuzz_build_url, timeout=20).text
     coverage_build_raw = requests.get(coverage_build_url, timeout=20).text
-    introspector_build_raw = requests.get(introspector_build_url, timeout=20).text
+    introspector_build_raw = requests.get(introspector_build_url,
+                                          timeout=20).text
 
     fuzz_build_json = json.loads(fuzz_build_raw)
     cov_build_json = json.loads(coverage_build_raw)
@@ -83,21 +85,27 @@ def get_projects_build_status():
     for p in fuzz_build_json['projects']:
         project_dict = build_status_dict.get(p['name'], dict())
         project_dict['fuzz-build'] = p['history'][0]['success']
-        project_dict['fuzz-build-log'] = OSS_FUZZ_BUILD_LOG_BASE + p['history'][0]['build_id'] + '.txt'
+        project_dict['fuzz-build-log'] = OSS_FUZZ_BUILD_LOG_BASE + p[
+            'history'][0]['build_id'] + '.txt'
         build_status_dict[p['name']] = project_dict
     for p in cov_build_json['projects']:
         project_dict = build_status_dict.get(p['name'], dict())
         project_dict['cov-build'] = p['history'][0]['success']
-        project_dict['cov-build-log'] = OSS_FUZZ_BUILD_LOG_BASE + p['history'][0]['build_id'] + '.txt'
+        project_dict['cov-build-log'] = OSS_FUZZ_BUILD_LOG_BASE + p['history'][
+            0]['build_id'] + '.txt'
         build_status_dict[p['name']] = project_dict
     for p in introspector_build_json['projects']:
         project_dict = build_status_dict.get(p['name'], dict())
         project_dict['introspector-build'] = p['history'][0]['success']
-        project_dict['introspector-build-log'] = OSS_FUZZ_BUILD_LOG_BASE + p['history'][0]['build_id'] + '.txt'
+        project_dict['introspector-build-log'] = OSS_FUZZ_BUILD_LOG_BASE + p[
+            'history'][0]['build_id'] + '.txt'
         build_status_dict[p['name']] = project_dict
 
     # Ensure all fields are set in each dictionary
-    needed_keys = ['introspector-build', 'fuzz-build', 'cov-build', 'introspector-build-log', 'cov-build-log', 'fuzz-build-log']
+    needed_keys = [
+        'introspector-build', 'fuzz-build', 'cov-build',
+        'introspector-build-log', 'cov-build-log', 'fuzz-build-log'
+    ]
     for project_name in build_status_dict:
         project_dict = build_status_dict[project_name]
         for needed_key in needed_keys:
@@ -111,8 +119,9 @@ def get_projects_build_status():
         except:
             project_language = 'N/A'
         build_status_dict[project_name]['language'] = project_language
-    print("Number of projects: %d"%(len(build_status_dict)))
+    print("Number of projects: %d" % (len(build_status_dict)))
     return build_status_dict
+
 
 def get_introspector_summary():
     introspector_summary_url = OSS_FUZZ_BUILD_STATUS_URL + '/' + INTROSPECTOR_BUILD_JSON
@@ -139,9 +148,11 @@ def get_latest_valid_reports():
 
 def try_to_get_project_language(project_name):
     if os.path.isdir(OSS_FUZZ_CLONE):
-        local_project_path = os.path.join(OSS_FUZZ_CLONE, "projects", project_name)
+        local_project_path = os.path.join(OSS_FUZZ_CLONE, "projects",
+                                          project_name)
         if os.path.isdir(local_project_path):
-            project_yaml_path = os.path.join(local_project_path, "project.yaml")
+            project_yaml_path = os.path.join(local_project_path,
+                                             "project.yaml")
             if os.path.isfile(project_yaml_path):
                 with open(project_yaml_path, "r") as f:
                     project_yaml = yaml.safe_load(f.read())
@@ -170,10 +181,12 @@ def get_introspector_report_url_report(project_name, datestr):
     return get_introspector_report_url_base(project_name,
                                             datestr) + "fuzz_report.html"
 
+
 def get_code_coverage_summary_url(project_name, datestr):
     base_url = 'https://storage.googleapis.com/oss-fuzz-coverage/{0}/reports/{1}/linux/summary.json'
     project_url = base_url.format(project_name, datestr)
     return project_url
+
 
 def get_coverage_report_url(project_name, datestr, language):
     if language == 'java' or language == 'python':
@@ -184,6 +197,7 @@ def get_coverage_report_url(project_name, datestr, language):
     project_url = base_url.format(project_name, datestr, file_report)
     return project_url
 
+
 def get_code_coverage_summary(project_name, datestr):
     cov_summary_url = get_code_coverage_summary_url(project_name, datestr)
     coverage_summary_raw = requests.get(cov_summary_url, timeout=20).text
@@ -193,6 +207,7 @@ def get_code_coverage_summary(project_name, datestr):
     except:
         return None
 
+
 def extract_introspector_report(project_name, date_str):
     introspector_summary_url = get_introspector_report_url_summary(
         project_name, date_str.replace("-", ""))
@@ -201,8 +216,10 @@ def extract_introspector_report(project_name, date_str):
 
     # Read the introspector atifact
     try:
-        logger.info("Extracting all functions from: %s"%(introspector_summary_url))
-        raw_introspector_json_request = requests.get(introspector_summary_url, timeout=10)
+        logger.info("Extracting all functions from: %s" %
+                    (introspector_summary_url))
+        raw_introspector_json_request = requests.get(introspector_summary_url,
+                                                     timeout=10)
         logger.info("Got all functions")
     except:
         return None
@@ -214,8 +231,8 @@ def extract_introspector_report(project_name, date_str):
     return introspector_report
 
 
-def extract_project_data(project_name, date_str,
-                                  should_include_details, manager_return_dict):
+def extract_project_data(project_name, date_str, should_include_details,
+                         manager_return_dict):
     """
     Extracts data about a given project on a given date. The data will be placed
     in manager_return dict.
@@ -232,7 +249,7 @@ def extract_project_data(project_name, date_str,
 
     # TODO (David): handle the case where there is neither code coverage or introspector reports.
     # In this case we should simply return an error so it will not be included. This is also useful
-    # for creating history 
+    # for creating history
 
     # Extract programming language of the project
     # The previous techniques we used to set language was quite heuristically.
@@ -246,7 +263,8 @@ def extract_project_data(project_name, date_str,
         project_language = 'c++'
 
     # Extract code coverage and introspector reports.
-    code_coverage_summary = get_code_coverage_summary(project_name, date_str.replace("-", ""))
+    code_coverage_summary = get_code_coverage_summary(
+        project_name, date_str.replace("-", ""))
     introspector_report = extract_introspector_report(project_name, date_str)
     introspector_report_url = get_introspector_report_url_report(
         project_name, date_str.replace("-", ""))
@@ -263,13 +281,15 @@ def extract_project_data(project_name, date_str,
 
     if introspector_report != None:
         # Access all functions
-        all_function_list = introspector_report['MergedProjectProfile']['all-functions']
+        all_function_list = introspector_report['MergedProjectProfile'][
+            'all-functions']
         project_stats = introspector_report['MergedProjectProfile']['stats']
         amount_of_fuzzers = len(introspector_report) - 2
         number_of_functions = len(all_function_list)
 
         #functions_covered_estimate = int(number_of_functions * float(0.01 * project_stats['code-coverage-function-percentage']))
-        functions_covered_estimate = project_stats['code-coverage-function-percentage']
+        functions_covered_estimate = project_stats[
+            'code-coverage-function-percentage']
         refined_proj_list = list()
         if should_include_details:
             for func in all_function_list:
@@ -314,7 +334,8 @@ def extract_project_data(project_name, date_str,
                     continue
 
                 for branch_blocker in branch_blockers:
-                    function_blocked = branch_blocker.get('function_name', None)
+                    function_blocked = branch_blocker.get(
+                        'function_name', None)
                     blocked_unique_not_covered_complexity = branch_blocker.get(
                         'blocked_unique_not_covered_complexity', None)
                     if function_blocked == None:
@@ -332,8 +353,10 @@ def extract_project_data(project_name, date_str,
                     })
         introspector_data_dict = {
             "introspector_report_url": introspector_report_url,
-            "coverage_lines": project_stats['code-coverage-function-percentage'],
-            "static_reachability": project_stats['reached-complexity-percentage'],
+            "coverage_lines":
+            project_stats['code-coverage-function-percentage'],
+            "static_reachability":
+            project_stats['reached-complexity-percentage'],
             "fuzzer_count": amount_of_fuzzers,
             "function_count": len(all_function_list),
             "functions_covered_estimate": functions_covered_estimate,
@@ -341,18 +364,20 @@ def extract_project_data(project_name, date_str,
             'branch_pairs': branch_pairs,
         }
 
-
     # Extract data from the code coverage reports
     if code_coverage_summary == None:
         code_coverage_data_dict = None
     else:
         if code_coverage_summary != None:
-            line_total_summary = code_coverage_summary['data'][0]['totals']['lines']
+            line_total_summary = code_coverage_summary['data'][0]['totals'][
+                'lines']
             #line_total_summary['percent']
             # For the sake of consistency, we re-calculate the percentage. This is because
             # some of the implentations have a value 0 <= p <= 1 and some have 0 <= p <= 100.
             try:
-                line_total_summary['percent'] = round(100.0*(float(line_total_summary['covered']) / float(line_total_summary['count'])),2) 
+                line_total_summary['percent'] = round(
+                    100.0 * (float(line_total_summary['covered']) /
+                             float(line_total_summary['count'])), 2)
             except:
                 pass
         else:
@@ -450,11 +475,13 @@ def analyse_list_of_projects(date, projects_to_analyse,
     # Accummulate the data from all the projects.
     for project_key in analyses_dictionary:
         # Append project timestamp to the list of timestamps
-        project_timestamp = analyses_dictionary[project_key]['project_timestamp']
-        project_timestamps.append(project_timestamp)        
+        project_timestamp = analyses_dictionary[project_key][
+            'project_timestamp']
+        project_timestamps.append(project_timestamp)
 
         # Accummulate all function list and branch blockers
-        introspector_dictionary = project_timestamp.get('introspector-data', None)
+        introspector_dictionary = project_timestamp.get(
+            'introspector-data', None)
         if introspector_dictionary != None:
             function_list += introspector_dictionary['refined_proj_list']
             # Remove the function list because we don't want it anymore.
@@ -462,15 +489,22 @@ def analyse_list_of_projects(date, projects_to_analyse,
             fuzz_branch_blocker_list += introspector_dictionary['branch_pairs']
 
             # Accummulate various stats for the DB timestamp.
-            db_timestamp['fuzzer_count'] += introspector_dictionary['fuzzer_count']
-            db_timestamp['function_count'] += introspector_dictionary['function_count']
-            db_timestamp['function_coverage_estimate'] += introspector_dictionary['functions_covered_estimate']
+            db_timestamp['fuzzer_count'] += introspector_dictionary[
+                'fuzzer_count']
+            db_timestamp['function_count'] += introspector_dictionary[
+                'function_count']
+            db_timestamp[
+                'function_coverage_estimate'] += introspector_dictionary[
+                    'functions_covered_estimate']
 
-        coverage_dictionary = analyses_dictionary[project_key].get('coverage-data-dict', None)
+        coverage_dictionary = analyses_dictionary[project_key].get(
+            'coverage-data-dict', None)
         if coverage_dictionary != None:
             # Accummulate various stats for the DB timestamp.
-            db_timestamp["accummulated_lines_total"] += coverage_dictionary['line_coverage']['count']
-            db_timestamp["accummulated_lines_covered"] += coverage_dictionary['line_coverage']['covered']
+            db_timestamp["accummulated_lines_total"] += coverage_dictionary[
+                'line_coverage']['count']
+            db_timestamp["accummulated_lines_covered"] += coverage_dictionary[
+                'line_coverage']['covered']
 
             # We include in project count if coverage is in here
             db_timestamp["project_count"] += 1
@@ -566,6 +600,7 @@ def update_build_status(build_dict):
     with open(DB_BUILD_STATUS_JSON, "w") as f:
         json.dump(build_dict, f)
 
+
 def analyse_set_of_dates(dates, projects_to_analyse, output_directory):
     """Pe/rforms analysis of all projects in the projects_to_analyse argument for
     the given set of dates. DB .json files are stored in output_directory.
@@ -629,7 +664,8 @@ def extract_oss_fuzz_build_status(output_directory):
     oss_fuzz_local_clone = os.path.join(output_directory, "oss-fuzz-clone")
     if os.path.isdir(oss_fuzz_local_clone):
         shutil.rmtree(oss_fuzz_local_clone)
-    git_clone_project("https://github.com/google/oss-fuzz", oss_fuzz_local_clone)
+    git_clone_project("https://github.com/google/oss-fuzz",
+                      oss_fuzz_local_clone)
 
     OSS_FUZZ_CLONE = oss_fuzz_local_clone
     build_status_dict = get_projects_build_status()
@@ -650,10 +686,13 @@ def create_db(max_projects, days_to_analyse, output_directory, input_directory,
     setup_folders(input_directory, output_directory)
 
     # Extract fuzz/coverage/introspector build status of each project and extract
-    projects_list_build_status = extract_oss_fuzz_build_status(output_directory)
+    projects_list_build_status = extract_oss_fuzz_build_status(
+        output_directory)
     projects_to_analyse = dict()
     for p in projects_list_build_status:
-        if projects_list_build_status[p]['introspector-build'] == True and projects_list_build_status[p]['cov-build'] == True:
+        if projects_list_build_status[p][
+                'introspector-build'] == True and projects_list_build_status[
+                    p]['cov-build'] == True:
             projects_to_analyse[p] = projects_list_build_status[p]
     #for project_name in projects_list_build_status:
     #    print("project: %s"%(project_name))
@@ -684,7 +723,8 @@ def create_db(max_projects, days_to_analyse, output_directory, input_directory,
     logger.info("Creating a DB with the specifications:")
     logger.info("- Date range: [%s : %s]" %
                 (str(date_range[0]), str(date_range[-1])))
-    logger.info("- Total of %d projects to analyse" % (len(projects_to_analyse)))
+    logger.info("- Total of %d projects to analyse" %
+                (len(projects_to_analyse)))
     if input_directory is not None:
         logger.info("- Extending upon the DB in %s" % (str(input_directory)))
     else:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -245,13 +245,23 @@ def extract_project_data(project_name, date_str,
         # Default set to c++ as this is OSS-Fuzz's default.
         project_language = 'c++'
 
-    # Extract introspect report.
+    # Extract code coverage and introspector reports.
+    code_coverage_summary = get_code_coverage_summary(project_name, date_str.replace("-", ""))
     introspector_report = extract_introspector_report(project_name, date_str)
     introspector_report_url = get_introspector_report_url_report(
         project_name, date_str.replace("-", ""))
-    if introspector_report == None:
+
+    # Currently, we fail if any of code_coverage_summary of introspector_report is
+    # None. This should later be adjusted such that we can continue if we only
+    # have code coverage but no introspector data. However, we need to adjust
+    # the OSS-Fuzz data generated before doing so, we need some basic stats e.g.
+    # number of fuzzers, which are currently only available in Fuzz Introspector.
+    if code_coverage_summary == None or introspector_report == None:
+        # Do not adjust the `manager_return_dict`, so nothing will be included in
+        # the report.
         return
-    else:
+
+    if introspector_report != None:
         # Access all functions
         all_function_list = introspector_report['MergedProjectProfile']['all-functions']
         project_stats = introspector_report['MergedProjectProfile']['stats']
@@ -333,7 +343,6 @@ def extract_project_data(project_name, date_str,
 
 
     # Extract data from the code coverage reports
-    code_coverage_summary = get_code_coverage_summary(project_name, date_str.replace("-", ""))
     if code_coverage_summary == None:
         code_coverage_data_dict = None
     else:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -216,11 +216,8 @@ def extract_introspector_report(project_name, date_str):
 
     # Read the introspector atifact
     try:
-        logger.info("Extracting all functions from: %s" %
-                    (introspector_summary_url))
         raw_introspector_json_request = requests.get(introspector_summary_url,
                                                      timeout=10)
-        logger.info("Got all functions")
     except:
         return None
     try:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -116,9 +116,7 @@ def get_projects_build_status():
 
 def get_introspector_summary():
     introspector_summary_url = OSS_FUZZ_BUILD_STATUS_URL + '/' + INTROSPECTOR_BUILD_JSON
-    #logger.info("Requesting %s"%(introspector_summary_url))
     r = requests.get(introspector_summary_url, timeout=20)
-    #logger.info("Got content")
     return json.loads(r.text)
 
 
@@ -188,12 +186,9 @@ def get_coverage_report_url(project_name, datestr, language):
 
 def get_code_coverage_summary(project_name, datestr):
     cov_summary_url = get_code_coverage_summary_url(project_name, datestr)
-    #logger.info("Getting coverage summary: %s"%(cov_summary_url))
     coverage_summary_raw = requests.get(cov_summary_url, timeout=20).text
-    #logger.info("Got coverage report")
     try:
         json_dict = json.loads(coverage_summary_raw)
-        #print(json.dumps(json_dict, indent=4))
         return json_dict
     except:
         return None
@@ -233,12 +228,6 @@ def extract_project_data(project_name, date_str,
     - Details extracted from code coverage reports
         - Lines of code totally in the project
         - Lines of code covered at runtime
-
-    OLD: For a given project and date gets a list of function profiles for
-    the project on the given date, and also creates a project time stamp.
-    The list of function profiles and the project timestamp is returned
-    as a tuple.
-    OLD END.
     """
 
     # TODO (David): handle the case where there is neither code coverage or introspector reports.
@@ -378,26 +367,7 @@ def extract_project_data(project_name, date_str,
         'language': project_language,
         'coverage-data': code_coverage_data_dict,
         'introspector-data': introspector_data_dict,
-        #"coverage_lines": project_stats['code-coverage-function-percentage'],
-        #"static_reachability": project_stats['reached-complexity-percentage'],
-        #"fuzzer_count": amount_of_fuzzers,
-        #"function_count": len(all_function_list),
-        #"introspector_report_url": introspector_report_url,
-        #"functions_covered_estimate": functions_covered_estimate,
     }
-
-
-    # The previous techniques we used to set language was quite heuristically.
-    # Here, we make a more precise effort by reading the project yaml file.
-    #try:
-    #    lang = try_to_get_project_language(project_name)
-    #    if lang == 'jvm':
-    #        lang = 'java'
-    #    project_timestamp['language'] = lang
-    #except:
-    #    # Default set to c++ as this is OSS-Fuzz's default.
-    #    project_timestamp['language'] = 'c++'
-
 
     dictionary_key = '%s###%s' % (project_name, date_str)
     manager_return_dict[dictionary_key] = {
@@ -689,10 +659,6 @@ def create_db(max_projects, days_to_analyse, output_directory, input_directory,
             tmp_dictionary[k] = projects_to_analyse[k]
             idx += 1
         projects_to_analyse = tmp_dictionary
-
-    #project_list = get_latest_valid_reports()
-    #if max_projects > 0 and len(project_list) > max_projects:
-    #    project_list = project_list[0:max_projects]
 
     if to_cleanup:
         cleanup(output_directory)

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -365,8 +365,13 @@ def extract_project_data(project_name, date_str, should_include_details,
         code_coverage_data_dict = None
     else:
         if code_coverage_summary != None:
-            line_total_summary = code_coverage_summary['data'][0]['totals'][
-                'lines']
+            try:
+                line_total_summary = code_coverage_summary['data'][0]['totals'][
+                    'lines']
+            except KeyError:
+                # This can happen in Python, where the correct code formatting was only done
+                # May 3rd 2023: https://github.com/google/oss-fuzz/pull/10201
+                return
             #line_total_summary['percent']
             # For the sake of consistency, we re-calculate the percentage. This is because
             # some of the implentations have a value 0 <= p <= 1 and some have 0 <= p <= 100.

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -287,7 +287,6 @@ def extract_project_data(project_name, date_str, should_include_details,
         amount_of_fuzzers = len(introspector_report) - 2
         number_of_functions = len(all_function_list)
 
-        #functions_covered_estimate = int(number_of_functions * float(0.01 * project_stats['code-coverage-function-percentage']))
         functions_covered_estimate = project_stats[
             'code-coverage-function-percentage']
         refined_proj_list = list()

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -46,7 +46,9 @@ def load_db():
                                project_count=ts['project_count'],
                                fuzzer_count=ts['fuzzer_count'],
                                function_count=ts['function_count'],
-                               function_coverage_estimate=ts['function_coverage_estimate']))
+                               function_coverage_estimate=ts['function_coverage_estimate'],
+                               accummulated_lines_total=ts['accummulated_lines_total'],
+                               accummulated_lines_covered=ts['accummulated_lines_covered']))
 
     with open(all_functions_file, 'r') as f:
         all_function_list = json.load(f)
@@ -86,10 +88,9 @@ def load_db():
             models.ProjectTimestamp(
                 date=project_timestamp['date'],
                 project_name=project_timestamp['project_name'],
-                coverage_lines=project_timestamp['coverage_lines'],
-                static_reachability=project_timestamp['static_reachability'],
-                fuzzer_count=project_timestamp['fuzzer_count'],
-                coverage_functions=project_timestamp['coverage_lines']))
+                language=project_timestamp['language'],
+                coverage_data=project_timestamp['coverage-data'],
+                introspector_data=project_timestamp['introspector-data']))
 
     # Load all profiles
     with open(project_currents, 'r') as f:
@@ -99,12 +100,10 @@ def load_db():
             models.Project(
                 name=project_timestamp['project_name'],
                 language=project_timestamp.get('language', 'c'),
-                fuzz_count=project_timestamp['fuzzer_count'],
-                reach=project_timestamp['static_reachability'],
-                runtime_cov=project_timestamp['coverage_lines'],
-                introspector_report_url=project_timestamp[
-                    'introspector_report_url'],
-                code_coverage_report_url=project_timestamp['coverage_url']))
+                date=project_timestamp['date'],
+                coverage_data=project_timestamp['coverage-data'],
+                introspector_data=project_timestamp['introspector-data']
+        ))
 
     if os.path.isfile(projects_build_status):
         # Read the builds

--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -23,12 +23,15 @@ def get_date_at_offset_as_str(day_offset=-1):
 
 class DBTimestamp:
 
-    def __init__(self, date, project_count, fuzzer_count, function_count, function_coverage_estimate):
+    def __init__(self, date, project_count, fuzzer_count, function_count,
+                 function_coverage_estimate, accummulated_lines_total, accummulated_lines_covered):
         self.date = date
         self.project_count = project_count
         self.fuzzer_count = fuzzer_count
         self.function_count = function_count
         self.function_coverage_estimate = function_coverage_estimate
+        self.accummulated_lines_total = accummulated_lines_total
+        self.accummulated_lines_covered = accummulated_lines_covered
 
 
 class DBSummary:
@@ -44,28 +47,23 @@ class DBSummary:
 
 class ProjectTimestamp:
 
-    def __init__(self, project_name, date, coverage_lines, coverage_functions,
-                 static_reachability, fuzzer_count):
+    def __init__(self, project_name, date, language, coverage_data, introspector_data):
         self.project_name = project_name
         # date in the format Y-m-d
         self.date = date
-        self.coverage_lines = coverage_lines
-        self.coverage_functions = coverage_functions
-        self.static_reachability = static_reachability
-        self.fuzzer_count = fuzzer_count
+        self.language = language
+        self.coverage_data = coverage_data
+        self.introspector_data = introspector_data
 
 
 class Project:
 
-    def __init__(self, name, language, fuzz_count, reach, runtime_cov,
-                 introspector_report_url, code_coverage_report_url):
+    def __init__(self, name, language, date, coverage_data, introspector_data):
         self.name = name
         self.language = language
-        self.fuzz_count = fuzz_count
-        self.reach = reach
-        self.runtime_cov = runtime_cov
-        self.introspector_report_url = introspector_report_url
-        self.code_coverage_report_url = code_coverage_report_url
+        self.date = date
+        self.coverage_data = coverage_data
+        self.introspector_data = introspector_data
 
 
 class Function:

--- a/tools/web-fuzzing-introspection/app/webapp/templates/index.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/index.html
@@ -143,8 +143,8 @@ const function_count_over_time2 = [];
 db_timestamp_x_axis.push("{{db_timestamp.date}}");
 project_count_over_time.push({{db_timestamp.project_count}})
 fuzzer_count_over_time.push({{db_timestamp.fuzzer_count}})
-function_count_over_time.push({{db_timestamp.function_count}})
-function_count_over_time2.push({{db_timestamp.function_coverage_estimate}})
+function_count_over_time.push({{db_timestamp.accummulated_lines_total}})
+function_count_over_time2.push({{db_timestamp.accummulated_lines_covered}})
 {%endfor%}
 
 
@@ -206,7 +206,7 @@ const function_count_over_time_data2 = [{
 
 const function_count_over_time_layout = {
   xaxis: {title: "Date"},
-        yaxis: {title: "Functions", range: [0.0, {{max_function_count}}]},  
+        yaxis: {title: "Functions", range: [0.0, {{max_line_count}}]},  
   type: "scatter",
   paper_bgcolor: "rgba(0,0,0,0)",
   plot_bgcolor: "rgba(0,0,0,0)"

--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -28,7 +28,7 @@
                   <tr>
                     <td>Code coverage</td>
                     {% if has_project_details %}
-                      <td> {{ '%0.2f' % project.runtime_cov |float}}% </td>
+                      <td> {{ '%0.2f' % project.coverage_data.line_coverage.percent |float}}% </td>
                     {% else %}
                       <td>N/A</td>
                     {% endif %}                      
@@ -36,7 +36,7 @@
                   <tr>
                     <td>Static reachability</td>
                     {% if has_project_details %}
-                      <td> {{ '%0.2f' % project.reach |float }} </td>
+                      <td> {{ '%0.2f' % project.introspector_data.static_reachability |float }} </td>
                     {% else %}
                       <td>N/A</td>
                     {% endif %}
@@ -44,7 +44,7 @@
                   <tr>
                     <td>Code coverage report</td>
                     {% if has_project_details %}
-                    <td><a href="{{ project.code_coverage_report_url }}">Report link</a></td>
+                    <td><a href="{{ project.coverage_data.coverage_url }}">Report link</a></td>
                     {% else %}
                       <td>N/A</td>
                     {% endif %}                             
@@ -52,7 +52,7 @@
                   <tr>
                     <td>Fuzz Introspector report</td>
                     {% if has_project_details %}
-                      <td><a href="{{ project.introspector_report_url }}">Report link</a></td>
+                      <td><a href="{{ project.introspector_data.introspector_report_url }}">Report link</a></td>
                     {% else %}
                       <td>N/A</td>
                     {% endif %}                      
@@ -125,12 +125,12 @@ const fuzzer_count_y = [];
 max_fuzzer_count = 0;
 
 {% for project_timestamp in project_statistics %}
-code_coverage_lines_x.push("{{project_timestamp.date}}");
-code_coverage_lines_y.push({{project_timestamp.coverage_lines}});
-code_coverage_functions_y.push({{project_timestamp.coverage_functions}});
-code_reachability_y.push({{project_timestamp.static_reachability}});
-fuzzer_count_y.push({{project_timestamp.fuzzer_count}});
-max_fuzzer_count = Math.max(max_fuzzer_count, {{project_timestamp.fuzzer_count}});
+  code_coverage_lines_x.push("{{project_timestamp.date}}");
+  code_coverage_lines_y.push({{project_timestamp.coverage_data.line_coverage.percent}});
+  code_coverage_functions_y.push({{project_timestamp.introspector_data.functions_covered_estimate}});
+  code_reachability_y.push({{project_timestamp.introspector_data.static_reachability}});
+  fuzzer_count_y.push({{project_timestamp.introspector_data.fuzzer_count}});
+  max_fuzzer_count = Math.max(max_fuzzer_count, {{project_timestamp.introspector_data.fuzzer_count}});
 {%endfor%}
 
 // Plot for code coverage in terms of lines over time

--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -36,7 +36,7 @@
                   <tr>
                     <td>Static reachability</td>
                     {% if has_project_details %}
-                      <td> {{ '%0.2f' % project.introspector_data.static_reachability |float }} </td>
+                      <td> {{ '%0.2f' % project.introspector_data.static_reachability |float }}% </td>
                     {% else %}
                       <td>N/A</td>
                     {% endif %}

--- a/tools/web-fuzzing-introspection/app/webapp/templates/projects-overview.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/projects-overview.html
@@ -36,9 +36,9 @@
                   <tr>
                       <td> <a href="/project-profile?project={{project.name}}">{{ project.name }}</a> </td>
                       <td> {{ project.language }} </td>
-                      <td> {{ project.fuzz_count }} </td>
-                      <td> {{ '%0.2f' % project.reach |float }} </td>
-                      <td> {{ '%0.2f' % project.runtime_cov |float }} </td>
+                      <td> {{ project.introspector_data.fuzzer_count }} </td>
+                      <td> {{ '%0.2f' % project.introspector_data.static_reachability |float }} </td>
+                      <td> {{ '%0.2f' % project.coverage_data.line_coverage.percent |float }} </td>
                   </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
The central theme of this PR is to split data sources from the fuzz runs into two:
- data from code coverage
- data from fuzz introspector analysis

The goal is to make https://introspector.oss-fuzz.com/ display data on all OSS-Fuzz projects that have either code coverage or introspector builds successful. Currently it only shows results for project with successful introspector results, which limits the number of projects shown.

The common denominator between OSS-Fuzz projects in terms of artifacts produced by code coverage builds is line coverage. All but Python have more common denominators, e.g. function coverage. As such, we use line coverage from coverage builds.

However, we cannot make the full transition yet, because there is currently a limitation in the data we have available from OSS-Fuzz where we do not have the number of fuzzers for a given project unless we have introspector reports. The number of fuzzers analysed in the data set is important, so I'll leave the dependency on introspector reports for now. However, I'll post a PR on OSS-Fuzz to adjust for this and when that is done then we should have enough good information to show data about all projects with either introspector/coverage builds, meaning we will display data about Golang and Rust projects too. As such, this PR gets us almost all the way there but will need a few nits when the OSS-Fuzz changes has been done.