### PR TITLE
webapp: extend with data about annotated cfg

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -357,7 +357,8 @@ def extract_project_data(project_name, date_str, should_include_details,
                 # are not such keys, so skip them.
                 if key == 'analyses':
                     if 'AnnotatedCFG' in introspector_report[key]:
-                        annotated_cfg = introspector_report['analyses']['AnnotatedCFG']
+                        annotated_cfg = introspector_report['analyses'][
+                            'AnnotatedCFG']
 
                 if key == "MergedProjectProfile" or key == 'analyses':
                     continue
@@ -697,7 +698,7 @@ def analyse_set_of_dates(dates, projects_to_analyse, output_directory):
 
         # Is this the last date to analyse?
         is_end = idx == len(dates)
-        print("Is end: %s"%(is_end))
+        print("Is end: %s" % (is_end))
 
         # Increment counter. Must happen after our is_end check.
         idx += 1

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -350,11 +350,16 @@ def extract_project_data(project_name, date_str, should_include_details,
 
         # Get all branch blockers
         branch_pairs = list()
+        annotated_cfg = dict()
         if should_include_details:
             for key in introspector_report:
                 # We look for dicts with fuzzer-specific content. The following two
                 # are not such keys, so skip them.
-                if key == "analyses" or key == "MergedProjectProfile":
+                if key == 'analyses':
+                    if 'AnnotatedCFG' in introspector_report[key]:
+                        annotated_cfg = introspector_report['analyses']['AnnotatedCFG']
+
+                if key == "MergedProjectProfile" or key == 'analyses':
                     continue
 
                 # Fuzzer-specific dictionary, get the contents of it.
@@ -385,6 +390,7 @@ def extract_project_data(project_name, date_str, should_include_details,
                         'blocked-runtime-coverage':
                         blocked_unique_not_covered_complexity
                     })
+
         introspector_data_dict = {
             "introspector_report_url": introspector_report_url,
             "coverage_lines":
@@ -396,6 +402,7 @@ def extract_project_data(project_name, date_str, should_include_details,
             "functions_covered_estimate": functions_covered_estimate,
             'refined_proj_list': refined_proj_list,
             'branch_pairs': branch_pairs,
+            'annotated_cfg': annotated_cfg,
         }
 
     # Extract data from the code coverage reports
@@ -687,12 +694,15 @@ def analyse_set_of_dates(dates, projects_to_analyse, output_directory):
         current_time = datetime.datetime.now().strftime("%H:%M:%S")
         logger.info("Analysing date %s -- [%d of %d] -- %s" %
                     (date, idx, dates_to_analyse, current_time))
-        idx += 1
-        # if idx > 5:
-        #     break
-        is_end = idx == len(dates)
 
-        # Check if it's not the last date and the data is in the cache
+        # Is this the last date to analyse?
+        is_end = idx == len(dates)
+        print("Is end: %s"%(is_end))
+
+        # Increment counter. Must happen after our is_end check.
+        idx += 1
+
+        # If it's not the last date and we have cached data, use the cache.
         if is_end == False and is_date_in_db(date, output_directory):
             logger.info("Date already analysed, skipping")
             continue

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -248,6 +248,33 @@ def indexing_overview():
 def about():
     return render_template('about.html', gtag=gtag)
 
+@blueprint.route('/api/annotated-cfg')
+def api_annotated_cfg():
+    project_name = request.args.get('project', None)
+    if project_name == None:
+        return {'result': 'error', 'msg': 'Please provide project name'}
+
+    target_project = None
+    all_projects = data_storage.get_projects()
+    for project in all_projects:
+        if project.name == project_name:
+            target_project = project
+            break
+    if target_project is None:
+        return {'result': 'error', 'msg': 'Project not in the database'}
+
+    try:
+        return {
+            'result': 'success',
+            'project': {
+                'name': project_name,
+                'annotated-cfg': project.introspector_data['annotated_cfg'],
+            }
+        }
+    except KeyError:
+        return {'result': 'error', 'msg': 'Found no annotated CFG data.'}
+    except TypeError:
+        return {'result': 'error', 'msg': 'Found no introspector data.'}
 
 @blueprint.route('/api/project-summary')
 def api_project_summary():

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -248,6 +248,7 @@ def indexing_overview():
 def about():
     return render_template('about.html', gtag=gtag)
 
+
 @blueprint.route('/api/annotated-cfg')
 def api_annotated_cfg():
     project_name = request.args.get('project', None)
@@ -275,6 +276,7 @@ def api_annotated_cfg():
         return {'result': 'error', 'msg': 'Found no annotated CFG data.'}
     except TypeError:
         return {'result': 'error', 'msg': 'Found no introspector data.'}
+
 
 @blueprint.route('/api/project-summary')
 def api_project_summary():


### PR DESCRIPTION
Will expose in the webapp the data added in:

- https://github.com/ossf/fuzz-introspector/pull/1170
- https://github.com/ossf/fuzz-introspector/pull/1177

The API will be `/api/annotated-cfg?project=XX`. It will take a few days however to be visible on introspector.oss-fuzz.com as we're waiting for the new introspector changes to be shown there.

Also fixes a bug in `is_end` calculation during DB creation. We were one day too late before.