### PR TITLE
Auto-fuzz: Stop gradle daemon after project build

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -169,6 +169,7 @@ do
     then
       chmod +x ./gradlew
       ./gradlew clean build -x test
+      ./gradlew --stop
       SUCCESS=true
       break
     elif test -f "build.xml"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -319,7 +319,7 @@ def _gradle_build_project(basedir, projectdir):
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
-    cmd = ["chmod +x gradlew", "./gradlew clean build -x test"]
+    cmd = ["chmod +x gradlew", "./gradlew clean build -x test", "./gradlew --stop"]
     try:
         subprocess.check_call(" && ".join(cmd),
                               shell=True,

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -319,7 +319,9 @@ def _gradle_build_project(basedir, projectdir):
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with maven
-    cmd = ["chmod +x gradlew", "./gradlew clean build -x test", "./gradlew --stop"]
+    cmd = [
+        "chmod +x gradlew", "./gradlew clean build -x test", "./gradlew --stop"
+    ]
     try:
         subprocess.check_call(" && ".join(cmd),
                               shell=True,


### PR DESCRIPTION
By default, gradle will turn on a daemon when a build process is started to save time for subsequent build. If different version of gradle wrapper is used, there will be multiple gradle daemon started in the background because different version of gradle will host its own gradle daemon. In general, it is not a problem. But for auto-fuzz, since we are aiming to process a long list of project which may have different gradle version specified in their gradle wrapper, it could generate a hugh memory consumption for starting loads of gradle daemon with different gradle version. That cause OOM quick in a batch execution. This PR fixes the command to force the gradle daemon to stop after the gradle project build completed.