### PR TITLE
Auto-fuzz: Fix maven toolchain and java version

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -125,7 +125,7 @@ ENV ANT $SRC/ant/apache-ant-1.9.16/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
 ENV PATH="$SRC/gradle/gradle-7.4.2/bin:$SRC/protoc/bin:$PATH"
-ENV JAVA_HOME="$SRC/jdk-19"
+ENV JAVA_HOME="$SRC/jdk-17"
 #RUN git clone --depth 1 %s %s
 COPY %s %s
 COPY *.sh *.java $SRC/
@@ -172,8 +172,6 @@ do
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
-      MAVEN_ARGS="-Dmaven.test.skip=true -Dmaven.javadoc.skip=true "
-      MAVEN_ARGS=$MAVEN_ARGS"-Dpmd.skip=true -Dencoding=UTF-8 -Dmaven.antrun.skip=true"
       mkdir -p ~/.m2
       echo "<toolchains><toolchain><type>jdk</type><provides><version>1.8</version></provides>" > ~/.m2/toolchains.xml
       echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
@@ -184,8 +182,6 @@ do
       echo "<toolchain><type>jdk</type><provides><version>15</version></provides>" >> ~/.m2/toolchains.xml
       echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
       echo "<toolchain><type>jdk</type><provides><version>17</version></provides>" >> ~/.m2/toolchains.xml
-      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
-      echo "<toolchain><type>jdk</type><provides><version>19</version></provides>" >> ~/.m2/toolchains.xml
       echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
       echo "</toolchains>" >> ~/.m2/toolchains.xml
       $MVN clean package -Dmaven.javadoc.skip=true -DskipTests=true -Dpmd.skip=true -Dencoding=UTF-8 \

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # License for bash script or python file
+import constants
+
 BASH_LICENSE = """
 # Copyright 2023 Google LLC
 #
@@ -105,25 +107,34 @@ WORKDIR $SRC/%s
 
 def gen_dockerfile_jvm(github_url, project_name):
     DOCKER_STEPS = """FROM gcr.io/oss-fuzz-base/base-builder-jvm
-#RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
+#RUN curl -L %s -o ant.zip && unzip ant.zip -d $SRC/maven && rm -rf ant.zip
+#RUN curl -L %s -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
+#RUN curl -L %s -o gradle.zip && unzip gradle.zip -d $SRC/maven && rm -rf gradle.zip
+#RUN curl -L %s -o protoc.zip && mkdir -p $SRC/protoc && unzip protoc.zip -d $SRC/maven && rm -rf protoc.zip
+#RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
 COPY ant.zip $SRC/ant.zip
 COPY maven.zip $SRC/maven.zip
 COPY gradle.zip $SRC/gradle.zip
 COPY protoc.zip $SRC/protoc.zip
+COPY jdk.tar.gz $SRC/jdk.tar.gz
 RUN unzip ant.zip -d $SRC/ant && rm ./ant.zip
 RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
 RUN unzip gradle.zip -d $SRC/gradle && rm ./gradle.zip
 RUN mkdir -p $SRC/protoc
 RUN unzip protoc.zip -d $SRC/protoc && rm ./protoc.zip
+RUN tar zxf jdk.tar.gz && rm ./jdk.tar.gz
 ENV ANT $SRC/ant/apache-ant-1.9.16/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
 ENV PATH="$SRC/gradle/gradle-7.4.2/bin:$SRC/protoc/bin:$PATH"
+ENV JAVA_HOME="$SRC/jdk-19"
 #RUN git clone --depth 1 %s %s
 COPY %s %s
 COPY *.sh *.java $SRC/
 WORKDIR $SRC/%s
-""" % (github_url, project_name, project_name, project_name, project_name)
+""" % (constants.ANT_URL, constants.MAVEN_URL, constants.GRADLE_URL,
+       constants.PROTOC_URL, constants.JDK_URL, github_url, project_name,
+       project_name, project_name, project_name)
 
     return BASH_LICENSE + "\n" + DOCKER_STEPS
 
@@ -163,9 +174,24 @@ do
       find ./ -name pom.xml -exec sed -i 's/java16/java18/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.5/java-1.8/g' {} \;
       find ./ -name pom.xml -exec sed -i 's/java-1.6/java-1.8/g' {} \;
-      MAVEN_ARGS="-Dmaven.test.skip=true --update-snapshots -Dmaven.javadoc.skip=true "
+      MAVEN_ARGS="-Dmaven.test.skip=true -Dmaven.javadoc.skip=true "
       MAVEN_ARGS=$MAVEN_ARGS"-Dpmd.skip=true -Dencoding=UTF-8 -Dmaven.antrun.skip=true"
