### PR TITLE
Use debug info for func args

### DIFF
--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -1067,10 +1067,39 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
   FuncWrap.ReturnType = resolveTypeName(F->getReturnType());
 
   // Arguments
+  // errs() << "Function:\n";
+  // errs() << FuncWrap.FunctionName << "\n";
   for (auto &A : F->args()) {
     FuncWrap.ArgTypes.push_back(resolveTypeName(A.getType()));
-    FuncWrap.ArgNames.push_back(A.getName().str());
+    //FuncWrap.ArgNames.push_back(A.getName().str());
+    if (A.getName().str().empty()) {
+      const DILocalVariable* Var = NULL;
+      bool FoundArg = false;
+      for (auto &BB : *F) {
+        for (auto &I : BB) {
+          if (const DbgDeclareInst* DbgDeclare = dyn_cast<DbgDeclareInst>(&I)) {
+            if (auto DLV = dyn_cast<DILocalVariable>(DbgDeclare->getVariable())) {
+              if (  DLV->getArg() == A.getArgNo() + 1 &&
+                    !DLV->getName().empty() &&
+                     DLV->getScope()->getSubprogram() == F->getSubprogram()) {
+                //errs() << "--" << DLV->getName().str() << "\n";
+                FuncWrap.ArgNames.push_back(DLV->getName().str());
+                FoundArg = true;
+              }
+            }
+          }
+        }
+      }
+      if (FoundArg == false) {
+        FuncWrap.ArgNames.push_back("");
+      }
+    }
+    else {
+      // It's non empty, we just push that.
+      FuncWrap.ArgNames.push_back(A.getName().str());
+    }
   }
+
 
   // Log the amount of basic blocks, instruction count and cyclomatic
   // complexity of the function.

--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -1100,7 +1100,6 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
     }
   }
 
-
   // Log the amount of basic blocks, instruction count and cyclomatic
   // complexity of the function.
   FuncWrap.BBCount = 0;

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -136,6 +136,7 @@ def create_all_function_table(
         json_copy = row_element.copy()
         json_copy['Func name'] = demangled_func_name
         json_copy['Args'] = str(fd.arg_types)
+        json_copy['ArgNames'] = fd.arg_names
         json_copy['Reached by Fuzzers'] = fd.reached_by_fuzzers
         json_copy['return_type'] = fd.return_type
         json_copy['raw-function-name'] = fd.raw_function_name


### PR DESCRIPTION
The current way we extract function names from arguments in LLVM is
rarely successful. This is because the names attached to the LLVM
Argument objects are empty, likely removed during the compilation
process. This adds an option for looking at debug information to spot
the right argument name.

Ref: https://github.com/ossf/fuzz-introspector/issues/1175