### PR TITLE
Java-Frontend: Fix frontend bug

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -347,6 +347,10 @@ class CustomSenceTransformer extends SceneTransformer {
         }
       }
 
+      if (!c.isConcrete()) {
+        isIgnore = true;
+      }
+
       if (!isIgnore) {
         //        System.out.println("[Callgraph] [USE] class: " + cname);
         List<SootMethod> mList = new LinkedList<SootMethod>();
@@ -414,6 +418,7 @@ class CustomSenceTransformer extends SceneTransformer {
           methodInfo.setIsStatic(m.isStatic());
           methodInfo.setIsClassEnum(c.isEnum());
           methodInfo.setIsClassPublic(c.isPublic());
+          methodInfo.setIsClassConcrete(c.isConcrete());
           for (SootClass exception : m.getExceptions()) {
             methodInfo.addException(exception.getFilePath());
           }


### PR DESCRIPTION
There is a missing statement and missing skipping logic in the java frontend, causing methods and constructors of abstract classes and interfaces missing the correct information if its class is concrete or not. Thats makes the auto-fuzz logic fails to filter them out from the target method list. This PR fixes the bug to ensure the class's concrete status of each method is correctly stored.