### PR TITLE
Auto-fuzz: Filter method

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -473,7 +473,7 @@ class CustomSenceTransformer extends SceneTransformer {
             // Looping statement from all blocks from this specific method.
             Unit unit = blockIt.next();
             if (unit instanceof Stmt) {
-              Callsite callsite = handleMethodInvocationInStatement((Stmt) unit, c.getFilePath());
+              Callsite callsite = handleMethodInvocationInStatement((Stmt) unit, c.getFilePath(), isAutoFuzz);
               if (callsite != null) {
                 element.addCallsite(callsite);
               }
@@ -983,7 +983,7 @@ class CustomSenceTransformer extends SceneTransformer {
    * @return the callsite object to store in the output yaml file, return null if Soot fails to
    *     resolve the invocation
    */
-  private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath) {
+  private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath, Boolean isAutoFuzz) {
     // Handle statements of a method
     try {
       if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
@@ -998,7 +998,11 @@ class CustomSenceTransformer extends SceneTransformer {
         }
         if (!this.excludeMethodList.contains(target.getName())) {
           callsite.setSource(sourceFilePath + ":" + stmt.getJavaSourceStartLineNumber() + ",1");
-          callsite.setMethodName("[" + tClass.getName() + "]." + target.getName());
+          if (isAutoFuzz) {
+            callsite.setMethodName("[" + tClass.getName() + "]." + target.getSubSignature().split(" ")[1]);
+          } else {
+            callsite.setMethodName("[" + tClass.getName() + "]." + target.getName());
+          }
           return callsite;
         }
       }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -473,7 +473,8 @@ class CustomSenceTransformer extends SceneTransformer {
             // Looping statement from all blocks from this specific method.
             Unit unit = blockIt.next();
             if (unit instanceof Stmt) {
-              Callsite callsite = handleMethodInvocationInStatement((Stmt) unit, c.getFilePath(), isAutoFuzz);
+              Callsite callsite =
+                  handleMethodInvocationInStatement((Stmt) unit, c.getFilePath(), isAutoFuzz);
               if (callsite != null) {
                 element.addCallsite(callsite);
               }
@@ -983,7 +984,8 @@ class CustomSenceTransformer extends SceneTransformer {
    * @return the callsite object to store in the output yaml file, return null if Soot fails to
    *     resolve the invocation
    */
-  private Callsite handleMethodInvocationInStatement(Stmt stmt, String sourceFilePath, Boolean isAutoFuzz) {
+  private Callsite handleMethodInvocationInStatement(
+      Stmt stmt, String sourceFilePath, Boolean isAutoFuzz) {
     // Handle statements of a method
     try {
       if ((stmt.containsInvokeExpr()) && (sourceFilePath != null)) {
@@ -999,7 +1001,8 @@ class CustomSenceTransformer extends SceneTransformer {
         if (!this.excludeMethodList.contains(target.getName())) {
           callsite.setSource(sourceFilePath + ":" + stmt.getJavaSourceStartLineNumber() + ",1");
           if (isAutoFuzz) {
-            callsite.setMethodName("[" + tClass.getName() + "]." + target.getSubSignature().split(" ")[1]);
+            callsite.setMethodName(
+                "[" + tClass.getName() + "]." + target.getSubSignature().split(" ")[1]);
           } else {
             callsite.setMethodName("[" + tClass.getName() + "]." + target.getName());
           }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark1/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark1/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark1/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark1/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark1/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark1/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark2/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark2/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark2/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark2/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark2/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark2/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark3/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark3/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark3/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark3/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark3/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark3/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark4/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark4/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark4/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark4/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark4/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark4/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark6/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark6/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark6/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark6/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark6/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark6/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 

--- a/tools/auto-fuzz/benchmark/jvm/benchmark8/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark8/src/main/java/autofuzz/benchmark/object/AutoFuzzException.java
@@ -16,7 +16,7 @@
 package autofuzz.benchmark.object;
 
 public class AutoFuzzException extends Exception {
-    public AutoFuzzException(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
+  public AutoFuzzException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark8/src/main/java/autofuzz/benchmark/object/SampleEnum.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark8/src/main/java/autofuzz/benchmark/object/SampleEnum.java
@@ -16,34 +16,34 @@
 package autofuzz.benchmark.object;
 
 public enum SampleEnum {
-    A("Alpha"),
-    B("Bravo"),
-    C("Charlie"),
-    D("Delta"),
-    E("Echo"),
-    F("Foxtrot"),
-    G("Golf"),
-    H("Hotel"),
-    I("India"),
-    J("Jullett");
+  A("Alpha"),
+  B("Bravo"),
+  C("Charlie"),
+  D("Delta"),
+  E("Echo"),
+  F("Foxtrot"),
+  G("Golf"),
+  H("Hotel"),
+  I("India"),
+  J("Jullett");
 
-    public final String label;
+  public final String label;
 
-    private SampleEnum(String label) {
-        this.label = label;
+  private SampleEnum(String label) {
+    this.label = label;
+  }
+
+  public static SampleEnum valueOfLabel(String label) {
+    for (SampleEnum e : values()) {
+      if (e.label.equals(label)) {
+        return e;
+      }
     }
+    return null;
+  }
 
-    public static SampleEnum valueOfLabel(String label) {
-        for (SampleEnum e : values()) {
-            if (e.label.equals(label)) {
-                return e;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return this.label;
-    }
+  @Override
+  public String toString() {
+    return this.label;
+  }
 }

--- a/tools/auto-fuzz/benchmark/jvm/benchmark8/src/main/java/autofuzz/benchmark/object/SampleObject.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark8/src/main/java/autofuzz/benchmark/object/SampleObject.java
@@ -34,7 +34,7 @@ public class SampleObject extends SampleClass implements SampleInterface {
     SampleObject.privateInterfaceMethod();
   }
 
-  public static SampleObject factoryMethod(){
+  public static SampleObject factoryMethod() {
     return new SampleObject();
   }
 


### PR DESCRIPTION
This PR fixes the frontend to allow a fully-qualified name stored for each method callsite. Then the callsite list of all target methods are retrieve to indicate which methods have already been covered by other target methods and thus filtering them out.