### PR TITLE
Auto-Fuzz: Refine filtering for dependencies

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -1695,7 +1695,8 @@ def _generate_heuristic_10(method_tuple, possible_targets, max_target):
                     break
 
 
-def generate_possible_targets(proj_folder, class_list, max_target, param_combination):
+def generate_possible_targets(proj_folder, class_list, max_target,
+                              param_combination):
     """Generate all possible targets for a given project folder"""
 
     # Set param_combination to global

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -826,29 +826,6 @@ def _group_method_by_class(method_list):
     return result_map
 
 
-def _extract_class_list(projectdir):
-    """Extract a list of path for all java files exist in the project directory"""
-    global project_class_list
-    project_class_list = []
-
-    for root, _, files in os.walk(projectdir):
-        for file in [file for file in files if file.endswith(".java")]:
-            path = os.path.join(root, file)
-            path = path.replace("%s/" % projectdir, "")
-            path = path.replace(".java", "").replace("/", ".")
-
-            # Filter some unrelatede class
-            if "module-info" in path or "package-info" in path:
-                continue
-            if "test" in path or "Test" in path:
-                continue
-            if path.endswith("Exception"):
-                continue
-
-            if path not in project_class_list:
-                project_class_list.append(path)
-
-
 def _extract_method(yaml_dict):
     """Extract method and group them into list for heuristic processing"""
     init_dict = {}
@@ -888,19 +865,17 @@ def _extract_method(yaml_dict):
             continue
 
         # Add candidates to result lists
+        func_class_name = func_elem['functionSourceFile'].split("$")[0]
         if func_elem['JavaMethodInfo']['static']:
             # Exclude methods that does not require parameters
-            if not plain:
+            if not plain and _is_project_class(func_class_name):
                 static_method_list.append(func_elem)
         else:
             instance_method_list.append(func_elem)
             # Check if this method belongs to this project
             # or not and filter out unrelated methods
             # from dependencies or libraries
-            if _is_project_class(
-                    func_elem['functionSourceFile'].split("$")[0]):
-                func_name = func_elem['functionName'].split("].")[1]
-
+            if _is_project_class(func_class_name):
                 # Exclude possible getters, setters and methods
                 # does not take any arguments. Also exclude methods
                 # inherits from the Object class
@@ -1720,17 +1695,16 @@ def _generate_heuristic_10(method_tuple, possible_targets, max_target):
                     break
 
 
-def generate_possible_targets(proj_folder, max_target, param_combination):
+def generate_possible_targets(proj_folder, class_list, max_target, param_combination):
     """Generate all possible targets for a given project folder"""
 
     # Set param_combination to global
     global need_param_combination
     need_param_combination = param_combination
 
-    # Extract a list of possible java classes of the project
-    # This is used to filter out methods not belonging to
-    # this project.
-    _extract_class_list(os.path.join(proj_folder, "work", "proj"))
+    # Set the project_class_list to global
+    global project_class_list
+    project_class_list = class_list
 
     # Read the Fuzz Introspector generated data as a method tuple
     yaml_file = os.path.join(proj_folder, "work",

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -772,6 +772,30 @@ def git_clone_project(github_url, destination):
     return True
 
 
+def extract_class_list(projectdir):
+    """Extract a list of path for all java files exist in the project directory"""
+    project_class_list = []
+
+    for root, _, files in os.walk(projectdir):
+        for file in [file for file in files if file.endswith(".java")]:
+            path = os.path.join(root, file)
+            path = path.replace("%s/" % projectdir, "")
+            path = path.replace(".java", "").replace("/", ".")
+
+            # Filter some unrelated class
+            if "module-info" in path or "package-info" in path:
+                continue
+            if "test" in path or "Test" in path:
+                continue
+            if path.endswith("Exception"):
+                continue
+
+            if path not in project_class_list:
+                project_class_list.append(path)
+
+    return project_class_list
+
+
 def autofuzz_project_from_github(github_url,
                                  language,
                                  do_static_analysis=False,
@@ -817,7 +841,9 @@ def autofuzz_project_from_github(github_url,
             return False
 
     # If this is a jvm target download ant, maven and gradle once so we don't
-    # have to do it for each proejct.
+    # have to do it for each proejct. Also extract a class_list for java classes
+    # in the repository before building the project. This class_list is used for
+    # target method filtering in the target generation stage.
     if language == "jvm":
         # Download Ant
         target_ant_path = os.path.join(oss_fuzz_base_project.project_folder,
@@ -836,6 +862,10 @@ def autofuzz_project_from_github(github_url,
                                           "gradle.zip")
         with open(target_gradle_path, 'wb') as gf:
             gf.write(requests.get(constants.GRADLE_URL).content)
+
+        # Extract class list for the etarget project
+        java_class_list = extract_class_list(os.path.join(oss_fuzz_base_project.project_folder,
+                                                         oss_fuzz_base_project.project_name))
 
     # Generate the base Dockerfile, build.sh, project.yaml and fuzz_1.py
     oss_fuzz_base_project.write_basefiles()
@@ -887,6 +917,7 @@ def autofuzz_project_from_github(github_url,
             elif language == "jvm":
                 possible_targets = fuzz_driver_generation_jvm.generate_possible_targets(
                     oss_fuzz_base_project.project_folder,
+                    java_class_list,
                     constants.MAX_TARGET_PER_PROJECT_HEURISTIC,
                     param_combination)
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -864,8 +864,9 @@ def autofuzz_project_from_github(github_url,
             gf.write(requests.get(constants.GRADLE_URL).content)
 
         # Extract class list for the etarget project
-        java_class_list = extract_class_list(os.path.join(oss_fuzz_base_project.project_folder,
-                                                         oss_fuzz_base_project.project_name))
+        java_class_list = extract_class_list(
+            os.path.join(oss_fuzz_base_project.project_folder,
+                         oss_fuzz_base_project.project_name))
 
     # Generate the base Dockerfile, build.sh, project.yaml and fuzz_1.py
     oss_fuzz_base_project.write_basefiles()
@@ -916,8 +917,7 @@ def autofuzz_project_from_github(github_url,
                     oss_fuzz_base_project.project_folder)
             elif language == "jvm":
                 possible_targets = fuzz_driver_generation_jvm.generate_possible_targets(
-                    oss_fuzz_base_project.project_folder,
-                    java_class_list,
+                    oss_fuzz_base_project.project_folder, java_class_list,
                     constants.MAX_TARGET_PER_PROJECT_HEURISTIC,
                     param_combination)
 


### PR DESCRIPTION
Some gradle and maven build process will relocate source of dependencies into their base directory. This adds noise to the filtering of non-target project code. This PR fixes that by retrieving a list of class before the building of the target project to get a better list of what class is indeed in the target project for further filtering.