### PR TITLE
Auto-fuzz: Fix class not found exception and clean directory

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -204,27 +204,23 @@ do
   fi
 done
 
-BUILD_CLASSPATH=
-
 curr_dir=$(pwd)
+rm -rf $OUT/jar_temp
 mkdir $OUT/jar_temp
 cd $OUT/jar_temp
 for JARFILE in $JARFILE_LIST
 do
   jar -xf $OUT/$JARFILE
-  BUILD_CLASSPATH=$BUILD_CLASSPATH$OUT/$(basename $JARFILE):
 done
-jar -cf $OUT/combined.jar .
 cd $curr_dir
-rm -r $OUT/jar_temp
 
 # Retrieve apache-common-lang3 library
 # This library provides method to translate primitive type arrays to
 # their respective class object arrays to avoid compilation error.
 wget -P $OUT/ https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar
 
-BUILD_CLASSPATH=$BUILD_CLASSPATH$JAZZER_API_PATH:$OUT/combined.jar:$OUT/commons-lang3-3.12.0.jar
-RUNTIME_CLASSPATH=\$this_dir/combined.jar:\$this_dir/commons-lang3-3.12.0.jar:\$this_dir
+BUILD_CLASSPATH=$JAZZER_API_PATH:$OUT/jar_temp:$OUT/commons-lang3-3.12.0.jar
+RUNTIME_CLASSPATH=\$this_dir/jar_temp:\$this_dir/commons-lang3-3.12.0.jar:\$this_dir
 
 for fuzzer in $(find $SRC -name 'Fuzz*.java')
 do

--- a/tools/auto-fuzz/oss_fuzz_manager.py
+++ b/tools/auto-fuzz/oss_fuzz_manager.py
@@ -116,13 +116,7 @@ def copy_and_build_project(src_folder,
         f.write(err)
 
     if base_autofuzz:
-        try:
-            shutil.rmtree(
-                os.path.join(oss_fuzz_base, "projects", "base-autofuzz"))
-            cleanup_project("base-autofuzz", oss_fuzz_base)
-        except shutil.Error:
-            # Pass if base_autofuzz cleaning is failed
-            pass
+        cleanup_project("base-autofuzz", oss_fuzz_base)
 
     if b"Building fuzzers failed" in err:
         return False
@@ -132,7 +126,8 @@ def copy_and_build_project(src_folder,
 
 def cleanup_project(proj_name, oss_fuzz_base):
     """Remove everything in the /out/ folder of a project. Does this by calling
-    docker run in the same way that OSS-Fuzz handles its Docker images."""
+    docker run in the same way that OSS-Fuzz handles its Docker images.
+    Also remove the copied oss-fuzz project folder."""
     project_out = os.path.join(oss_fuzz_base, "build", "out", proj_name)
     oss_fuzz_project_docker_args = [
         '-v', f'{project_out}:/out', '-t', f'gcr.io/oss-fuzz/{proj_name}',
@@ -157,4 +152,11 @@ def cleanup_project(proj_name, oss_fuzz_base):
                               stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
         pass
+
+    try:
+        shutil.rmtree(
+            os.path.join(oss_fuzz_base, "projects", proj_name))
+    except shutil.Error:
+        pass
+
     return True

--- a/tools/auto-fuzz/oss_fuzz_manager.py
+++ b/tools/auto-fuzz/oss_fuzz_manager.py
@@ -154,8 +154,7 @@ def cleanup_project(proj_name, oss_fuzz_base):
         pass
 
     try:
-        shutil.rmtree(
-            os.path.join(oss_fuzz_base, "projects", proj_name))
+        shutil.rmtree(os.path.join(oss_fuzz_base, "projects", proj_name))
     except shutil.Error:
         pass
 


### PR DESCRIPTION
There is an error in combining the project jar files, causing ClassNotFoundException during generated fuzzers execution. This PR fixes the logic by pointing the classpath to the jar dump directory. Also, this PR fixes the cleaning logic after each fuzzer testing in oss-fuzz directory.