### PR TITLE
Fix empty class file list bug

### DIFF
--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -87,8 +87,9 @@ def find_fuzz_targets(path):
               os.rename(full_path, os.path.join(path, class_location))
             class_file_list.append(class_location)
 
-  # Create relevant .jar file for all loose class files
-  subprocess.check_call("jar cvf package.jar %s" %  " ".join(class_file_list), shell=True, cwd=path)
+  # Create relevant .jar file for all loose class files if there are any
+  if len(class_file_list) > 0:
+    subprocess.check_call("jar cvf package.jar %s" %  " ".join(class_file_list), shell=True, cwd=path)
 
   return targets
 

--- a/frontends/java/oss-fuzz-main.py
+++ b/frontends/java/oss-fuzz-main.py
@@ -73,6 +73,7 @@ def find_fuzz_targets(path):
       # If wrapper script exists, retrieve the java class with package name
       classname = content.split("--target_class=")[1].split(" ")[0]
       targets.append(classname)
+      print("Found fuzz-target %s" % classname)
 
       # If classfile exists, pack it to jar file
       for root, _, files in os.walk(path):


### PR DESCRIPTION
As mentioned in #1174, some projects do not have any loose class files to package because of different reasons. Thus passing an empty list of class files to the jar tools result in errors in shell execution. This PR fixes that by adding a conditional check to only run the jar tools when any loose class files are discovered. It will not affect the frontend execution as jar files packaged by the project itself would still be discovered in later code.