### PR TITLE
Auto-fuzz: Fix gradle build and maven build

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -127,6 +127,7 @@ RUN unzip protoc.zip -d $SRC/protoc && rm ./protoc.zip
 ENV ANT $SRC/ant/apache-ant-1.10.13/bin/ant
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
+ENV GRADLE_OPTS="-Dfile.encoding=utf-8"
 ENV JAVA_HOME="$SRC/%s"
 ENV PATH="$JAVA_HOME/bin:$SRC/gradle/gradle-7.4.2/bin:$SRC/protoc/bin:$PATH"
 #RUN git clone --depth 1 %s %s
@@ -179,6 +180,8 @@ do
       mkdir -p ~/.m2
       echo "<toolchains><toolchain><type>jdk</type><provides><version>1.8</version></provides>" > ~/.m2/toolchains.xml
       echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
+      echo "<toolchain><type>jdk</type><provides><version>8</version></provides>" >> ~/.m2/toolchains.xml
+      echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
       echo "<toolchain><type>jdk</type><provides><version>11</version></provides>" >> ~/.m2/toolchains.xml
       echo "<configuration><jdkHome>\${env.JAVA_HOME}</jdkHome></configuration></toolchain>" >> ~/.m2/toolchains.xml
       echo "<toolchain><type>jdk</type><provides><version>14</version></provides>" >> ~/.m2/toolchains.xml
@@ -198,9 +201,9 @@ do
       chmod +x ./gradlew
       if ./gradlew tasks --all | grep -qw "^spotlessCheck"
       then
-        ./gradlew clean build -x test -x spotlessCheck
+        ./gradlew clean build -x test -x javadoc -x sources -x spotlessCheck
       else
-        ./gradlew clean build -x test
+        ./gradlew clean build -x test -x javadoc -x sources
       fi
       ./gradlew --stop
       SUCCESS=true

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -269,6 +269,8 @@ def _maven_build_project(basedir, projectdir, jdk_dir):
         file.write(
             """<toolchains><toolchain><type>jdk</type><provides><version>1.8</version></provides>
                     <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
+                    <toolchain><type>jdk</type><provides><version>8</version></provides>
+                    <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
                     <toolchain><type>jdk</type><provides><version>11</version></provides>
                     <configuration><jdkHome>${env.JAVA_HOME}</jdkHome></configuration></toolchain>
                     <toolchain><type>jdk</type><provides><version>14</version></provides>
@@ -340,6 +342,7 @@ def _gradle_build_project(basedir, projectdir, jdk_dir):
     env_var = os.environ.copy()
     env_var['GRADLE_HOME'] = os.path.join(basedir, constants.GRADLE_HOME)
     env_var['JAVA_HOME'] = os.path.join(basedir, jdk_dir)
+    env_var['GRADLE_OPTS'] = "-Dfile.encoding=utf-8"
     env_var['PATH'] = os.path.join(
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
@@ -349,9 +352,9 @@ def _gradle_build_project(basedir, projectdir, jdk_dir):
         "rm -rf $HOME/.gradle/caches/", "chmod +x ./gradlew",
         """if ./gradlew tasks --all | grep -qw "^spotlessCheck";
         then
-          ./gradlew clean build -x test -x spotlessCheck;
+          ./gradlew clean build -x test -x javadoc -x sources -x spotlessCheck;
         else
-          ./gradlew clean build -x test;
+          ./gradlew clean build -x test -x javadoc -x sources;
         fi""", "./gradlew --stop"
     ]
     try:


### PR DESCRIPTION
This PR fixes the following gradle and maven project build error.
1. Sources comment or javadoc using non-ASCII encoding and cause building errors.
2. Project that experiencing building error during javadoc and sources jar compiling and generation.
3. Maven project that requires JDK8 tools chain and specify it as java version 8 instead of 1.8.