### PR TITLE
Java-format-ci: Fix java format checking CI

### DIFF
--- a/.github/workflows/google-java.yml
+++ b/.github/workflows/google-java.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'frontends/java/**'
       - '.github/workflows/google-java.yml'
+      - 'tools/auto-fuzz/benchmark/jvm/**'
 jobs:
   formatting:
     runs-on: ubuntu-latest

--- a/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/Benchmark5.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark5/src/main/java/autofuzz/benchmark/Benchmark5.java
@@ -24,9 +24,9 @@ import java.util.*;
  * post processing should be able to identify either one of the methods and include that in a fuzzer
  * and ignoring the remaining two as they created a recursive loop.
  *
- * <p>Target fuzzing methods (either one of them only): public void parseAlphabetic(String)
- * throws AutoFuzzException; public void parseInteger(String) throws AutoFuzzException; pulic
- * void parseFloat(String) throws AutoFuzzException
+ * <p>Target fuzzing methods (either one of them only): public void parseAlphabetic(String) throws
+ * AutoFuzzException; public void parseInteger(String) throws AutoFuzzException; pulic void
+ * parseFloat(String) throws AutoFuzzException
  *
  * @author Fuzz Introspector
  */

--- a/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/Benchmark7.java
+++ b/tools/auto-fuzz/benchmark/jvm/benchmark7/src/main/java/autofuzz/benchmark/Benchmark7.java
@@ -24,8 +24,8 @@ import java.util.*;
  * focus on invoking methods in the SampleObject with Java Reflection. Auto-Fuzz post-processing
  * should be able to identify only one fuzzer that covers all other logic.
  *
- * <p>Target fuzzing method: public Boolean processClass(Class<? extends SampleObject>,
- * String, Integer) throws AutoFuzzException
+ * <p>Target fuzzing method: public Boolean processClass(Class<? extends SampleObject>, String,
+ * Integer) throws AutoFuzzException
  *
  * @author Fuzz Introspector
  */


### PR DESCRIPTION
Java benchmarks for auto-fuzz are obviously written in Java, but the original java format checking CI does not monitor pull request from the new benchmark directory. This PR fixes the java format checking CI and some "historic" format problem in the java benchmark.