### PR TITLE
analyses: annotated cfg: include all 1st level funcs

### DIFF
--- a/src/fuzz_introspector/analyses/annotated_cfg.py
+++ b/src/fuzz_introspector/analyses/annotated_cfg.py
@@ -78,8 +78,6 @@ class FuzzAnnotatedCFG(analysis.AnalysisInterface):
                     if callsite.depth == 0:
                         src_file = dst_fd.function_source_file
                     else:
-                        if dst_fd.function_source_file == "":
-                            continue
                         destinations.append({
                             'function-name':
                             dst_fd.function_name,


### PR DESCRIPTION
It's nice to have all functions used, including `malloc`, `free` etc. where we don't have source files available. It's easy to filter after in case