### PR TITLE
Fix dict type checking

### DIFF
--- a/src/fuzz_introspector/data_loader.py
+++ b/src/fuzz_introspector/data_loader.py
@@ -122,7 +122,7 @@ def load_input_bugs(bug_file: str) -> List[bug.Bug]:
     with open(bug_file, "r") as f:
         data = json.load(f)
 
-    if type(data) != dict:
+    if not isinstance(data, dict):
         return input_bugs
 
     if "bugs" not in data:


### PR DESCRIPTION
This PR changes the not preferred `type(data) != dict` checking to the preferred `not isinstance(data, dict)` checking.