### PR TITLE
Java Frontend: Fix typo

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -123,7 +123,7 @@ def run_introspector_frontend(target_class, jar_set):
       target_class, # entry class
       "fuzzerTestOneInput", # entry method
       package_name, # target package prefix
-      "<clinit>:finalize", # exclude method list
+      "\"<clinit>:finalize\"", # exclude method list
       "False", # Auto-fuzz switch
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\


### PR DESCRIPTION
There is a missing double quote for the newly added exclude method feature in #1055 and #1057. This PR fixes it.
Referencing: https://github.com/google/oss-fuzz/pull/10481