### PR TITLE
Auto-fuzz: Fix build error and git repo white space

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -153,8 +153,10 @@ do
       break
     elif test -f "pom.xml"
     then
-      find ./ -name pom.xml -exec sed -i 's/>1.5</>1.8</g' {} \;
-      find ./ -name pom.xml -exec sed -i 's/>1.6</>1.8</g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/<maven.compiler.source>1.5</<maven.compiler.source>1.8</g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/<maven.compiler.source>1.6</<maven.compiler.source>1.8</g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/<maven.compiler.target>1.5</<maven.compiler.target>1.8</g' {} \;
+      find ./ -name pom.xml -exec sed -i 's/<maven.compiler.target>1.6</<maven.compiler.target>1.8</g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java15/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
@@ -190,12 +192,15 @@ then
 fi
 
 JARFILE_LIST=
-for JARFILE in $(find ./target ./build  -name *.jar 2>/dev/null)
+for JARFILE in $(find ./  -name *.jar)
 do
-  if [[ "$JARFILE" != *sources.jar ]] && [[ "$JARFILE" != *javadoc.jar ]]
+  if [[ "$JARFILE" == *"target/"* ]] || [[ "$JARFILE" == *"build/"* ]]
   then
-    cp $JARFILE $OUT/
-    JARFILE_LIST="$JARFILE_LIST$(basename $JARFILE) "
+    if [[ "$JARFILE" != *sources.jar ]] && [[ "$JARFILE" != *javadoc.jar ]]
+    then
+      cp $JARFILE $OUT/
+      JARFILE_LIST="$JARFILE_LIST$(basename $JARFILE) "
+    fi
   fi
 done
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -253,8 +253,10 @@ def _maven_build_project(basedir, projectdir):
 
     # Patch pom.xml to use at least jdk 1.8
     cmd = [
-        "find ./ -name pom.xml -exec sed -i 's/>1.5</>1.8</g' {} \;",
-        "find ./ -name pom.xml -exec sed -i 's/>1.6</>1.8</g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/<maven.compiler.source>1.5</<maven.compiler.source>1.8</g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/<maven.compiler.source>1.6</<maven.compiler.source>1.8</g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/<maven.compiler.target>1.5</<maven.compiler.target>1.8</g' {} \;",
+        "find ./ -name pom.xml -exec sed -i 's/<maven.compiler.target>1.6</<maven.compiler.target>1.8</g' {} \;",
         "find ./ -name pom.xml -exec sed -i 's/java15/java18/g' {} \;",
         "find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;",
         "find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;",
@@ -1045,7 +1047,7 @@ def get_target_repos(targets, language):
     github_projects = []
     with open(args.targets, 'r') as f:
         for line in f:
-            github_projects.append(line.replace("\n", ""))
+            github_projects.append(line.replace("\n", "").strip())
     return github_projects
 
 


### PR DESCRIPTION
There is a logic in auto-fuzz maven build to replace some values in the project's pom.xml to force the project build with java 1.8. But the text replacement logic is ambiguous and replace some settings unexpectedly and cause some projects fail to build. This PR fixes the logic to ensure only the precise java version setting has been replaced. This PR also fixes the problem when the provided target repo list file contains unwanted whitespace.