### PR TITLE
Auto-fuzz: Fix logic for call depth filtering

### DIFF
--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -47,12 +47,12 @@ JAVA_IGNORE_TEST_METHOD = True
 JAVA_IGNORE_OBJECT_METHOD = True
 
 # This is an user-controlled options. If it is not between 0 and 1, the
-# default value of 0.75 is used. This ratio is used to config and filter
+# default value of 0.4 is used. This ratio is used to config and filter
 # of some target methods which does not have too much function depth.
 # The ratio indicated that the methods with function depth lower
 # than the ratio times the max function depth of all methods will
 # be ignored in the fuzzer target generation process.
-TARGET_FUNCTION_DEPTH_RATIO = 0.75
+TARGET_FUNCTION_DEPTH_RATIO = 0.4
 
 git_repos = {
     'python': [

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -798,27 +798,15 @@ def _filter_polymorphism(method_list):
     return result_list
 
 
-def _filter_method(reference_method_list, target_method_list):
+def _filter_method(callsites, max_calldepth, target_method_list):
     """
     Filter methods from the target_method list which has
     been called by and methods in both method list.
     """
-    callsites = _search_all_callsite_dst(reference_method_list)
-    target_callsites = _search_all_callsite_dst(target_method_list)
-    for item in target_callsites:
-        if item in callsites:
-            caller_list = callsites[item]
-            caller_list.extend(target_callsites[item])
-            callsites[item] = list(set(caller_list))
-        else:
-            callsites[item] = target_callsites[item]
-
-    max_calldepth = _search_max_calldepth(reference_method_list +
-                                          target_method_list)
     if constants.TARGET_FUNCTION_DEPTH_RATIO >= 0 and constants.TARGET_FUNCTION_DEPTH_RATIO < 1:
         target_depth_ratio = constants.TARGET_FUNCTION_DEPTH_RATIO
     else:
-        target_depth_ratio = 0.75
+        target_depth_ratio = 0.4
     min_calldepth = max_calldepth * target_depth_ratio
 
     result_method_list = []
@@ -908,9 +896,24 @@ def _extract_method(yaml_dict):
                 method_list.append(func_elem)
 
     method_list = _filter_polymorphism(method_list)
-    method_list = _filter_method(static_method_list, method_list)
-    filtered_static_method_list = _filter_method(method_list,
+
+    callsites = _search_all_callsite_dst(static_method_list)
+    target_callsites = _search_all_callsite_dst(method_list)
+    for item in target_callsites:
+        if item in callsites:
+            caller_list = callsites[item]
+            caller_list.extend(target_callsites[item])
+            callsites[item] = list(set(caller_list))
+        else:
+            callsites[item] = target_callsites[item]
+
+    max_calldepth = _search_max_calldepth(static_method_list +
+                                          method_list)
+
+    method_list = _filter_method(callsites, max_calldepth, method_list)
+    filtered_static_method_list = _filter_method(callsites, max_calldepth,
                                                  static_method_list)
+
     return init_dict, method_list, instance_method_list, static_method_list, filtered_static_method_list
 
 

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -907,8 +907,7 @@ def _extract_method(yaml_dict):
         else:
             callsites[item] = target_callsites[item]
 
-    max_calldepth = _search_max_calldepth(static_method_list +
-                                          method_list)
+    max_calldepth = _search_max_calldepth(static_method_list + method_list)
 
     method_list = _filter_method(callsites, max_calldepth, method_list)
     filtered_static_method_list = _filter_method(callsites, max_calldepth,


### PR DESCRIPTION
This PR fixes the logic for call depth filtering and change the default ratio after source folder filtering has been added to the frontend processing in #1101.