-      $MVN clean package dependency:copy-dependencies $MAVEN_ARGS
+      mkdir -p ~/.m2
+      echo "<toolchains><toolchain><type>jdk</type><provides><version>1.8</version></provides>" > ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "<toolchain><type>jdk</type><provides><version>11</version></provides>" >> ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "<toolchain><type>jdk</type><provides><version>14</version></provides>" >> ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "<toolchain><type>jdk</type><provides><version>15</version></provides>" >> ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "<toolchain><type>jdk</type><provides><version>17</version></provides>" >> ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "<toolchain><type>jdk</type><provides><version>19</version></provides>" >> ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "</toolchains>" >> ~/.m2/toolchains.xml
+      $MVN clean package -Dmaven.javadoc.skip=true -DskipTests=true -Dpmd.skip=true \
+      -Dencoding=UTF-8 -Dmaven.antrun.skip=true dependency:copy-dependencies
       SUCCESS=true
       break
     elif test -f "build.gradle" || test -f "build.gradle.kts"
@@ -197,7 +223,7 @@ for JARFILE in $(find ./  -name *.jar)
 do
   if [[ "$JARFILE" == *"target/"* ]] || [[ "$JARFILE" == *"build/"* ]]
   then
-    if [[ "$JARFILE" != *sources.jar ]] && [[ "$JARFILE" != *javadoc.jar ]]
+    if [[ "$JARFILE" != *sources.jar ]] && [[ "$JARFILE" != *javadoc.jar ]] && [[ "$JARFILE" != *tests.jar ]]
     then
       cp $JARFILE $OUT/
       JARFILE_LIST="$JARFILE_LIST$(basename $JARFILE) "

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -111,18 +111,16 @@ def gen_dockerfile_jvm(github_url, project_name):
 #RUN curl -L %s -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
 #RUN curl -L %s -o gradle.zip && unzip gradle.zip -d $SRC/maven && rm -rf gradle.zip
 #RUN curl -L %s -o protoc.zip && mkdir -p $SRC/protoc && unzip protoc.zip -d $SRC/maven && rm -rf protoc.zip
-#RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
+RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
 COPY ant.zip $SRC/ant.zip
 COPY maven.zip $SRC/maven.zip
 COPY gradle.zip $SRC/gradle.zip
 COPY protoc.zip $SRC/protoc.zip
-COPY jdk.tar.gz $SRC/jdk.tar.gz
 RUN unzip ant.zip -d $SRC/ant && rm ./ant.zip
 RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
 RUN unzip gradle.zip -d $SRC/gradle && rm ./gradle.zip
 RUN mkdir -p $SRC/protoc
 RUN unzip protoc.zip -d $SRC/protoc && rm ./protoc.zip
-RUN tar zxf jdk.tar.gz && rm ./jdk.tar.gz
 ENV ANT $SRC/ant/apache-ant-1.9.16/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -188,8 +188,8 @@ do
       echo "<toolchain><type>jdk</type><provides><version>19</version></provides>" >> ~/.m2/toolchains.xml
       echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
       echo "</toolchains>" >> ~/.m2/toolchains.xml
-      $MVN clean package -Dmaven.javadoc.skip=true -DskipTests=true -Dpmd.skip=true \
-      -Dencoding=UTF-8 -Dmaven.antrun.skip=true dependency:copy-dependencies
+      $MVN clean package -Dmaven.javadoc.skip=true -DskipTests=true -Dpmd.skip=true -Dencoding=UTF-8 \
+      -Dmaven.antrun.skip=true -Dcheckstyle.skip=true dependency:copy-dependencies
       SUCCESS=true
       break
     elif test -f "build.gradle" || test -f "build.gradle.kts"

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -18,7 +18,7 @@ MAX_THREADS = 4
 
 BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
 
-JDK_URL = "https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz"
+JDK_URL = "https://download.java.net/openjdk/jdk19/ri/openjdk-19+36_linux-x64_bin.tar.gz"
 ANT_URL = "https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip"
 MAVEN_URL = "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
 GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -18,7 +18,7 @@ MAX_THREADS = 4
 
 BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
 
