### PR TITLE
Auto-fuzz: Remove empty line in license

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -15,8 +15,7 @@
 # License for bash script or python file
 import constants
 
-BASH_LICENSE = """
-# Copyright 2023 Google LLC
+BASH_LICENSE = """# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR removes empty line added to dockerfile and build.sh license.