### PR TITLE
Auto-fuzz: Fix ambiguous fuzzer name

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -223,7 +223,7 @@ wget -P $OUT/ https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.
 BUILD_CLASSPATH=$JAZZER_API_PATH:$OUT/jar_temp:$OUT/commons-lang3-3.12.0.jar
 RUNTIME_CLASSPATH=\$this_dir/jar_temp:\$this_dir/commons-lang3-3.12.0.jar:\$this_dir
 
-for fuzzer in $(find $SRC -name 'Fuzz*.java')
+for fuzzer in $(find $SRC -name 'Fuzz.java')
 do
   fuzzer_basename=$(basename -s .java $fuzzer)
   javac -cp $BUILD_CLASSPATH $fuzzer


### PR DESCRIPTION
The current logic look for all Fuzz*.java to compile, but it could cause error if the project have some java source file also named with similar name. This PR fixes the ambiguity by removing the unnecessary wildcard character.