### PR TITLE
Auto-Fuzz: Fix dependencies

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -162,7 +162,7 @@ do
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
       MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true"
-      $MVN clean package $MAVEN_ARGS
+      $MVN clean package dependency:copy-dependencies $MAVEN_ARGS
       SUCCESS=true
       break
     elif test -f "build.gradle"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -282,8 +282,8 @@ def _maven_build_project(basedir, projectdir):
 
     # Build project with maven with default jdk
     cmd = [
-        "mvn clean package", "-DskipTests", "-Dmaven.javadoc.skip=true",
-        "--update-snapshots"
+        "mvn clean package dependency:copy-dependencies", "-DskipTests",
+        "-Dmaven.javadoc.skip=true", "--update-snapshots"
     ]
     try:
         subprocess.check_call(" ".join(cmd),


### PR DESCRIPTION
Some maven project does not include shadowJar or copy-dependencies goal in their settings. This result in missing dependencies in the build jar and fail to use them directly without manually including the dependencies. This PR fixes the maven build process to force it to copy all needed dependencies jar file to the target directory in order for auto-fuzz to use them.