-JDK_URL = "https://download.java.net/openjdk/jdk19/ri/openjdk-19+36_linux-x64_bin.tar.gz"
+JDK_URL = "https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_linux-x64_bin.tar.gz"
 ANT_URL = "https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip"
 MAVEN_URL = "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
 GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -221,7 +221,7 @@ def _ant_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-19")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-17")
     env_var['PATH'] = os.path.join(
         basedir, constants.ANT_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -252,7 +252,7 @@ def _maven_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-19")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-17")
     env_var['PATH'] = os.path.join(
         basedir, constants.MAVEN_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -333,7 +333,7 @@ def _gradle_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-19")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-17")
     env_var['PATH'] = os.path.join(
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -415,8 +415,8 @@ def build_jvm_project(basedir, projectdir, proj_name):
     # directory
     builddir = find_project_build_folder(projectdir, proj_name)
 
-    # Prepare OpenJDK 15
-    os.makedirs(os.path.join(basedir, "jdk-19"), exist_ok=True)
+    # Prepare OpenJDK 17
+    os.makedirs(os.path.join(basedir, "jdk-17"), exist_ok=True)
     with tarfile.open(os.path.join(basedir, "jdk.tar.gz"), "r:gz") as jf:
         jf.extractall(os.path.join(basedir))
 
@@ -620,7 +620,7 @@ def cleanup_base_directory(base_dir, project_name):
         'work/jazzer.tar.gz', 'work/jazzer_standalone.jar'
     ]
     dir_to_clean = [
-        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-19',
+        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-17',
         'protoc', project_name, 'work/jar', 'work/proj'
     ]
 
@@ -919,7 +919,7 @@ def autofuzz_project_from_github(github_url,
     # target method filtering in the target generation stage. Some project requires
     # protoc to generate java code, so protoc is also downloaded here.
     if language == "jvm":
-        # Download OpenJDK 15:
+        # Download OpenJDK 17:
         target_jdk_path = os.path.join(oss_fuzz_base_project.project_folder,
                                        "jdk.tar.gz")
         with open(target_jdk_path, 'wb') as jf:

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -306,7 +306,7 @@ def _maven_build_project(basedir, projectdir):
         "mvn clean package dependency:copy-dependencies", "-DskipTests",
         "-Dmaven.javadoc.skip=true", "--update-snapshots",
         "-DoutputDirectory=lib", "-Dpmd.skip=true", "-Dencoding=UTF-8",
-        "-Dmaven.antrun.skip=true"
+        "-Dmaven.antrun.skip=true", "-Dcheckstyle.skip=true"
     ]
     try:
         subprocess.check_call(" ".join(cmd),

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -221,7 +221,7 @@ def _ant_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-15", "jdk-15.0.2")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-19")
     env_var['PATH'] = os.path.join(
         basedir, constants.ANT_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -252,10 +252,28 @@ def _maven_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-15", "jdk-15.0.2")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-19")
     env_var['PATH'] = os.path.join(
         basedir, constants.MAVEN_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+
+    # Prepare maven toolchains location
+    with open(os.path.join(os.path.expanduser('~'), ".m2", "toolchains.xml"),
+              "w") as file:
+        file.write(
+            """<toolchains><toolchain><type>jdk</type><provides><version>1.8</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
+                    <toolchain><type>jdk</type><provides><version>11</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
+                    <toolchain><type>jdk</type><provides><version>14</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
+                    <toolchain><type>jdk</type><provides><version>15</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
+                    <toolchain><type>jdk</type><provides><version>17</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
+                    <toolchain><type>jdk</type><provides><version>19</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain></toolchains>"""
+        )
 
     # Patch pom.xml to use at least jdk 1.8
     cmd = [
@@ -315,7 +333,7 @@ def _gradle_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-15", "jdk-15.0.2")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-19")
     env_var['PATH'] = os.path.join(
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -398,9 +416,9 @@ def build_jvm_project(basedir, projectdir, proj_name):
     builddir = find_project_build_folder(projectdir, proj_name)
 
     # Prepare OpenJDK 15
-    os.makedirs(os.path.join(basedir, "jdk-15"), exist_ok=True)
+    os.makedirs(os.path.join(basedir, "jdk-19"), exist_ok=True)
     with tarfile.open(os.path.join(basedir, "jdk.tar.gz"), "r:gz") as jf:
-        jf.extractall(os.path.join(basedir, "jdk-15"))
+        jf.extractall(os.path.join(basedir))
 
     # Prepare protoc
     os.makedirs(os.path.join(basedir, "protoc"), exist_ok=True)
@@ -602,7 +620,7 @@ def cleanup_base_directory(base_dir, project_name):
         'work/jazzer.tar.gz', 'work/jazzer_standalone.jar'
     ]
     dir_to_clean = [
-        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-15',
+        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-19',
         'protoc', project_name, 'work/jar', 'work/proj'
     ]
 


### PR DESCRIPTION
Some maven projects defined require toolchains. This PR fixes the setting to direct the toolchains to the JDK HOME. In addition, this PR updates the JDK version to 19 to accommodate more projects. Lastly, this PR add configuration to skip checkstyle plugin to avoid project fail to build because of formatting problem.