### PR TITLE
JVM: Fix constructor display for jvm project

### DIFF
--- a/src/fuzz_introspector/analyses/calltree_analysis.py
+++ b/src/fuzz_introspector/analyses/calltree_analysis.py
@@ -15,6 +15,7 @@
 
 import os
 import logging
+import html
 import json
 import random
 import string
@@ -75,7 +76,7 @@ class FuzzCalltreeAnalysis(analysis.AnalysisInterface):
         data-paddingleft="{indentation}" style="padding-left: {indentation}">
             <span class="node-depth-wrapper">{node.depth}</span>
             <code class="language-clike">
-                {demangled_name}
+                {html.escape(demangled_name)}
             </code>
             <span class="coverage-line-filename">
                 {func_href}


### PR DESCRIPTION
The current logic fails to display the name of the constructor for jvm project because the method name returned by Soot is <init> or <cinit> for class constructors and browsers treat it as a general html tag. This PR adds additional logic to encode the < and > character to its entity name &lt; and &gt;  for correct display in the html.