### PR TITLE
Auto-fuzz: Fix default jdk build

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -163,13 +163,8 @@ do
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
-      MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15 --update-snapshots"
+      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots"
       $MVN clean package $MAVEN_ARGS
-      if [[ $? != "0" ]]
-      then
-        MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=8 -Djavac.target.version=8 --update-snapshots"
-        $MVN clean package $MAVEN_ARGS
-      fi
       SUCCESS=true
       break
     elif test -f "build.xml"

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -163,7 +163,7 @@ do
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
-      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots"
+      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true"
       $MVN clean package $MAVEN_ARGS
       SUCCESS=true
       break

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -277,10 +277,9 @@ def _maven_build_project(basedir, projectdir):
     except subprocess.CalledProcessError:
         return False
 
-    # Build project with maven with javac version 15
+    # Build project with maven with default jdk
     cmd = [
-        "mvn clean package", "-DskipTests", "-Djavac.src.version=15",
-        "-Djavac.target.version=15", "-Dmaven.javadoc.skip=true",
+        "mvn clean package", "-DskipTests", "-Dmaven.javadoc.skip=true",
         "--update-snapshots"
     ]
     try:
@@ -294,25 +293,7 @@ def _maven_build_project(basedir, projectdir):
     except subprocess.TimeoutExpired:
         return False
     except subprocess.CalledProcessError:
-        # Fail to build project with javac version 15,
-        # try javac version 8 instead
-        cmd = [
-            "mvn clean package", "-DskipTests", "-Djavac.src.version=8",
-            "-Djavac.target.version=8", "-Dmaven.javadoc.skip=true",
-            "--update-snapshots"
-        ]
-        try:
-            subprocess.check_call(" ".join(cmd),
-                                  shell=True,
-                                  timeout=1800,
-                                  stdout=subprocess.DEVNULL,
-                                  stderr=subprocess.DEVNULL,
-                                  env=env_var,
-                                  cwd=projectdir)
-        except subprocess.TimeoutExpired:
-            return False
-        except subprocess.CalledProcessError:
-            return False
+        return False
 
     return True
 


### PR DESCRIPTION
Some project may requires different jdk version except for 15 and 8. This PR fixes the maven build command to let the project choose the default version needed they are using version 1.8+. Otherwise force it to at least build with version 1.8.