### PR TITLE
Java frontend: Fix duplicate callsite

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/Callsite.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/Callsite.java
@@ -38,4 +38,14 @@ public class Callsite {
   public void setMethodName(String methodName) {
     this.methodName = methodName;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Callsite) {
+      String selfMethodName = this.getMethodName();
+      String objMethodName = ((Callsite) obj).getMethodName();
+      return selfMethodName.equals(objMethodName);
+    }
+    return false;
+  }
 }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
@@ -216,7 +216,16 @@ public class FunctionElement {
   }
 
   public void addCallsite(Callsite callsite) {
-    this.callsites.add(callsite);
+    Boolean duplicate = false;
+    for (Callsite item : this.callsites) {
+      if (item.equals(callsite)) {
+        duplicate = true;
+      }
+    }
+
+    if (!duplicate) {
+      this.callsites.add(callsite);
+    }
   }
 
   public void setCallsites(List<Callsite> callsites) {


### PR DESCRIPTION
The current logic does not check for duplicate callsite in the function elements and create many duplication. This makes the resulting data.yaml file large. This PR fixes the checking to decrease the size of the data profile.