### PR TITLE
webapp: adjust DB creator to most recent date

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -878,7 +878,7 @@ def create_db(max_projects, days_to_analyse, output_directory, input_directory,
         today = datetime.date.today()
         delta = today - start_date
         days_to_analyse = delta.days - 1
-        day_offset = 1
+        day_offset = 0
 
     date_range = create_date_range(day_offset, days_to_analyse)
     print(date_range)


### PR DESCRIPTION
Ref: https://github.com/google/oss-fuzz/issues/10970

We're likely still 1 day behind "today" when looking on the webapp at introspector.oss-fuzz.com. I'd like to keep it this way since we need to guarantee the DB collector runs at a point where all the coverage/introspector runs on OSS-Fuzz are done for the day and for some of the projects the runtime for that is many hours.