### PR TITLE
tools: add top api scanner

### DIFF
--- a/tools/oss-fuzz-scanner/get_top_apis.py
+++ b/tools/oss-fuzz-scanner/get_top_apis.py
@@ -1,0 +1,104 @@
+# Copyright 2023 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import json
+import cxxfilt
+import scanner
+
+
+def count_depth_from_fuzzer(line):
+    spaces_at_start = 0
+    for c in line:
+        if c == ' ':
+            spaces_at_start += 1
+        else:
+            break
+    return int(spaces_at_start / 2)
+
+
+def get_filename_from_line(line):
+    retval = line.split(" ")[-2]
+    if retval != '':
+        return retval
+    raise Exception(
+        "No file found, this could be because it's a system function or deps with no file info"
+    )
+
+
+def get_function_from_line(line):
+    retval = line.split(" ")[-3]
+    if retval != '':
+        return retval
+    raise Exception(
+        "No function found. This should not happen for real call lines, but may happen for metadata"
+    )
+
+
+def get_mappings_for_project(project_name):
+    scanner.download_project_introspector_artifacts(project_name, '.', -1)
+    results = []
+
+    # Scan for files downloaded
+    for datafile in os.listdir("."):
+        src_file = None
+        dst_files = []
+        dst_fnames = []
+        if datafile.endswith(".data"):
+            #print(datafile)
+            with open(datafile, "r") as f:
+                for line in f.read().split("\n"):
+                    # Skip end of file line
+                    if "============" in line:
+                        continue
+
+                    # get depth of call from fuzzer entry
+                    d = count_depth_from_fuzzer(line)
+
+                    # skip those above 1
+                    if d > 1:
+                        continue
+                    # Get the filename of the call
+                    try:
+                        filename = get_filename_from_line(line)
+                        fname = cxxfilt.demangle(get_function_from_line(line))
+                    except:
+                        continue
+
+                    if d == 0:
+                        # LLVMFuzzerTestOneInput
+                        src_file = filename
+                    else:
+                        dst_files.append(filename)
+                        dst_fnames.append(fname)
+
+            #print("Src: %s"%(src_file))
+            #print(dst_files)
+            #print(dst_fnames)
+            results.append({'fuzzer_src': src_file, 'dst_function_names': dst_fnames})
+
+    # Clean up the downloaded files
+    for f2 in os.listdir("."):
+        if f2.endswith(".yaml") or f2.endswith(".data") or f2.endswith(
+                ".covreport"):
+            os.remove(f2)
+    return results
+
+
+ALL_PROJECTS = ['htslib', 'tinyxml2', 'leveldb', 'c-ares']
+for project_name in ALL_PROJECTS:
+    print(project_name)
+    for fuzzer_result in get_mappings_for_project(project_name):
+        print(json.dumps(fuzzer_result))

--- a/tools/oss-fuzz-scanner/scanner.py
+++ b/tools/oss-fuzz-scanner/scanner.py
@@ -23,7 +23,8 @@ from typing import Optional, List
 import lxml.html
 from lxml import etree
 
-sys.path.insert(0, '../../src/')
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../../src/')
+
 from fuzz_introspector import analysis, exceptions
 
 CORRELATION_FILENAME = "exe_to_fuzz_introspector_logs.yaml"


### PR DESCRIPTION
Experimenting with extracting top-level APIs from fuzzers

To try:
```bash
# Install relevant fuzz introspector
git clone https://github.com/ossf/fuzz-introspector
cd fuzz-introspector
git checkout add-tpo-api
python3 -m virtualenv .venv
. .venv/bin/activate
python3 -m pip install -r ./requirements.txt

# Run the tool
cd tools/oss-fuzz-scanner
python3 ./get_top_apis.py 
htslib                                                                                               
{"fuzzer_src": "/src/htslib/test/fuzz/hts_open_fuzzer.c", "dst_function_names": ["hopen", "hts_hopen", "hclose", "view_sam", "view_vcf"]}
tinyxml2                                                                                             
{"fuzzer_src": "/src/xmltest.cpp", "dst_function_names": ["tinyxml2::XMLDocument::XMLDocument(bool, tinyxml2::Whitespace)", "tinyxml2::XMLDocument::Parse(char const*, unsigned long)", "tinyxml2::XMLDocum
ent::~XMLDocument()"]}                                                                               
leveldb                                                                                              
{"fuzzer_src": "/src/leveldb/build/../fuzz_db.cc", "dst_function_names": ["(anonymous namespace)::OpenDB()", "leveldb::WriteOptions::WriteOptions()", "leveldb::ReadOptions::ReadOptions()", "leveldb::Stat
us::~Status()", "leveldb::WriteOptions::WriteOptions()", "leveldb::Status::~Status()", "leveldb::ReadOptions::ReadOptions()", "(anonymous namespace)::OpenDB()", "leveldb::Slice::Slice(std::__1::basic_str
ing<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", "(anonymous namespace)::AutoDbDeleter::~AutoDbDeleter()"]}
c-ares                                                                                               
{"fuzzer_src": "/src/c-ares/test/ares-test-fuzz.c", "dst_function_names": ["ares_parse_a_reply", "ares_free_hostent", "ares_parse_aaaa_reply", "ares_free_hostent", "ares_parse_ptr_reply", "ares_free_host
ent", "ares_parse_ns_reply", "ares_free_hostent", "ares_parse_srv_reply", "ares_free_data", "ares_parse_mx_reply", "ares_free_data", "ares_parse_txt_reply", "ares_free_data", "ares_parse_soa_reply", "are
s_free_data", "ares_parse_naptr_reply", "ares_free_data", "ares_parse_caa_reply", "ares_free_data", "ares_parse_uri_reply", "ares_free_data"]}
{"fuzzer_src": "/src/c-ares/test/ares-test-fuzz-name.c", "dst_function_names": ["ares_create_query"]}
```