### PR TITLE
Auto-fuzz: Fix java version to match oss-fuzz default version

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -111,7 +111,7 @@ def gen_dockerfile_jvm(github_url, project_name):
 #RUN curl -L %s -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
 #RUN curl -L %s -o gradle.zip && unzip gradle.zip -d $SRC/maven && rm -rf gradle.zip
 #RUN curl -L %s -o protoc.zip && mkdir -p $SRC/protoc && unzip protoc.zip -d $SRC/maven && rm -rf protoc.zip
-RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
+#RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
 COPY ant.zip $SRC/ant.zip
 COPY maven.zip $SRC/maven.zip
 COPY gradle.zip $SRC/gradle.zip
@@ -125,7 +125,7 @@ ENV ANT $SRC/ant/apache-ant-1.9.16/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
 ENV PATH="$SRC/gradle/gradle-7.4.2/bin:$SRC/protoc/bin:$PATH"
-ENV JAVA_HOME="$SRC/jdk-17"
+#ENV JAVA_HOME="$SRC/jdk-15.0.2"
 #RUN git clone --depth 1 %s %s
 COPY %s %s
 COPY *.sh *.java $SRC/

--- a/tools/auto-fuzz/constants.py
+++ b/tools/auto-fuzz/constants.py
@@ -18,7 +18,7 @@ MAX_THREADS = 4
 
 BATCH_SIZE_BEFORE_DOCKER_CLEAN = 40
 
-JDK_URL = "https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_linux-x64_bin.tar.gz"
+JDK_URL = "https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz"
 ANT_URL = "https://dlcdn.apache.org//ant/binaries/apache-ant-1.9.16-bin.zip"
 MAVEN_URL = "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip"
 GRADLE_URL = "https://services.gradle.org/distributions/gradle-7.4.2-bin.zip"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -625,8 +625,8 @@ def cleanup_base_directory(base_dir, project_name):
         'work/jazzer.tar.gz', 'work/jazzer_standalone.jar'
     ]
     dir_to_clean = [
-        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-15.0.2',
-        'protoc', project_name, 'work/jar', 'work/proj'
+        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2',
+        'jdk-15.0.2', 'protoc', project_name, 'work/jar', 'work/proj'
     ]
 
     for file in file_to_clean:

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -221,7 +221,7 @@ def _ant_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-17")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-15.0.2")
     env_var['PATH'] = os.path.join(
         basedir, constants.ANT_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -252,7 +252,7 @@ def _maven_build_project(basedir, projectdir):
 
     # Set environment variable
     env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-17")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-15.0.2")
     env_var['PATH'] = os.path.join(
         basedir, constants.MAVEN_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -333,7 +333,7 @@ def _gradle_build_project(basedir, projectdir):
     # Set environment variable
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
-    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-17")
+    env_var['JAVA_HOME'] = os.path.join(basedir, "jdk-15.0.2")
     env_var['PATH'] = os.path.join(
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -420,8 +420,8 @@ def build_jvm_project(basedir, projectdir, proj_name):
     # directory
     builddir = find_project_build_folder(projectdir, proj_name)
 
-    # Prepare OpenJDK 17
-    os.makedirs(os.path.join(basedir, "jdk-17"), exist_ok=True)
+    # Prepare OpenJDK 15
+    os.makedirs(os.path.join(basedir, "jdk-15.0.2"), exist_ok=True)
     with tarfile.open(os.path.join(basedir, "jdk.tar.gz"), "r:gz") as jf:
         jf.extractall(os.path.join(basedir))
 
@@ -625,7 +625,7 @@ def cleanup_base_directory(base_dir, project_name):
         'work/jazzer.tar.gz', 'work/jazzer_standalone.jar'
     ]
     dir_to_clean = [
-        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-17',
+        'apache-maven-3.6.3', 'apache-ant-1.9.16', 'gradle-7.4.2', 'jdk-15.0.2',
         'protoc', project_name, 'work/jar', 'work/proj'
     ]
 
@@ -924,7 +924,7 @@ def autofuzz_project_from_github(github_url,
     # target method filtering in the target generation stage. Some project requires
     # protoc to generate java code, so protoc is also downloaded here.
     if language == "jvm":
-        # Download OpenJDK 17:
+        # Download OpenJDK 15:
         target_jdk_path = os.path.join(oss_fuzz_base_project.project_folder,
                                        "jdk.tar.gz")
         with open(target_jdk_path, 'wb') as jf:


### PR DESCRIPTION
By default, the base builder and base runner of oss-fuzz jvm image are using OpenJDK15. This PR changes the JDK version back to Java15 to match the oss-fuzz settings. It also removes the download of JDK in the base build.sh and use the oss-fuzz provided JDK to test the generated fuzzers.