### PR TITLE
Auto-fuzz: Fix gradle build version

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -170,14 +170,14 @@ do
       break
     elif test -f "build.gradle" || test -f "build.gradle.kts"
     then
-      chmod +x ./gradlew
-      if ./gradlew tasks --all | grep -qw "^spotlessCheck"
+      rm -rf $HOME/.gradle/caches/
+      if gradle tasks --all | grep -qw "^spotlessCheck"
       then
-        ./gradlew clean build -x test -x spotlessCheck
+        gradle clean build -x test -x spotlessCheck
       else
-        ./gradlew clean build -x test
+        gradle clean build -x test
       fi
-      ./gradlew --stop
+      gradle --stop
       SUCCESS=true
       break
     elif test -f "build.xml"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -322,13 +322,13 @@ def _gradle_build_project(basedir, projectdir):
 
     # Build project with maven
     cmd = [
-        "chmod +x gradlew",
-        """if ./gradlew tasks --all | grep -qw "^spotlessCheck";
+        "rm -rf $HOME/.gradle/caches/",
+        """if gradle tasks --all | grep -qw "^spotlessCheck";
         then
-          ./gradlew clean build -x test -x spotlessCheck;
+          gradle clean build -x test -x spotlessCheck;
         else
-          ./gradlew clean build -x test;
-        fi""", "./gradlew --stop"
+          gradle clean build -x test;
+        fi""", "gradle --stop"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),


### PR DESCRIPTION
Fix the logic to use the downloaded gradle bundle rather then the wrapper.