### PR TITLE
Auto-fuzz: Fix jvm path bug

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -229,6 +229,7 @@ def _ant_build_project(basedir, projectdir, jdk_dir):
     env_var = os.environ.copy()
     env_var['JAVA_HOME'] = os.path.join(basedir, jdk_dir)
     env_var['PATH'] = os.path.join(
+        basedir, jdk_dir, "bin") + ":" + os.path.join(
         basedir, constants.ANT_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
@@ -260,6 +261,7 @@ def _maven_build_project(basedir, projectdir, jdk_dir):
     env_var = os.environ.copy()
     env_var['JAVA_HOME'] = os.path.join(basedir, jdk_dir)
     env_var['PATH'] = os.path.join(
+        basedir, jdk_dir, "bin") + ":" + os.path.join(
         basedir, constants.MAVEN_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
@@ -344,6 +346,7 @@ def _gradle_build_project(basedir, projectdir, jdk_dir):
     env_var['JAVA_HOME'] = os.path.join(basedir, jdk_dir)
     env_var['GRADLE_OPTS'] = "-Dfile.encoding=utf-8"
     env_var['PATH'] = os.path.join(
+        basedir, jdk_dir, "bin") + ":" + os.path.join(
         basedir, constants.GRADLE_PATH) + ":" + os.path.join(
             basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -230,8 +230,8 @@ def _ant_build_project(basedir, projectdir, jdk_dir):
     env_var['JAVA_HOME'] = os.path.join(basedir, jdk_dir)
     env_var['PATH'] = os.path.join(
         basedir, jdk_dir, "bin") + ":" + os.path.join(
-        basedir, constants.ANT_PATH) + ":" + os.path.join(
-            basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+            basedir, constants.ANT_PATH) + ":" + os.path.join(
+                basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with ant
     cmd = "chmod +x %s/ant && ant" % os.path.join(basedir, constants.ANT_PATH)
@@ -262,8 +262,8 @@ def _maven_build_project(basedir, projectdir, jdk_dir):
     env_var['JAVA_HOME'] = os.path.join(basedir, jdk_dir)
     env_var['PATH'] = os.path.join(
         basedir, jdk_dir, "bin") + ":" + os.path.join(
-        basedir, constants.MAVEN_PATH) + ":" + os.path.join(
-            basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+            basedir, constants.MAVEN_PATH) + ":" + os.path.join(
+                basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Prepare maven toolchains location
     with open(os.path.join(os.path.expanduser('~'), ".m2", "toolchains.xml"),
@@ -347,8 +347,8 @@ def _gradle_build_project(basedir, projectdir, jdk_dir):
     env_var['GRADLE_OPTS'] = "-Dfile.encoding=utf-8"
     env_var['PATH'] = os.path.join(
         basedir, jdk_dir, "bin") + ":" + os.path.join(
-        basedir, constants.GRADLE_PATH) + ":" + os.path.join(
-            basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
+            basedir, constants.GRADLE_PATH) + ":" + os.path.join(
+                basedir, constants.PROTOC_PATH) + ":" + env_var['PATH']
 
     # Build project with gradle wrapper of the project
     cmd = [


### PR DESCRIPTION
In #1160, self-contained JDK support for Auto-fuzz has been added. But there is a bug in path variable definition which makes Auto-fuzz manager use the default JDK in the running environment rather than the chosen OpenJDK retrieved during runtime. This PR fixes that setting bugs to make Auto-fuzz self-contained and support different JDK versions.