### PR TITLE
Auto-fuzz: Fix bug

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -420,7 +420,7 @@ def _search_static_factory_method(classname,
             arg_list.extend(
                 _handle_argument(argType.replace('$', '.'),
                                  None,
-                                 None,
+                                 possible_target,
                                  max_target, [],
                                  False,
                                  class_object=class_object))


### PR DESCRIPTION
The search factory method call the handle argument method with a wrong None object and cause NoneType error. This PR fixes that bug.