### PR TITLE
Java-frontend: Fix class filtering in frontend

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -124,6 +124,7 @@ def run_introspector_frontend(target_class, jar_set):
       "fuzzerTestOneInput", # entry method
       package_name, # target package prefix
       "\"<clinit>:finalize\"", # exclude method list
+      "NULL", # source directory
       "False", # Auto-fuzz switch
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\
 com.apple.*:apple.awt.*===[java.lang.Runtime].exec:[javax.xml.xpath.XPath].compile:\

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -59,6 +59,11 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -r|--src)
+      SRCDIRECTORY="$2"
+      shift
+      shift
+      ;;
     -a|--autofuzz)
       AUTOFUZZ="True"
       shift
@@ -110,6 +115,10 @@ then
     echo "No target package prefix defined, analysing all packages"
     PACKAGEPREFIX="ALL"
 fi
+if [ -z $SRCDIRECTORY ]
+then
+    SRCDIRECTORY="NULL"
+fi
 if [ -z $AUTOFUZZ ]
 then
     AUTOFUZZ="False"
@@ -122,5 +131,5 @@ mvn clean package -Dmaven.test.skip
 for CLASS in $(echo $ENTRYCLASS | tr ":" "\n")
 do
     echo $CLASS
-    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" "$EXCLUDEMETHOD" $AUTOFUZZ "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
+    java -Xmx6144M -cp "target/ossf.fuzz.introspector.soot-1.0.jar" ossf.fuzz.introspector.soot.CallGraphGenerator $JARFILE $CLASS $ENTRYMETHOD "$PACKAGEPREFIX" "$EXCLUDEMETHOD" "$SRCDIRECTORY" $AUTOFUZZ "$INCLUDEPREFIX===$EXCLUDEPREFIX===$SINKMETHOD"
 done

--- a/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
+++ b/frontends/java/src/test/java/ossf/fuzz/intropsector/soot/CustomSenceTransformerTest.java
@@ -16,7 +16,8 @@ public class CustomSenceTransformerTest {
 
   @Test
   public void testBasic() {
-    CustomSenceTransformer custom = new CustomSenceTransformer("", "", "ALL", "", "", "", "");
+    CustomSenceTransformer custom =
+        new CustomSenceTransformer("", "", "ALL", "", "", "", "", "NULL", false);
     assertTrue(custom instanceof SceneTransformer);
     assertTrue(custom instanceof CustomSenceTransformer);
     assertEquals(custom.getIncludeList().size(), 1);
@@ -26,7 +27,8 @@ public class CustomSenceTransformerTest {
   @Test
   public void testExcludePrefix() {
     CustomSenceTransformer custom =
-        new CustomSenceTransformer("", "", "ALL", "", "abc:def:ghi", "jkl:mno:pqr", "");
+        new CustomSenceTransformer(
+            "", "", "ALL", "", "abc:def:ghi", "jkl:mno:pqr", "", "NULL", false);
     assertEquals(custom.getIncludeList().size(), 4);
     assertEquals(custom.getExcludeList().size(), 3);
     Object[] eexpected = {"jkl", "mno", "pqr"};


### PR DESCRIPTION
Some projects may include too much dependency libraries in their packaged jar files. This setting affects the effectivenes of frontend analysis on the project code as there are too much noise. This PR adds a feature to the java-frontend for filtering out classes that are not belongs to the target project. If the source directory of the target project is provided, the Java frontend will scan through that directory for a list of Java files. If a class is not in that list, it is skipped during the frontend processing.