### PR TITLE
Auto-fuzz: Fix gradle build toolchain discovery

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -350,12 +350,17 @@ def _gradle_build_project(basedir, projectdir, jdk_dir):
     # Build project with gradle wrapper of the project
     cmd = [
         "rm -rf $HOME/.gradle/caches/", "chmod +x ./gradlew",
-        """if ./gradlew tasks --all | grep -qw "^spotlessCheck";
+        "EXCLUDE_SPOTLESS_CHECK=",
+        """if ./gradlew tasks --all | grep -qw "^spotlessCheck"
         then
-          ./gradlew clean build -x test -x javadoc -x sources -x spotlessCheck;
-        else
-          ./gradlew clean build -x test -x javadoc -x sources;
-        fi""", "./gradlew --stop"
+          EXCLUDE_SPOTLESS_CHECK="-x spotlessCheck "
+        fi
+        ./gradlew clean build -x test -x javadoc -x sources \
+        $EXCLUDE_SPOTLESS_CHECK\
+        -Porg.gradle.java.installations.auto-detect=false \
+        -Porg.gradle.java.installations.auto-download=false \
+        -Porg.gradle.java.installations.paths=$JAVA_HOME""",
+        "./gradlew --stop"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -359,8 +359,7 @@ def _gradle_build_project(basedir, projectdir, jdk_dir):
         $EXCLUDE_SPOTLESS_CHECK\
         -Porg.gradle.java.installations.auto-detect=false \
         -Porg.gradle.java.installations.auto-download=false \
-        -Porg.gradle.java.installations.paths=$JAVA_HOME""",
-        "./gradlew --stop"
+        -Porg.gradle.java.installations.paths=$JAVA_HOME""", "./gradlew --stop"
     ]
     try:
         subprocess.check_call(" && ".join(cmd),


### PR DESCRIPTION
By default, gradle will discover toolchain path automatically, this may affect the correct jdk version detecting logic in auto-fuzz because gradle may detect the wrong version of JDK. This PR fixes the gradle build parameter by disabling the auto toolchain discovery of the gradle build and manually providing the JDK path to the gradle build system to avoid wrong java version detected.