### PR TITLE
project-profile: add an additional fd cache

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -438,14 +438,13 @@ def overlay_calltree_with_coverage(
             if n2.cov_hitcount != 0:
                 break
 
-            for fd_k, fd in proj_profile.all_functions.items():
-                if (utils.demangle_cpp_func(
-                        fd.function_name) == n2.dst_function_name
-                        and fd.total_cyclomatic_complexity >
-                        largest_blocked_count):
+            try:
+                fd = proj_profile.dst_to_fd_cache[n2.dst_function_name]
+                if fd.total_cyclomatic_complexity > largest_blocked_count:
                     largest_blocked_count = fd.total_cyclomatic_complexity
                     largest_blocked_name = n2.dst_function_name
-                    break
+            except KeyError:
+                pass
 
             forward_red += 1
             idx2 += 1

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -487,4 +487,5 @@ class MergedProjectProfile:
 
     def _set_fd_cache(self):
         for fd_k, fd in self.all_functions.items():
-            self.dst_to_fd_cache[utils.demangle_cpp_func(fd.function_name)] = fd
+            self.dst_to_fd_cache[utils.demangle_cpp_func(
+                fd.function_name)] = fd

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -45,6 +45,8 @@ class MergedProjectProfile:
         self.unreached_functions = set()
         self.functions_reached = set()
         self.coverage_url = "#"
+        self.dst_to_fd_cache: Dict[str,
+                                   function_profile.FunctionProfile] = dict()
 
         logger.info(
             f"Creating merged profile of {len(self.profiles)} profiles")
@@ -151,6 +153,7 @@ class MergedProjectProfile:
             # TODO (navidem): will need to merge branch coverages (branch_cov_map) if we need to
             # identify blockers based on all fuzz targets coverage
         self._set_basefolder()
+        self._set_fd_cache()
         logger.info("Completed creationg of merged profile")
 
     def get_all_runtime_covered_functions(self) -> List[str]:
@@ -481,3 +484,7 @@ class MergedProjectProfile:
         except Exception:
             hit_percentage = 0.0
         return hit_percentage
+
+    def _set_fd_cache(self):
+        for fd_k, fd in self.all_functions.items():
+            self.dst_to_fd_cache[utils.demangle_cpp_func(fd.function_name)] = fd


### PR DESCRIPTION
`for fd_k, fd in proj_profile.all_functions.items():` is expensive. This PR removes it from a loop when overlaying callgraph with coverage data.