### PR TITLE
Java-frontend: Fix method filtering for auto-fuzz

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -109,8 +109,16 @@ public class CallGraphGenerator {
 
     // Add an custom analysis phase to Soot
     CustomSenceTransformer custom =
-        new CustomSenceTransformer(entryClass, entryMethod, targetPackagePrefix, excludeMethod,
-            includePrefix, excludePrefix, sinkMethod, sourceDirectory, isAutoFuzz);
+        new CustomSenceTransformer(
+            entryClass,
+            entryMethod,
+            targetPackagePrefix,
+            excludeMethod,
+            includePrefix,
+            excludePrefix,
+            sinkMethod,
+            sourceDirectory,
+            isAutoFuzz);
     PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
 
     // Set basic settings for the call graph generation
@@ -204,9 +212,16 @@ class CustomSenceTransformer extends SceneTransformer {
   private Boolean isAutoFuzz;
   private Boolean analyseFinished;
 
-  public CustomSenceTransformer(String entryClassStr, String entryMethodStr,
-      String targetPackagePrefix, String excludeMethodStr, String includePrefix,
-      String excludePrefix, String sinkMethod, String sourceDirectory, Boolean isAutoFuzz) {
+  public CustomSenceTransformer(
+      String entryClassStr,
+      String entryMethodStr,
+      String targetPackagePrefix,
+      String excludeMethodStr,
+      String includePrefix,
+      String excludePrefix,
+      String sinkMethod,
+      String sourceDirectory,
+      Boolean isAutoFuzz) {
     this.entryClassStr = entryClassStr;
     this.entryMethodStr = entryMethodStr;
     this.isAutoFuzz = isAutoFuzz;
@@ -248,9 +263,10 @@ class CustomSenceTransformer extends SceneTransformer {
 
     if ((!sourceDirectory.equals("")) && (!sourceDirectory.equals("NULL"))) {
       try (Stream<Path> walk = Files.walk(Paths.get(sourceDirectory))) {
-        List<String> sourceList = walk.map(x -> x.toString())
-                                      .filter(f -> f.endsWith(".java"))
-                                      .collect(Collectors.toList());
+        List<String> sourceList =
+            walk.map(x -> x.toString())
+                .filter(f -> f.endsWith(".java"))
+                .collect(Collectors.toList());
         for (String source : sourceList) {
           projectClassList.add(source.substring(source.lastIndexOf("/") + 1).replace(".java", ""));
         }
@@ -350,8 +366,10 @@ class CustomSenceTransformer extends SceneTransformer {
       }
 
       if (isAutoFuzz) {
-        if (c.getName().endsWith("Exception") || c.getName().endsWith("Error")
-            || c.getName().contains("$") || !c.isPublic()) {
+        if (c.getName().endsWith("Exception")
+            || c.getName().endsWith("Error")
+            || c.getName().contains("$")
+            || !c.isPublic()) {
           isIgnore = true;
           isAutoFuzzIgnore = true;
         }
@@ -450,10 +468,17 @@ class CustomSenceTransformer extends SceneTransformer {
           }
           String callerClass = edge.src().getDeclaringClass().getName();
           String className = "";
-          Set<String> classNameSet = new HashSet<String>(this.edgeClassMap.getOrDefault(callerClass
-                  + ":" + tgt.getName() + ":"
-                  + ((edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber()),
-              Collections.emptySet()));
+          Set<String> classNameSet =
+              new HashSet<String>(
+                  this.edgeClassMap.getOrDefault(
+                      callerClass
+                          + ":"
+                          + tgt.getName()
+                          + ":"
+                          + ((edge.srcStmt() == null)
+                              ? -1
+                              : edge.srcStmt().getJavaSourceStartLineNumber()),
+                      Collections.emptySet()));
           className = this.mergeClassName(classNameSet);
           boolean merged = false;
           for (String name : className.split(":")) {
@@ -466,7 +491,8 @@ class CustomSenceTransformer extends SceneTransformer {
             className = tgt.getDeclaringClass().getName();
           }
           element.addFunctionsReached("[" + className + "]." + tgt.getSubSignature().split(" ")[1]);
-          functionLineMap.put(tgt.getSubSignature().split(" ")[1],
+          functionLineMap.put(
+              tgt.getSubSignature().split(" ")[1],
               (edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber());
         }
         element.setEdgeCount(methodEdges);
@@ -670,16 +696,24 @@ class CustomSenceTransformer extends SceneTransformer {
   }
 
   // Shorthand for extractCallTree from top
-  private void extractCallTree(FileWriter fw, CallGraph cg, SootMethod method, Integer depth,
-      Integer line) throws IOException {
+  private void extractCallTree(
+      FileWriter fw, CallGraph cg, SootMethod method, Integer depth, Integer line)
+      throws IOException {
     fw.write("Call tree\n");
     this.extractCallTree(fw, cg, method, depth, line, new LinkedList<SootMethod>(), null);
   }
 
   // Recursively extract calltree from stored method relationship, ignoring loops
   // and write to the output data file
-  private void extractCallTree(FileWriter fw, CallGraph cg, SootMethod method, Integer depth,
-      Integer line, List<SootMethod> handled, String callerClass) throws IOException {
+  private void extractCallTree(
+      FileWriter fw,
+      CallGraph cg,
+      SootMethod method,
+      Integer depth,
+      Integer line,
+      List<SootMethod> handled,
+      String callerClass)
+      throws IOException {
     StringBuilder callTree = new StringBuilder();
 
     if (this.excludeMethodList.contains(method.getName())) {
@@ -688,8 +722,10 @@ class CustomSenceTransformer extends SceneTransformer {
 
     String className = "";
     if (callerClass != null) {
-      Set<String> classNameSet = new HashSet<String>(this.edgeClassMap.getOrDefault(
-          callerClass + ":" + method.getName() + ":" + line, Collections.emptySet()));
+      Set<String> classNameSet =
+          new HashSet<String>(
+              this.edgeClassMap.getOrDefault(
+                  callerClass + ":" + method.getName() + ":" + line, Collections.emptySet()));
       className = this.mergeClassName(classNameSet);
       boolean merged = false;
       for (String name : className.split(":")) {
@@ -705,12 +741,18 @@ class CustomSenceTransformer extends SceneTransformer {
       className = method.getDeclaringClass().getName();
     }
     String methodName = method.getSubSignature().split(" ")[1];
-    String calltreeLine = StringUtils.leftPad("", depth * 2) + methodName + " " + className
-        + " linenumber=" + line + "\n";
+    String calltreeLine =
+        StringUtils.leftPad("", depth * 2)
+            + methodName
+            + " "
+            + className
+            + " linenumber="
+            + line
+            + "\n";
 
     boolean excluded = false;
     boolean sink = false;
-  checkExclusionLoop:
+    checkExclusionLoop:
     for (String cl : className.split(":")) {
       for (String prefix : this.excludeList) {
         if (cl.startsWith(prefix.replace("*", ""))) {
@@ -743,8 +785,13 @@ class CustomSenceTransformer extends SceneTransformer {
           continue;
         }
 
-        extractCallTree(fw, cg, tgt, depth + 1,
-            (edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber(), handled,
+        extractCallTree(
+            fw,
+            cg,
+            tgt,
+            depth + 1,
+            (edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber(),
+            handled,
             edge.src().getDeclaringClass().getName());
       }
     }
@@ -892,21 +939,23 @@ class CustomSenceTransformer extends SceneTransformer {
     while (it.hasNext()) {
       edgeList.add(it.next());
     }
-    Collections.sort(edgeList, new Comparator<Edge>() {
-      @Override
-      public int compare(Edge e1, Edge e2) {
-        Integer e1LineNo =
-            (e1.srcStmt() == null) ? -1 : e1.srcStmt().getJavaSourceStartLineNumber();
-        Integer e2LineNo =
-            (e2.srcStmt() == null) ? -1 : e2.srcStmt().getJavaSourceStartLineNumber();
-        int line = e1LineNo - e2LineNo;
-        if (line == 0) {
-          return e1.tgt().getName().compareTo(e2.tgt().getName());
-        } else {
-          return line;
-        }
-      }
-    });
+    Collections.sort(
+        edgeList,
+        new Comparator<Edge>() {
+          @Override
+          public int compare(Edge e1, Edge e2) {
+            Integer e1LineNo =
+                (e1.srcStmt() == null) ? -1 : e1.srcStmt().getJavaSourceStartLineNumber();
+            Integer e2LineNo =
+                (e2.srcStmt() == null) ? -1 : e2.srcStmt().getJavaSourceStartLineNumber();
+            int line = e1LineNo - e2LineNo;
+            if (line == 0) {
+              return e1.tgt().getName().compareTo(e2.tgt().getName());
+            } else {
+              return line;
+            }
+          }
+        });
 
     return edgeList.iterator();
   }
@@ -921,8 +970,12 @@ class CustomSenceTransformer extends SceneTransformer {
     while (it.hasNext()) {
       Edge edge = it.next();
       String className = edge.tgt().getDeclaringClass().getName();
-      String matchStr = edge.src().getDeclaringClass().getName() + ":" + edge.tgt().getName() + ":"
-          + ((edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber());
+      String matchStr =
+          edge.src().getDeclaringClass().getName()
+              + ":"
+              + edge.tgt().getName()
+              + ":"
+              + ((edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber());
 
       boolean excluded = false;
       for (String prefix : this.excludeList) {
@@ -935,7 +988,8 @@ class CustomSenceTransformer extends SceneTransformer {
       }
 
       if (!excluded) {
-        if (cg.edgesOutOf(edge.tgt()).hasNext() || edge.tgt().getName().equals("<init>")
+        if (cg.edgesOutOf(edge.tgt()).hasNext()
+            || edge.tgt().getName().equals("<init>")
             || edge.tgt().getName().equals("<cinit>")) {
           // Does not merge methods with deeper method calls
           // Does not merge edge for constructor calls
@@ -948,9 +1002,10 @@ class CustomSenceTransformer extends SceneTransformer {
             String previousEdgeName = previous.tgt().getName();
             Integer edgeLineNo =
                 (edge.srcStmt() == null) ? -1 : edge.srcStmt().getJavaSourceStartLineNumber();
-            Integer previousEdgeLineNo = (previous.srcStmt() == null)
-                ? -1
-                : previous.srcStmt().getJavaSourceStartLineNumber();
+            Integer previousEdgeLineNo =
+                (previous.srcStmt() == null)
+                    ? -1
+                    : previous.srcStmt().getJavaSourceStartLineNumber();
             if (!(edgeName.equals(previousEdgeName)) || !(edgeLineNo == previousEdgeLineNo)) {
               if (processingEdgeList.size() > 0) {
                 Set<String> classNameSet = new HashSet<String>();
@@ -980,10 +1035,14 @@ class CustomSenceTransformer extends SceneTransformer {
         classNameSet.add(mergeEdge.tgt().getDeclaringClass().getName());
       }
       if (classNameSet.size() > 1) {
-        String matchStr = edgeToAdd.src().getDeclaringClass().getName() + ":"
-            + edgeToAdd.tgt().getName() + ":"
-            + ((edgeToAdd.srcStmt() == null) ? -1
-                                             : edgeToAdd.srcStmt().getJavaSourceStartLineNumber());
+        String matchStr =
+            edgeToAdd.src().getDeclaringClass().getName()
+                + ":"
+                + edgeToAdd.tgt().getName()
+                + ":"
+                + ((edgeToAdd.srcStmt() == null)
+                    ? -1
+                    : edgeToAdd.srcStmt().getJavaSourceStartLineNumber());
         this.edgeClassMap.put(matchStr, classNameSet);
       }
     }


### PR DESCRIPTION
This PR fixes the method and class filtering logic to reduce the output data.yaml files for auto-fuzz generation.