### PR TITLE
Auto-fuzz: Fix gradle build skip

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -171,7 +171,12 @@ do
     elif test -f "build.gradle" || test -f "build.gradle.kts"
     then
       chmod +x ./gradlew
-      ./gradlew clean build -x test -x spotlessCheck
+      if ./gradlew tasks --all | grep -qw "^spotlessCheck"
+      then
+        ./gradlew clean build -x test -x spotlessCheck
+      else
+        ./gradlew clean build -x test
+      fi
       ./gradlew --stop
       SUCCESS=true
       break

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -328,8 +328,7 @@ def _gradle_build_project(basedir, projectdir):
           ./gradlew clean build -x test -x spotlessCheck;
         else
           ./gradlew clean build -x test;
-        fi""",
-        "./gradlew --stop"
+        fi""", "./gradlew --stop"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -322,7 +322,13 @@ def _gradle_build_project(basedir, projectdir):
 
     # Build project with maven
     cmd = [
-        "chmod +x gradlew", "./gradlew clean build -x test -x spotlessCheck",
+        "chmod +x gradlew",
+        """if ./gradlew tasks --all | grep -qw "^spotlessCheck";
+        then
+          ./gradlew clean build -x test -x spotlessCheck;
+        else
+          ./gradlew clean build -x test;
+        fi""",
         "./gradlew --stop"
     ]
     try:


### PR DESCRIPTION
This PR fixes the spotlessCheck skip bug when spotlessCheck task is not defined in the project.