### PR TITLE
doc: installation doc fixes

### DIFF
--- a/doc/LocalBuild.md
+++ b/doc/LocalBuild.md
@@ -65,6 +65,7 @@ cd ../
 # Build LLVM and Clang
 git clone https://github.com/llvm/llvm-project/
 cd llvm-project/
+git checkout release/15.x
 
 # Patch Clang to run fuzz introspector
 ../../frontends/llvm/patch-llvm.sh

--- a/doc/LocalBuild.md
+++ b/doc/LocalBuild.md
@@ -77,6 +77,7 @@ cd ../
 mkdir llvm-build
 cd llvm-build
 cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS="clang;compiler-rt"  \
+      -DCMAKE_BUILD_TYPE=Debug \
       -DLLVM_BINUTILS_INCDIR=../binutils/include \
       -DLLVM_TARGETS_TO_BUILD="X86" ../llvm-project/llvm/
 make llvm-headers

--- a/doc/sphinx/source/installation-instructions/installation.rst
+++ b/doc/sphinx/source/installation-instructions/installation.rst
@@ -61,6 +61,7 @@ do to this:
     mkdir llvm-build
     cd llvm-build
     cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS="clang;compiler-rt"  \
+          -DCMAKE_BUILD_TYPE=Debug \
           -DLLVM_BINUTILS_INCDIR=../binutils/include \
           -DLLVM_TARGETS_TO_BUILD="X86" ../llvm-project/llvm/
     make llvm-headers

--- a/doc/sphinx/source/installation-instructions/installation.rst
+++ b/doc/sphinx/source/installation-instructions/installation.rst
@@ -47,6 +47,7 @@ do to this:
     # Build LLVM and Clang
     git clone https://github.com/llvm/llvm-project/
     cd llvm-project/
+    git checkout release/15.x
 
     # Patch Clang to run fuzz introspector
     ../../frontends/llvm/patch-llvm.sh

--- a/doc/sphinx/source/installation-instructions/installation.rst
+++ b/doc/sphinx/source/installation-instructions/installation.rst
@@ -49,7 +49,7 @@ do to this:
     cd llvm-project/
 
     # Patch Clang to run fuzz introspector
-    ../../frontends/llvm/patch_llvm.sh
+    ../../frontends/llvm/patch-llvm.sh
     cp -rf ../../frontends/llvm/include/llvm/Transforms/FuzzIntrospector/ \
            ./llvm/include/llvm/Transforms/FuzzIntrospector
     cp -rf ../../frontends/llvm/lib/Transforms/FuzzIntrospector \


### PR DESCRIPTION
Minor changes after running into issues following the installation instructions here: https://fuzz-introspector.readthedocs.io/en/latest/installation-instructions/installation.html. Using the main branch of LLVM doesn't work, as much has changed, and the patches don't apply. Given OSS-Fuzz uses the LLVM 15 branch, it seemed reasonable to pin to that (can also drop to 14). LLVM 15 requires a `DCMAKE_BUILD_TYPE` to be specificed when configuring, given that 14 defaulted to `Debug` if unset, I've used that here. Also fix the name of the patch-file.