### PR TITLE
Auto-fuzz: Fix protoc binary dependency

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -109,13 +109,16 @@ def gen_dockerfile_jvm(github_url, project_name):
 COPY ant.zip $SRC/ant.zip
 COPY maven.zip $SRC/maven.zip
 COPY gradle.zip $SRC/gradle.zip
+COPY protoc.zip $SRC/protoc.zip
 RUN unzip ant.zip -d $SRC/ant && rm ./ant.zip
 RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
 RUN unzip gradle.zip -d $SRC/gradle && rm ./gradle.zip
+RUN mkdir -p $SRC/protoc
+RUN unzip protoc.zip -d $SRC/protoc && rm ./gradle.zip
 ENV ANT $SRC/ant/apache-ant-1.9.16/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
-ENV PATH="$SRC/gradle/gradle-7.4.2/bin:$PATH"
+ENV PATH="$SRC/gradle/gradle-7.4.2/bin:$SRC/protoc/bin:$PATH"
 #RUN git clone --depth 1 %s %s
 COPY %s %s
 COPY *.sh *.java $SRC/
@@ -145,6 +148,7 @@ do
   then
     dir=$(realpath ${dir%*:})
     cd $dir
+    chmod +x $SRC/protoc/bin/protoc
     if test -f "pom.xml"
     then
       find ./ -name pom.xml -exec sed -i 's/compilerVersion>1.5</compilerVersion>1.8</g' {} \;

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -21,11 +21,13 @@ BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
 ANT_URL = "https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip"
 MAVEN_URL = "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
 GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"
+PROTOC_URL = "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip"
 
 ANT_PATH = "apache-ant-1.9.16/bin"
 MAVEN_PATH = "apache-maven-3.6.3/bin"
 GRADLE_HOME = "gradle-7.4.2"
 GRADLE_PATH = f"{GRADLE_HOME}/bin"
+PROTOC_PATH = "protoc/bin"
 
 # This is an user-controlled options. If this is set to True, it will always
 # search for all subclasses of a target class when the auto-fuzz generation

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -220,9 +220,9 @@ def _ant_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['PATH'] = os.path.join(basedir,
-                                   constants.ANT_PATH) + ":" + os.path.join(
-        basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+    env_var['PATH'] = os.path.join(
+        basedir, constants.ANT_PATH) + ":" + os.path.join(
+            basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with ant
     cmd = "chmod +x %s/ant && ant" % os.path.join(basedir, constants.ANT_PATH)
@@ -252,7 +252,7 @@ def _maven_build_project(basedir, projectdir):
     env_var = os.environ.copy()
     env_var['PATH'] = os.path.join(
         basedir, constants.MAVEN_PATH) + ":" + os.path.join(
-        basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+            basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Patch pom.xml to use at least jdk 1.8
     cmd = [
@@ -312,7 +312,7 @@ def _gradle_build_project(basedir, projectdir):
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
     env_var['PATH'] = os.path.join(
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
-        basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+            basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = ["chmod +x gradlew", "./gradlew clean build -x test"]
@@ -393,7 +393,8 @@ def build_jvm_project(basedir, projectdir, proj_name):
         pf.extractall(os.path.join(basedir, "protoc"))
     protoc_executable = os.path.join(basedir, "protoc", "bin", "protoc")
     base_stat = os.stat(protoc_executable)
-    os.chmod(os.path.join(basedir, "protoc", "bin", "protoc"), base_stat.st_mode | stat.S_IEXEC)
+    os.chmod(os.path.join(basedir, "protoc", "bin", "protoc"),
+             base_stat.st_mode | stat.S_IEXEC)
 
     if builddir:
         if os.path.exists(os.path.join(builddir, "pom.xml")):
@@ -866,7 +867,6 @@ def autofuzz_project_from_github(github_url,
                                           "protoc.zip")
         with open(target_protoc_path, 'wb') as gf:
             gf.write(requests.get(constants.PROTOC_URL).content)
-
 
         # Extract class list for the target project
         java_class_list = extract_class_list(

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import stat
 import yaml
 import json
 import shutil
@@ -220,7 +221,8 @@ def _ant_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['PATH'] = os.path.join(basedir,
-                                   constants.ANT_PATH) + ":" + env_var['PATH']
+                                   constants.ANT_PATH) + ":" + os.path.join(
+        basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with ant
     cmd = "chmod +x %s/ant && ant" % os.path.join(basedir, constants.ANT_PATH)
@@ -249,7 +251,8 @@ def _maven_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['PATH'] = os.path.join(
-        basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
+        basedir, constants.MAVEN_PATH) + ":" + os.path.join(
+        basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Patch pom.xml to use at least jdk 1.8
     cmd = [
@@ -308,7 +311,8 @@ def _gradle_build_project(basedir, projectdir):
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
     env_var['PATH'] = os.path.join(
-        basedir, constants.GRADLE_PATH) + ":" + env_var['PATH']
+        basedir, constants.GRADLE_PATH) + ":" + os.path.join(
+        basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
     cmd = ["chmod +x gradlew", "./gradlew clean build -x test"]
@@ -382,6 +386,14 @@ def build_jvm_project(basedir, projectdir, proj_name):
     # Find project subfolder if build properties not in the outtermost
     # directory
     builddir = find_project_build_folder(projectdir, proj_name)
+
+    # Prepare protoc
+    os.makedirs(os.path.join(basedir, "protoc"), exist_ok=True)
+    with zipfile.ZipFile(os.path.join(basedir, "protoc.zip"), "r") as pf:
+        pf.extractall(os.path.join(basedir, "protoc"))
+    protoc_executable = os.path.join(basedir, "protoc", "bin", "protoc")
+    base_stat = os.stat(protoc_executable)
+    os.chmod(os.path.join(basedir, "protoc", "bin", "protoc"), base_stat.st_mode | stat.S_IEXEC)
 
     if builddir:
         if os.path.exists(os.path.join(builddir, "pom.xml")):
@@ -828,7 +840,8 @@ def autofuzz_project_from_github(github_url,
     # If this is a jvm target download ant, maven and gradle once so we don't
     # have to do it for each proejct. Also extract a class_list for java classes
     # in the repository before building the project. This class_list is used for
-    # target method filtering in the target generation stage.
+    # target method filtering in the target generation stage. Some project requires
+    # protoc to generate java code, so protoc is also downloaded here.
     if language == "jvm":
         # Download Ant
         target_ant_path = os.path.join(oss_fuzz_base_project.project_folder,
@@ -848,7 +861,14 @@ def autofuzz_project_from_github(github_url,
         with open(target_gradle_path, 'wb') as gf:
             gf.write(requests.get(constants.GRADLE_URL).content)
 
-        # Extract class list for the etarget project
+        # Download protoc
+        target_protoc_path = os.path.join(oss_fuzz_base_project.project_folder,
+                                          "protoc.zip")
+        with open(target_protoc_path, 'wb') as gf:
+            gf.write(requests.get(constants.PROTOC_URL).content)
+
+
+        # Extract class list for the target project
         java_class_list = extract_class_list(
             os.path.join(oss_fuzz_base_project.project_folder,
                          oss_fuzz_base_project.project_name))


### PR DESCRIPTION
Some java project depends on Protoc to generate the source code during project building phase. This PR fixes the logic to also retrieve and include the protoc binary in the project directory in order for those project to build.