### PR TITLE
Auto-fuzz: Fix build error and change constant parameters

### DIFF
--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -47,12 +47,12 @@ JAVA_IGNORE_TEST_METHOD = True
 JAVA_IGNORE_OBJECT_METHOD = True
 
 # This is an user-controlled options. If it is not between 0 and 1, the
-# default value of 0.75 is used. This ratio is used to config and filter
+# default value of 0.5 is used. This ratio is used to config and filter
 # of some target methods which does not have too much function depth.
 # The ratio indicated that the methods with function depth lower
 # than the ratio times the max function depth of all methods will
 # be ignored in the fuzzer target generation process.
-TARGET_FUNCTION_DEPTH_RATIO = 0.75
+TARGET_FUNCTION_DEPTH_RATIO = 0.5
 
 git_repos = {
     'python': [

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -493,7 +493,7 @@ def run_static_analysis_jvm(git_repo, basedir, project_name):
     # Run the java frontend static analysis
     cmd = [
         "./run.sh", "--jarfile", ":".join(jarfiles), "--entryclass", "Fuzz",
-        "--autofuzz"
+        "--src", projectdir, "--autofuzz"
     ]
     try:
         subprocess.check_call(" ".join(cmd),


### PR DESCRIPTION
This PR fixes a bugs in the build script logic on duplicate classes in jar files which fails some of the project build. This PR also changes some of the constants value to allow more target to process.