### PR TITLE
Java-Frontend: Fix missing constructor

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -340,7 +340,7 @@ class CustomSenceTransformer extends SceneTransformer {
             isIgnore = true;
           }
         } else {
-          String currClassName = cname.substring(cname.lastIndexOf(".") + 1).split("$")[0];
+          String currClassName = cname.substring(cname.lastIndexOf(".") + 1).split("\\$")[0];
           if ((projectClassList.size() > 0) && (!projectClassList.contains(currClassName))) {
             isIgnore = true;
           }
@@ -660,13 +660,11 @@ class CustomSenceTransformer extends SceneTransformer {
     return null;
   }
 
-  // Add or replace method element to the method list
+  // Add method element to the method list
   private void addMethodElement(FunctionElement newElement) {
     FunctionElement oldElement = this.searchElement(newElement.getFunctionName());
     if (oldElement == null) {
       this.methodList.addFunctionElement(newElement);
-    } else {
-      this.methodList.replaceFunctionElement(oldElement, newElement);
     }
   }
 
@@ -778,11 +776,13 @@ class CustomSenceTransformer extends SceneTransformer {
     for (FunctionElement element : this.methodList.getFunctionElements()) {
       if (!element.getFunctionName().contains("init>")) {
         this.calculateCallDepth(element, null);
-      }
-      if (this.depthHandled != null) {
-        for (FunctionElement handledElement : this.depthHandled) {
-          newMethodList.add(handledElement);
+        if (this.depthHandled != null) {
+          for (FunctionElement handledElement : this.depthHandled) {
+            newMethodList.add(handledElement);
+          }
         }
+      } else {
+        newMethodList.add(element);
       }
     }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionConfig.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionConfig.java
@@ -45,12 +45,6 @@ public class FunctionConfig {
     this.functionElements.add(functionElement);
   }
 
-  public void replaceFunctionElement(FunctionElement oldElement, FunctionElement newElement) {
-    if (this.functionElements.remove(oldElement)) {
-      this.addFunctionElement(newElement);
-    }
-  }
-
   public void setFunctionElements(List<FunctionElement> functionElements) {
     this.functionElements = functionElements;
   }


### PR DESCRIPTION
When calculating calldepth, the current logic accidentally removed all constructor from the method list. This cause some auto-fuzz project fails to generate any fuzzers because no constructor information exists in the data.yaml file. This PR fixes the bug. 