### PR TITLE
Auto-fuzz: Ignore unrelated jar

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -192,8 +192,11 @@ fi
 JARFILE_LIST=
 for JARFILE in $(find ./target ./build  -name *.jar 2>/dev/null)
 do
-  cp $JARFILE $OUT/
-  JARFILE_LIST="$JARFILE_LIST$(basename $JARFILE) "
+  if [[ "$JARFILE" != *sources.jar ]] && [[ "$JARFILE" != *javadoc.jar ]]
+  then
+    cp $JARFILE $OUT/
+    JARFILE_LIST="$JARFILE_LIST$(basename $JARFILE) "
+  fi
 done
 
 BUILD_CLASSPATH=

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -190,7 +190,7 @@ then
 fi
 
 JARFILE_LIST=
-for JARFILE in $(find ./ -name *.jar)
+for JARFILE in $(find ./target ./build  -name *.jar 2>/dev/null)
 do
   cp $JARFILE $OUT/
   JARFILE_LIST="$JARFILE_LIST$(basename $JARFILE) "


### PR DESCRIPTION
Some jar file in the project directory may include some unsolved dependencies, they should be solved and included in the build.jar. Thus there is no need to include them for the fuzzer compile process. This PR fixes the discovery logic of jar files and remove the possibility of compilation error on those unrelated jar.