### PR TITLE
Java-frontend: Fix filtering for auto-fuzz

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -245,21 +245,6 @@ class CustomSenceTransformer extends SceneTransformer {
         }
       }
     }
-    for (String include : includePrefix.split(":")) {
-      if (!include.equals("")) {
-        includeList.add(include);
-      }
-    }
-    includeList.add(entryClassStr);
-    for (String exclude : excludePrefix.split(":")) {
-      if (!exclude.equals("")) {
-        excludeList.add(exclude);
-      }
-    }
-
-    for (String exclude : excludeMethodStr.split(":")) {
-      excludeMethodList.add(exclude);
-    }
 
     if ((!sourceDirectory.equals("")) && (!sourceDirectory.equals("NULL"))) {
       try (Stream<Path> walk = Files.walk(Paths.get(sourceDirectory))) {
@@ -274,6 +259,25 @@ class CustomSenceTransformer extends SceneTransformer {
         // Fail to retrieve project class list, ignore the list.
         projectClassList = new LinkedList<String>();
       }
+    }
+
+    for (String include : includePrefix.split(":")) {
+      if (!include.equals("")) {
+        includeList.add(include);
+      }
+    }
+    includeList.add(entryClassStr);
+
+    if (projectClassList.size() == 0 ) {
+      for (String exclude : excludePrefix.split(":")) {
+        if (!exclude.equals("")) {
+          excludeList.add(exclude);
+        }
+      }
+    }
+
+    for (String exclude : excludeMethodStr.split(":")) {
+      excludeMethodList.add(exclude);
     }
 
     sinkMethodMap = new HashMap<String, Set<String>>();

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -268,7 +268,7 @@ class CustomSenceTransformer extends SceneTransformer {
     }
     includeList.add(entryClassStr);
 
-    if (projectClassList.size() == 0 ) {
+    if (projectClassList.size() == 0) {
       for (String exclude : excludePrefix.split(":")) {
         if (!exclude.equals("")) {
           excludeList.add(exclude);


### PR DESCRIPTION
This PR fixes the source code filtering of java-frontend for auto-fuzz. If source directory is specified, then the exclude prefix option will be ignored. This allows some projects with "JDK-like" package prefix to be included in the analysis if the source files do existed.