### PR TITLE
utils: enable c-based loading of yaml files

### DIFF
--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -84,9 +84,9 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         return None
 
     try:
-        yaml.SafeLoader = yaml.CSafeLoader
+        yaml.SafeLoader = yaml.CSafeLoader  # type: ignore[assignment]
         logger.info("Set base loader to use CSafeLoader")
-    except:
+    except Exception:
         logger.info("Could not set CSafeLoader as base loader")
 
     try:

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -84,7 +84,7 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         return None
 
     try:
-        yaml.SafeLoader = yaml.CSafeLoader  # type: ignore[assignment]
+        yaml.SafeLoader = yaml.CSafeLoader  # type: ignore[assignment, misc]
         logger.info("Set base loader to use CSafeLoader")
     except Exception:
         logger.info("Could not set CSafeLoader as base loader")

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -84,8 +84,15 @@ def data_file_read_yaml(filename: str) -> Optional[Dict[Any, Any]]:
         return None
 
     try:
+        yaml.SafeLoader = yaml.CSafeLoader
+        logger.info("Set base loader to use CSafeLoader")
+    except:
+        logger.info("Could not set CSafeLoader as base loader")
+
+    try:
         with open(filename, 'r') as stream:
             data_dict: Dict[Any, Any] = yaml.safe_load(stream)
+            logger.info("Loaded single yaml module")
             return data_dict
     except Exception:
         # YAML library does not completely wrap exceptions, so unless


### PR DESCRIPTION
This has significant impact on speeding up `.yaml` loading. The `.yaml` files are often quite large and a bottleneck when running analyses.

In my experiment it takes e.g. the `htslib` `.yaml` file loading time down to ~2 seconds from ~2 minutes.

Requires the `libyaml-dev` package is installed