### PR TITLE
Auto-fuzz: Fix filtering problem

### DIFF
--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -976,9 +976,9 @@ def _extract_method(yaml_dict,
                 method_list, static_method_list, max_count, calldepth_filter)
 
         # Still too many method after filtering, return the current result set
-        if len(static_method_list) > max_method or len(
-                method_list) > max_method:
-            return init_dict, method_list, instance_method_list, static_method_list, True
+        if not calldepth_filter:
+            if len(static_method_list) > max_method or len(method_list) > max_method:
+                return init_dict, method_list, instance_method_list, static_method_list, True
 
         # Skip method belongs to non public or non concrete class
         if not func_elem['JavaMethodInfo']['classPublic']:

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -977,7 +977,8 @@ def _extract_method(yaml_dict,
 
         # Still too many method after filtering, return the current result set
         if not calldepth_filter:
-            if len(static_method_list) > max_method or len(method_list) > max_method:
+            if len(static_method_list) > max_method or len(
+                    method_list) > max_method:
                 return init_dict, method_list, instance_method_list, static_method_list, True
 
         # Skip method belongs to non public or non concrete class

--- a/tools/auto-fuzz/fuzz_driver_generation_jvm.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_jvm.py
@@ -978,7 +978,7 @@ def _extract_method(yaml_dict,
         # Still too many method after filtering, return the current result set
         if len(static_method_list) > max_method or len(
                 method_list) > max_method:
-            return init_dict, method_list, instance_method_list, static_method_list
+            return init_dict, method_list, instance_method_list, static_method_list, True
 
         # Skip method belongs to non public or non concrete class
         if not func_elem['JavaMethodInfo']['classPublic']:
@@ -1037,7 +1037,7 @@ def _extract_method(yaml_dict,
                                                      max_count,
                                                      calldepth_filter)
 
-    return init_dict, method_list, instance_method_list, static_method_list
+    return init_dict, method_list, instance_method_list, static_method_list, False
 
 
 def _extract_super_exceptions(exceptions):
@@ -1957,6 +1957,16 @@ def _generate_heuristics(yaml_dict,
                                    max_count=20,
                                    calldepth_filter=calldepth_filter)
 
+    # Extract and remove the halting flag from the method_tuple result
+    method_extraction_halted = method_tuple[-1]
+    last = len(method_tuple) - 1
+    method_tuple = method_tuple[:last]
+
+    # Check if the method extraction is halted because it requires filteirng
+    if method_extraction_halted and not calldepth_filter:
+        return None, True
+
+    # Start generating possible targets with different heuristics
     possible_targets = []
     temp_targets = []
     _generate_heuristic_1(method_tuple, temp_targets, max_target)
@@ -1989,7 +1999,7 @@ def _generate_heuristics(yaml_dict,
     _generate_heuristic_11(method_tuple, temp_targets, max_target)
     possible_targets.extend(temp_targets)
 
-    return possible_targets
+    return possible_targets, False
 
 
 def generate_possible_targets(proj_folder, class_list, max_target,
@@ -2012,9 +2022,9 @@ def generate_possible_targets(proj_folder, class_list, max_target,
 
     max_fuzzer = constants.MAX_FUZZERS_PER_PROJECT
 
-    possible_targets = _generate_heuristics(yaml_dict, max_target, max_fuzzer,
-                                            False)
-    if len(possible_targets) > max_fuzzer:
-        possible_targets = _generate_heuristics(yaml_dict, max_target, True)
+    possible_targets, need_calldepth_filter = _generate_heuristics(
+        yaml_dict, max_target, max_fuzzer, False)
+    if need_calldepth_filter or len(possible_targets) > max_fuzzer:
+        possible_targets, _ = _generate_heuristics(yaml_dict, max_target, True)
 
     return possible_targets


### PR DESCRIPTION
The newly implement filtering logic for auto-fuzz in #1156 and #1161 add in more filtering to reduce the size of those method lists. But some of the logic actually avoid them to go deep into all the methods in the data.yaml file. This PR fixes some of the filtering logic to allow it to explore the full data.yaml list if possible.