### PR TITLE
core: output raw function names

### DIFF
--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -34,6 +34,7 @@ class FunctionProfile:
 
     def __init__(self, elem: Dict[Any, Any]) -> None:
         self.function_name = utils.demangle_cpp_func(elem['functionName'])
+        self.raw_function_name = elem['functionName']
         self.function_source_file = elem['functionSourceFile']
         self.linkage_type = elem['linkageType']
         self.function_linenumber = elem['functionLinenumber']

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -138,6 +138,7 @@ def create_all_function_table(
         json_copy['Args'] = str(fd.arg_types)
         json_copy['Reached by Fuzzers'] = fd.reached_by_fuzzers
         json_copy['return_type'] = fd.return_type
+        json_copy['raw-function-name'] = fd.raw_function_name
         table_rows_json_report.append(json_copy)
 
     logger.info("Assembled a total of %d entries" %


### PR DESCRIPTION
Keep the original function name as it is in the binary. This is needed for cases such as https://github.com/ossf/fuzz-introspector/issues/1165