### PR TITLE
Auto-fuzz: Add logic to clean base directory

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -584,8 +584,15 @@ def cleanup_base_directory(base_dir, project_name):
     """Cleans up the base directory, removing unnecessary files after
     the fuzzers auto-generation and checking process.
     """
-    file_to_clean = ['Fuzz.jar', 'Fuzz.class', 'ant.zip', 'gradle.zip', 'maven.zip', 'protoc.zip', 'jdk.tar.gz', 'work/commons-lang3.jar', 'work/jazzer', 'work/jazzer.tar.gz', 'work/jazzer_standalone.jar']
-    dir_to_clean = ['apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-15', 'protoc', project_name, 'work/jar', 'work/proj']
+    file_to_clean = [
+        'Fuzz.jar', 'Fuzz.class', 'ant.zip', 'gradle.zip', 'maven.zip',
+        'protoc.zip', 'jdk.tar.gz', 'work/commons-lang3.jar', 'work/jazzer',
+        'work/jazzer.tar.gz', 'work/jazzer_standalone.jar'
+    ]
+    dir_to_clean = [
+        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-15',
+        'protoc', project_name, 'work/jar', 'work/proj'
+    ]
 
     for file in file_to_clean:
         if os.path.isfile(os.path.join(base_dir, file)):
@@ -1001,7 +1008,8 @@ def autofuzz_project_from_github(github_url,
 
     # Clean base directory for the project
     print("Cleaning base directory for %s" % (github_url))
-    cleanup_base_directory(base_oss_fuzz_project_dir, oss_fuzz_base_project.project_name)
+    cleanup_base_directory(base_oss_fuzz_project_dir,
+                           oss_fuzz_base_project.project_name)
 
     return True
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -580,6 +580,22 @@ def cleanup_build_cache():
                           stderr=subprocess.DEVNULL)
 
 
+def cleanup_base_directory(base_dir, project_name):
+    """Cleans up the base directory, removing unnecessary files after
+    the fuzzers auto-generation and checking process.
+    """
+    file_to_clean = ['Fuzz.jar', 'Fuzz.class', 'ant.zip', 'gradle.zip', 'maven.zip', 'protoc.zip', 'jdk.tar.gz', 'work/commons-lang3.jar', 'work/jazzer', 'work/jazzer.tar.gz', 'work/jazzer_standalone.jar']
+    dir_to_clean = ['apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-15', 'protoc', project_name, 'work/jar', 'work/proj']
+
+    for file in file_to_clean:
+        if os.path.isfile(os.path.join(base_dir, file)):
+            os.remove(os.path.join(base_dir, file))
+
+    for dir in dir_to_clean:
+        if os.path.isdir(os.path.join(base_dir, dir)):
+            shutil.rmtree(os.path.join(base_dir, dir))
+
+
 def build_and_test_single_possible_target(idx_folder,
                                           idx,
                                           oss_fuzz_base_project,
@@ -931,11 +947,12 @@ def autofuzz_project_from_github(github_url,
         else:
             return False
 
-    # Check basic fuzzer
+    # Check basic fuzzer and clean it afterwards
     res = oss_fuzz_manager.copy_and_build_project(
         oss_fuzz_base_project.project_folder,
         OSS_FUZZ_BASE,
-        log_dir=base_oss_fuzz_project_dir)
+        log_dir=base_oss_fuzz_project_dir,
+        base_autofuzz=True)
     if not res:
         return False
 
@@ -981,6 +998,10 @@ def autofuzz_project_from_github(github_url,
                 print("No introspector generated")
         else:
             print("Fail to merge project")
+
+    # Clean base directory for the project
+    print("Cleaning base directory for %s" % (github_url))
+    cleanup_base_directory(base_oss_fuzz_project_dir, oss_fuzz_base_project.project_name)
 
     return True
 

--- a/tools/auto-fuzz/oss_fuzz_manager.py
+++ b/tools/auto-fuzz/oss_fuzz_manager.py
@@ -78,7 +78,7 @@ def copy_and_introspect_project(src_folder, oss_fuzz_base, log_dir=None):
     return True
 
 
-def copy_and_build_project(src_folder, oss_fuzz_base, log_dir=None):
+def copy_and_build_project(src_folder, oss_fuzz_base, log_dir=None, base_autofuzz=False):
     """Copies src_folder into the oss-fuzz located at oss_fuzz_base project's
     folder and runs the oss-fuzz command:
     build_fuzzers
@@ -111,6 +111,14 @@ def copy_and_build_project(src_folder, oss_fuzz_base, log_dir=None):
         f.write(out)
     with open(err_log, "wb") as f:
         f.write(err)
+
+    if base_autofuzz:
+        try:
+            shutil.rmtree(os.path.join(oss_fuzz_base, "projects", "base-autofuzz"))
+            cleanup_project("base-autofuzz", oss_fuzz_base)
+        except shutil.Error:
+            # Pass if base_autofuzz cleaning is failed
+            pass
 
     if b"Building fuzzers failed" in err:
         return False

--- a/tools/auto-fuzz/oss_fuzz_manager.py
+++ b/tools/auto-fuzz/oss_fuzz_manager.py
@@ -78,7 +78,10 @@ def copy_and_introspect_project(src_folder, oss_fuzz_base, log_dir=None):
     return True
 
 
-def copy_and_build_project(src_folder, oss_fuzz_base, log_dir=None, base_autofuzz=False):
+def copy_and_build_project(src_folder,
+                           oss_fuzz_base,
+                           log_dir=None,
+                           base_autofuzz=False):
     """Copies src_folder into the oss-fuzz located at oss_fuzz_base project's
     folder and runs the oss-fuzz command:
     build_fuzzers
@@ -114,7 +117,8 @@ def copy_and_build_project(src_folder, oss_fuzz_base, log_dir=None, base_autofuz
 
     if base_autofuzz:
         try:
-            shutil.rmtree(os.path.join(oss_fuzz_base, "projects", "base-autofuzz"))
+            shutil.rmtree(
+                os.path.join(oss_fuzz_base, "projects", "base-autofuzz"))
             cleanup_project("base-autofuzz", oss_fuzz_base)
         except shutil.Error:
             # Pass if base_autofuzz cleaning is failed


### PR DESCRIPTION
This PR fixes the cleaning logic to remove large and build only folder from the base directory to reverse space for larger batch execution.