### PR TITLE
Auto-fuzz: Add CharSequence parameters handling

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -340,9 +340,9 @@ def _handle_argument(argType,
         return ["data.consumeFloat()"]
     elif argType == "char" or argType == "java.lang.Character":
         return ["data.consumeCharNoSurrogates()"]
-    elif argType == "java.lang.String":
+    elif argType == "java.lang.String" or argType == "java.lang.CharSequence":
         return ["data.consumeString(100)"]
-    elif argType == "java.lang.String[]":
+    elif argType == "java.lang.String[]" or argType == "java.lang.CharSequence[]":
         return ["new java.lang.String[]{data.consumeString(100)}"]
 
     if argType == "java.io.File":


### PR DESCRIPTION
It is found that some projects have methods that take string like input parameters using the CharSequence interface (implements by String class) as argument types. This avoid the current auto-fuzz logic to generate correct parameters for these methods. This PR fixes it by extending the primitive parameter handling method to take care of CharSequence parameter type as String object.