### PR TITLE
Auto-fuzz: Fix gradle build

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -191,13 +191,14 @@ do
     elif test -f "build.gradle" || test -f "build.gradle.kts"
     then
       rm -rf $HOME/.gradle/caches/
-      if gradle tasks --all | grep -qw "^spotlessCheck"
+      chmod +x ./gradlew
+      if ./gradlew tasks --all | grep -qw "^spotlessCheck"
       then
-        gradle clean build -x test -x spotlessCheck
+        ./gradlew clean build -x test -x spotlessCheck
       else
-        gradle clean build -x test
+        ./gradlew clean build -x test
       fi
-      gradle --stop
+      ./gradlew --stop
       SUCCESS=true
       break
     elif test -f "build.xml"

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -338,15 +338,16 @@ def _gradle_build_project(basedir, projectdir):
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
-    # Build project with maven
+    # Build project with gradle wrapper of the project
     cmd = [
         "rm -rf $HOME/.gradle/caches/",
-        """if gradle tasks --all | grep -qw "^spotlessCheck";
+        "chmod +x ./gradlew",
+        """if ./gradlew tasks --all | grep -qw "^spotlessCheck";
         then
-          gradle clean build -x test -x spotlessCheck;
+          ./gradlew clean build -x test -x spotlessCheck;
         else
-          gradle clean build -x test;
-        fi""", "gradle --stop"
+          ./gradlew clean build -x test;
+        fi""", "./gradlew --stop"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -340,8 +340,7 @@ def _gradle_build_project(basedir, projectdir):
 
     # Build project with gradle wrapper of the project
     cmd = [
-        "rm -rf $HOME/.gradle/caches/",
-        "chmod +x ./gradlew",
+        "rm -rf $HOME/.gradle/caches/", "chmod +x ./gradlew",
         """if ./gradlew tasks --all | grep -qw "^spotlessCheck";
         then
           ./gradlew clean build -x test -x spotlessCheck;


### PR DESCRIPTION
Some project need different gradle version to compile and failed to compile with the default gradle 7.4.2. This PR fixes the logic to use the gradle wrapper provided by the project instead of the default gradle.