### PR TITLE
Java-Frontend: Exclude main method

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -123,7 +123,7 @@ def run_introspector_frontend(target_class, jar_set):
       target_class, # entry class
       "fuzzerTestOneInput", # entry method
       package_name, # target package prefix
-      "\"<clinit>:finalize\"", # exclude method list
+      "\"<clinit>:finalize:main\"", # exclude method list
       "NULL", # source directory
       "False", # Auto-fuzz switch
       """===jdk.*:java.*:javax.*:sun.*:sunw.*:com.sun.*:com.ibm.*:\

--- a/frontends/java/run.sh
+++ b/frontends/java/run.sh
@@ -103,7 +103,7 @@ fi
 if [ -z $EXCLUDEMETHOD ]
 then
     echo "No exclude method list defined, using default exclude method list"
-    EXCLUDEMETHOD="<clinit>:finalize"
+    EXCLUDEMETHOD="<clinit>:finalize:main"
 fi
 if [ -z $SINKMETHOD ]
 then


### PR DESCRIPTION
Some project may include main method in their code in order for user to use their build jar directly in command line. In general, main method is the entrance method and don't have much logic to fuzz. Thus it has not too useful for both fuzz-introspector report and auto-fuzz. This PR fixes the configuration to exclude the main method by default.