### PR TITLE
Auto-fuzz: Skip PMD checking

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -161,7 +161,7 @@ do
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
-      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true"
+      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true -Dpmd.skip=true"
       $MVN clean package dependency:copy-dependencies $MAVEN_ARGS
       SUCCESS=true
       break

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -286,7 +286,7 @@ def _maven_build_project(basedir, projectdir):
     cmd = [
         "mvn clean package dependency:copy-dependencies", "-DskipTests",
         "-Dmaven.javadoc.skip=true", "--update-snapshots",
-        "-DoutputDirectory=lib"
+        "-DoutputDirectory=lib -Dpmd.skip=true"
     ]
     try:
         subprocess.check_call(" ".join(cmd),


### PR DESCRIPTION
Some projects has included PMD checking in their project build. PMD checking is  a static analysis of the code to discover possible code style, redundant / unused code or possible code with errors. This process may fail the maven build of the project which the code may passes through the compiler normally without errors. In order to speed up the process and to ignore warnings in the original project, this PR adds additional flag to skip the PMD checking for maven build.