### PR TITLE
webapp: handle cases where language is not in dict

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -52,7 +52,10 @@ def get_frontpage_summary_stats():
         'swift': 0
     }
     for project in all_projects:
-        language_count[project.language] += 1
+        try:
+            language_count[project.language] += 1
+        except KeyError:
+            continue
 
     # wrap it in a DBSummary
     db_summary = models.DBSummary(all_projects, total_number_of_projects,


### PR DESCRIPTION
This happened today since a project was removed from OSS-Fuzz. The result was that the language of the project was lost, but we still had data on the project. In this case we will avoid these projects.