### PR TITLE
Auto-fuzz: Add sample project for auto-fuzz benchmark

### DIFF
--- a/tools/auto-fuzz/benchmark/.gitignore
+++ b/tools/auto-fuzz/benchmark/.gitignore
@@ -1,0 +1,3 @@
+maven-*
+*.class
+target

--- a/tools/auto-fuzz/benchmark/pom.xml
+++ b/tools/auto-fuzz/benchmark/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>auto-fuzz</groupId>
+  <artifactId>benchmark</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0</version>
+  <name>auto-fuzz-benchmark</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+</project>

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic1.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic1.java
@@ -1,0 +1,59 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic1 {
+  public static void testHeuristic1(String string) throws AutoFuzzException {
+    Heuristic1.testHeuristic1Inner(string);
+  }
+
+  public static void testHeuristic1(Integer integer) throws AutoFuzzException {
+    Heuristic1.testHeuristic1Inner(integer);
+  }
+
+  public static void testHeuristic1(Integer[] array) throws AutoFuzzException {
+    Heuristic1.testHeuristic1Inner(array);
+  }
+
+  public static void testHeuristic1Inner(String string) throws AutoFuzzException {
+    Heuristic1.privateStaticMethod(string);
+  }
+
+  public static void testHeuristic1Inner(Integer integer) throws AutoFuzzException {
+    Heuristic1.privateStaticMethod(integer);
+  }
+
+  public static void testHeuristic1Inner(Integer[] array) throws AutoFuzzException {
+    Heuristic1.privateStaticMethod(array);
+  }
+
+  private static void privateStaticMethod(String string) throws AutoFuzzException {
+    SampleObject.testStaticMethodString(string);
+    (new SampleObject()).testMethodString(string);
+  }
+
+  private static void privateStaticMethod(Integer integer) throws AutoFuzzException {
+    SampleObject.testStaticMethodInteger(integer);
+    (new SampleObject()).testMethodInteger(integer);
+  }
+
+  private static void privateStaticMethod(Integer[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodIntegerArray(array);
+    (new SampleObject()).testMethodIntegerArray(array);
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic10.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic10.java
@@ -1,0 +1,48 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic10 {
+  public static Heuristic10 factory() {
+    return new Heuristic10();
+  }
+
+  public void testMethod(SampleObject object) throws AutoFuzzException {
+    this.privateMethod(object);
+  }
+
+  public void testMethod(Class<? extends Object> cl) throws AutoFuzzException {
+    this.privateMethod(cl);
+  }
+
+  private void privateMethod(SampleObject object) throws AutoFuzzException {
+    SampleObject.testStaticMethodObject(object);
+    object.testMethodObject(new SampleObject());
+  }
+
+  private void privateMethod(Class<? extends Object> cl) throws AutoFuzzException {
+    SampleObject.testStaticMethodClass(cl);
+    (new SampleObject()).testMethodClass(cl);
+  }
+
+  class Heuristic10Factory {
+    public Heuristic10 genHeuristic10() {
+      return new Heuristic10();
+    }
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic2.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic2.java
@@ -1,0 +1,21 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public abstract class Heuristic2 {
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic2sp.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic2sp.java
@@ -1,0 +1,47 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic2sp {
+  public void testMethod(int[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  public void testMethod(boolean bool) throws AutoFuzzException {
+    this.privateMethod(bool);
+  }
+
+  public void testMethod(boolean[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  private void privateMethod(int[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodIntegerArray(array);
+    (new SampleObject()).testMethodIntegerArray(array);
+  }
+
+  private void privateMethod(boolean bool) throws AutoFuzzException {
+    SampleObject.testStaticMethodBoolean(bool);
+    (new SampleObject()).testMethodBoolean(bool);
+  }
+
+  private void privateMethod(boolean[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodBooleanArray(array);
+    (new SampleObject()).testMethodBooleanArray(array);
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic3.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic3.java
@@ -1,0 +1,55 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic3 {
+  private Heuristic3() {
+    // Deny object creation from constructor
+  }
+
+  public static Heuristic3 factory() {
+    return new Heuristic3();
+  }
+
+  public void testMethod(Boolean[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  public void testMethod(Byte b) throws AutoFuzzException {
+    this.privateMethod(b);
+  }
+
+  public void testMethod(byte[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  private void privateMethod(Boolean[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodBooleanArray(array);
+    (new SampleObject()).testMethodBooleanArray(array);
+  }
+
+  private void privateMethod(Byte b) throws AutoFuzzException {
+    SampleObject.testStaticMethodByte(b);
+    (new SampleObject()).testMethodByte(b);
+  }
+
+  private void privateMethod(byte[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodByteArray(array);
+    (new SampleObject()).testMethodByteArray(array);
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic4.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic4.java
@@ -1,0 +1,48 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic4 {
+  private Heuristic4() {
+    // Deny object creation from constructor
+  }
+
+  public void testMethod(Byte[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  public void testMethod(Short sh) throws AutoFuzzException {
+    this.privateMethod(sh);
+  }
+
+  private void privateMethod(Byte[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodByteArray(array);
+    (new SampleObject()).testMethodByteArray(array);
+  }
+
+  private void privateMethod(Short sh) throws AutoFuzzException {
+    SampleObject.testStaticMethodShort(sh);
+    (new SampleObject()).testMethodShort(sh);
+  }
+
+  class Heuristic4Factory {
+    public Heuristic4 genHeuristic4() {
+      return new Heuristic4();
+    }
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic6.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic6.java
@@ -1,0 +1,62 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic6 {
+  private SampleObject object;
+
+  public Heuristic6() {
+    object = null;
+  }
+
+  public void settings(SampleObject object) {
+    this.object = object;
+  }
+
+  public static Heuristic6 factory() {
+    return new Heuristic6();
+  }
+
+  public void testMethod(short[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  public void testMethod(Short[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  private void privateMethod(short[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodShortArray(array);
+    if (this.object != null) {
+      this.object.testMethodShortArray(array);
+    }
+  }
+
+  private void privateMethod(Short[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodShortArray(array);
+    if (this.object != null) {
+      this.object.testMethodShortArray(array);
+    }
+  }
+
+  class Heuristic6Factory {
+    public Heuristic6 genHeuristic6() {
+      return new Heuristic6();
+    }
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic7.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic7.java
@@ -1,0 +1,50 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic7 {
+  public static Heuristic7 factory() {
+    return new Heuristic7();
+  }
+
+  public Boolean testMethod(Long l) throws AutoFuzzException {
+    return this.privateMethod(l);
+  }
+
+  public Boolean testMethod(long[] array) throws AutoFuzzException {
+    return this.privateMethod(array);
+  }
+
+  private Boolean privateMethod(Long l) throws AutoFuzzException {
+    SampleObject.testStaticMethodLong(l);
+    (new SampleObject()).testMethodLong(l);
+    return false;
+  }
+
+  private Boolean privateMethod(long[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodLongArray(array);
+    (new SampleObject()).testMethodLongArray(array);
+    return true;
+  }
+
+  class Heuristic7Factory {
+    public Heuristic7 genHeuristic7() {
+      return new Heuristic7();
+    }
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic8.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic8.java
@@ -1,0 +1,48 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic8 {
+  public static Heuristic8 factory() {
+    return new Heuristic8();
+  }
+
+  public void testMethod(Long[] array) throws AutoFuzzException {
+    this.privateMethod(array);
+  }
+
+  public void testMethod(SampleEnum sampleEnum) throws AutoFuzzException {
+    this.privateMethod(sampleEnum);
+  }
+
+  private void privateMethod(Long[] array) throws AutoFuzzException {
+    SampleObject.testStaticMethodLongArray(array);
+    (new SampleObject()).testMethodLongArray(array);
+  }
+
+  private void privateMethod(SampleEnum sampleEnum) throws AutoFuzzException {
+    SampleObject.testStaticMethodEnum(sampleEnum);
+    (new SampleObject()).testMethodEnum(sampleEnum);
+  }
+
+  class Heuristic8Factory {
+    public Heuristic8 genHeuristic8() {
+      return new Heuristic8();
+    }
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic9.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/Heuristic9.java
@@ -1,0 +1,71 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark;
+
+import autofuzz.benchmark.object.*;
+
+public class Heuristic9 {
+  public final static Integer STATIC_METHOD_ONLY = 1;
+  public final static Integer INSTANCE_METHOD_ONLY = 2;
+
+  private Integer mode;
+
+  private Heuristic9() {
+    // Deny direct instance creation
+  }
+
+  public Heuristic9(Integer mode) {
+    this.mode = mode;
+  }
+
+  public static Heuristic9 factory(Integer mode) {
+    return new Heuristic9(mode);
+  }
+
+  public void testMethod(Float f) throws AutoFuzzException {
+    this.privateMethod(f);
+  }
+
+  public void testMethod(Character character) throws AutoFuzzException {
+    this.privateMethod(character);
+  }
+
+  private void privateMethod(Float f) throws AutoFuzzException {
+    if (mode == Heuristic9.STATIC_METHOD_ONLY) {
+      SampleObject.testStaticMethodFloat(f);
+    } else if (mode == Heuristic9.INSTANCE_METHOD_ONLY) {
+      (new SampleObject()).testMethodFloat(f);
+    } else {
+      throw new AutoFuzzException("Unsupported mode.", new IllegalStateException());
+    }
+  }
+
+  private void privateMethod(Character character) throws AutoFuzzException {
+    if (mode == Heuristic9.STATIC_METHOD_ONLY) {
+      SampleObject.testStaticMethodCharacter(character);
+    } else if (mode == Heuristic9.INSTANCE_METHOD_ONLY) {
+      (new SampleObject()).testMethodCharacter(character);
+    } else {
+      throw new AutoFuzzException("Unsupported mode.", new IllegalStateException());
+    }
+  }
+
+  class Heuristic9Factory {
+    public Heuristic9 genHeuristic9(Integer mode) {
+      return new Heuristic9(mode);
+    }
+  }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -1,0 +1,22 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark.object;
+
+public class AutoFuzzException extends Exception {
+    public AutoFuzzException(String errorMessage, Throwable err) {
+        super(errorMessage, err);
+    }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleClass.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleClass.java
@@ -1,0 +1,20 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark.object;
+
+public abstract class SampleClass {
+  public abstract void testInstanceMethod();
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark.object;
+
+public enum SampleEnum {
+    A("Alpha"),
+    B("Bravo"),
+    C("Charlie"),
+    D("Delta"),
+    E("Echo"),
+    F("Foxtrot"),
+    G("Golf"),
+    H("Hotel"),
+    I("India"),
+    J("Jullett");
+
+    public final String label;
+
+    private SampleEnum(String label) {
+        this.label = label;
+    }
+
+    public static SampleEnum valueOfLabel(String label) {
+        for (SampleEnum e : values()) {
+            if (e.label.equals(label)) {
+                return e;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.label;
+    }
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleInterface.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleInterface.java
@@ -1,0 +1,20 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark.object;
+
+public interface SampleInterface {
+  public abstract void testInterfaceInstanceMethod();
+}

--- a/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -1,0 +1,266 @@
+// Copyright 2023 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package autofuzz.benchmark.object;
+
+public class SampleObject extends SampleClass implements SampleInterface {
+  @Override
+  public void testInstanceMethod() {
+    this.privateInstanceMethod();
+  }
+
+  @Override
+  public void testInterfaceInstanceMethod() {
+    this.privateInterfaceInstanceMethod();
+  }
+
+  public static void testClassMethod() {
+    SampleObject.privateClassMethod();
+  }
+
+  public static void testInterfaceMethod() {
+    SampleObject.privateInterfaceMethod();
+  }
+
+  public static SampleObject factoryMethod(){
+    return new SampleObject();
+  }
+
+  public static void testStaticMethodString(String string) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodInteger(Integer integer) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodIntegerArray(int[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodIntegerArray(Integer[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodBoolean(Boolean bool) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodBooleanArray(boolean[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodBooleanArray(Boolean[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodByte(Byte b) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodByteArray(byte[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodByteArray(Byte[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodShort(Short sh) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodShortArray(short[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodShortArray(Short[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodLong(Long l) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodLongArray(long[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodLongArray(Long[] array) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodFloat(Float fl) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodCharacter(Character character) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodObject(SampleObject object) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodClass(Class<? extends Object> cl) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public static void testStaticMethodEnum(SampleEnum sampleEnum) throws AutoFuzzException {
+    SampleObject.testClassMethod();
+    SampleObject.testInterfaceMethod();
+  }
+
+  public void testMethodString(String string) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodInteger(Integer integer) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodIntegerArray(int[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodIntegerArray(Integer[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodBoolean(Boolean bool) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodBooleanArray(boolean[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodBooleanArray(Boolean[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodByte(Byte b) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodByteArray(byte[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodByteArray(Byte[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodShort(Short sh) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodShortArray(short[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodShortArray(Short[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodLong(Long l) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodLongArray(long[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodLongArray(Long[] array) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodFloat(Float fl) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodCharacter(Character character) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodObject(SampleObject object) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodClass(Class<? extends Object> cl) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  public void testMethodEnum(SampleEnum sampleEnum) throws AutoFuzzException {
+    this.testInstanceMethod();
+    this.testInterfaceInstanceMethod();
+  }
+
+  private static void privateClassMethod() {
+    (new SampleObject()).toString();
+  }
+
+  private static void privateInterfaceMethod() {
+    (new SampleObject()).toString();
+  }
+
+  private void privateInstanceMethod() {
+    this.toString();
+  }
+
+  private void privateInterfaceInstanceMethod() {
+    this.toString();
+  }
+}


### PR DESCRIPTION
This PR creates a sample java project (with maven build) to include different method calls matching the auto-fuzz heuristic for java project. The main usage of this sample project is to act as a benchmark for quantifiable and qualifiable analysis of the auto-fuzz heuristic and general generation process for java project. It is small in size and could help to benchmark the behaviour of auto-fuzz fast which also help to evaluate and identify the limitation and possible improvement for auto-fuzz in java project.