### PR TITLE
Java-frontend: Fix entry method discovery

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -52,8 +52,6 @@ import soot.SceneTransformer;
 import soot.SootClass;
 import soot.SootField;
 import soot.SootMethod;
-import soot.tagkit.AnnotationTag;
-import soot.tagkit.VisibilityAnnotationTag;
 import soot.Transform;
 import soot.Unit;
 import soot.Value;
@@ -72,6 +70,8 @@ import soot.jimple.toolkits.annotation.logic.LoopFinder;
 import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.jimple.toolkits.callgraph.Edge;
 import soot.options.Options;
+import soot.tagkit.AnnotationTag;
+import soot.tagkit.VisibilityAnnotationTag;
 import soot.toolkits.graph.Block;
 import soot.toolkits.graph.BlockGraph;
 import soot.toolkits.graph.BriefBlockGraph;
@@ -156,7 +156,8 @@ public class CallGraphGenerator {
       outer:
       for (SootMethod method : c.getMethods()) {
         if (method.hasTag("VisibilityAnnotationTag")) {
-          VisibilityAnnotationTag tag = (VisibilityAnnotationTag) method.getTag("VisibilityAnnotationTag");
+          VisibilityAnnotationTag tag =
+              (VisibilityAnnotationTag) method.getTag("VisibilityAnnotationTag");
           for (AnnotationTag annotation : tag.getAnnotations()) {
             if (annotation.getType().equals("Lcom/code_intelligence/jazzer/junit/FuzzTest;")) {
               entryPoint = method;
@@ -168,7 +169,12 @@ public class CallGraphGenerator {
     }
 
     if (entryPoint == null) {
-      System.out.println("Cannot find method: " + entryMethod + " or methods with @FuzzTest annotation from class: " + entryClass + ".");
+      System.out.println(
+          "Cannot find method: "
+              + entryMethod
+              + " or methods with @FuzzTest annotation from class: "
+              + entryClass
+              + ".");
       return;
     }
     custom.setEntryMethodStr(entryPoint.getName());

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/CallGraphGenerator.java
@@ -52,6 +52,8 @@ import soot.SceneTransformer;
 import soot.SootClass;
 import soot.SootField;
 import soot.SootMethod;
+import soot.tagkit.AnnotationTag;
+import soot.tagkit.VisibilityAnnotationTag;
 import soot.Transform;
 import soot.Unit;
 import soot.Value;
@@ -119,7 +121,6 @@ public class CallGraphGenerator {
             sinkMethod,
             sourceDirectory,
             isAutoFuzz);
-    PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
 
     // Set basic settings for the call graph generation
     Options.v().set_process_dir(jarFiles);
@@ -147,13 +148,31 @@ public class CallGraphGenerator {
     c.setApplicationClass();
 
     // Load and set custom entry point
-    SootMethod entryPoint;
+    SootMethod entryPoint = null;
     try {
       entryPoint = c.getMethodByName(entryMethod);
     } catch (RuntimeException e) {
-      System.out.println("Cannot find method: " + entryMethod + "from class: " + entryClass + ".");
+      // Default entry method not found. Try retrieve entry method by annotation.
+      outer:
+      for (SootMethod method : c.getMethods()) {
+        if (method.hasTag("VisibilityAnnotationTag")) {
+          VisibilityAnnotationTag tag = (VisibilityAnnotationTag) method.getTag("VisibilityAnnotationTag");
+          for (AnnotationTag annotation : tag.getAnnotations()) {
+            if (annotation.getType().equals("Lcom/code_intelligence/jazzer/junit/FuzzTest;")) {
+              entryPoint = method;
+              break outer;
+            }
+          }
+        }
+      }
+    }
+
+    if (entryPoint == null) {
+      System.out.println("Cannot find method: " + entryMethod + " or methods with @FuzzTest annotation from class: " + entryClass + ".");
       return;
     }
+    custom.setEntryMethodStr(entryPoint.getName());
+
     List<SootMethod> entryPoints = new LinkedList<SootMethod>();
     entryPoints.add(entryPoint);
     Scene.v().setEntryPoints(entryPoints);
@@ -164,6 +183,7 @@ public class CallGraphGenerator {
 
     try {
       // Start the generation
+      PackManager.v().getPack("wjtp").add(new Transform("wjtp.custom", custom));
       PackManager.v().runPacks();
     } catch (RuntimeException e) {
       if (!custom.isAnalyseFinished()) {
@@ -1176,5 +1196,9 @@ class CustomSenceTransformer extends SceneTransformer {
 
   public Boolean isAnalyseFinished() {
     return this.analyseFinished;
+  }
+
+  public void setEntryMethodStr(String entryMethodStr) {
+    this.entryMethodStr = entryMethodStr;
   }
 }


### PR DESCRIPTION
It is discovered that Jazzer allows using custom methods with FuzzTest annotation to indicate the method to be fuzzed in addition to the default fuzzerTestOneInput method. The current JVM frontend logic fails to discover these custom methods and causes some projects using the annotation approach to fail to generate fuzzer profile for fuzz-introspector build. This PR fixes the frontend to add in annotation scanning to look for possible fuzzing methods if fuzzerTestOneInput is not found in the fuzzer class.
Example project: https://github.com/google/oss-fuzz/tree/master/projects/apache-cxf