### PR TITLE
Auto-fuzz: Skip legacy ant build

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -163,7 +163,8 @@ do
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
-      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true -Dpmd.skip=true"
+      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true "
+      MAVEN_ARGS=$MAVEN_ARGS"-Dpmd.skip=true -Dencoding=UTF-8 -Dmaven.antrun.skip=true"
       $MVN clean package dependency:copy-dependencies $MAVEN_ARGS
       SUCCESS=true
       break

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -287,7 +287,8 @@ def _maven_build_project(basedir, projectdir):
     cmd = [
         "mvn clean package dependency:copy-dependencies", "-DskipTests",
         "-Dmaven.javadoc.skip=true", "--update-snapshots",
-        "-DoutputDirectory=lib", "-Dpmd.skip=true"
+        "-DoutputDirectory=lib", "-Dpmd.skip=true", "-Dencoding=UTF-8",
+        "-Dmaven.antrun.skip=true"
     ]
     try:
         subprocess.check_call(" ".join(cmd),


### PR DESCRIPTION
Some maven projects depend on ant run plugin to check code. This PR disable the legacy ant run to avoid error in ant encoding.