### PR TITLE
Auto-fuzz: Fix Inconsistence language naming and fix project discovery logic.

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -32,8 +32,8 @@ def gen_dockerfile(github_url,
         return _gen_dockerfile_python(github_url, project_name, template_dir)
     elif language == "java":
         return _gen_dockerfile_java(github_url, project_name, jdk_version,
-                                   build_project, template_dir,
-                                   project_build_type)
+                                    build_project, template_dir,
+                                    project_build_type)
     else:
         return ""
 
@@ -91,7 +91,7 @@ def _gen_dockerfile_python(github_url, project_name, template_dir):
 
 
 def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
-                        template_dir, project_build_type):
+                         template_dir, project_build_type):
     if build_project:
         comment = "#"
     else:

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -30,8 +30,8 @@ def gen_dockerfile(github_url,
 
     if language == "python":
         return _gen_dockerfile_python(github_url, project_name, template_dir)
-    elif language == "jvm":
-        return _gen_dockerfile_jvm(github_url, project_name, jdk_version,
+    elif language == "java":
+        return _gen_dockerfile_java(github_url, project_name, jdk_version,
                                    build_project, template_dir,
                                    project_build_type)
     else:
@@ -48,8 +48,8 @@ def gen_builder_1(language="python",
 
     if language == "python":
         return _gen_builder_1_python(template_dir)
-    elif language == "jvm":
-        return _gen_builder_1_jvm(template_dir, build_project)
+    elif language == "java":
+        return _gen_builder_1_java(template_dir, build_project)
     else:
         return ""
 
@@ -64,8 +64,8 @@ def gen_base_fuzzer(language="python",
 
     if language == "python":
         return _gen_base_fuzzer_python(template_dir)
-    elif language == "jvm":
-        return _gen_base_fuzzer_jvm(template_dir, need_base_import)
+    elif language == "java":
+        return _gen_base_fuzzer_java(template_dir, need_base_import)
     else:
         return ""
 
@@ -90,7 +90,7 @@ def _gen_dockerfile_python(github_url, project_name, template_dir):
     return BASE_DOCKERFILE
 
 
-def _gen_dockerfile_jvm(github_url, project_name, jdk_version, build_project,
+def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
                         template_dir, project_build_type):
     if build_project:
         comment = "#"
@@ -120,7 +120,7 @@ def _gen_builder_1_python(template_dir):
     return BASE_BUILDER
 
 
-def _gen_builder_1_jvm(template_dir, build_project):
+def _gen_builder_1_java(template_dir, build_project):
     with open(os.path.join(template_dir, "build.sh-template"), "r") as file:
         BASE_BUILDER = "#!/bin/bash -eu\n" + file.read()
 
@@ -137,7 +137,7 @@ def _gen_base_fuzzer_python(template_dir):
     return BASE_FUZZER
 
 
-def _gen_base_fuzzer_jvm(template_dir, need_base_import):
+def _gen_base_fuzzer_java(template_dir, need_base_import):
     BASE_IMPORT = """import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.apache.commons.lang3.ArrayUtils;"""
 

--- a/tools/auto-fuzz/fuzz_driver_generation_java.py
+++ b/tools/auto-fuzz/fuzz_driver_generation_java.py
@@ -64,7 +64,7 @@ class FuzzTarget:
             self.fuzzer_init_source_code = orig.fuzzer_init_source_code
             self.fuzzer_tear_down_source_code = orig.fuzzer_tear_down_source_code
         elif func_elem:
-            # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
+            # Method name in .data.yaml for java: [className].methodName(methodParameterList)
             self.function_name = func_elem['functionName'].split(
                 '].')[1].split('(')[0]
             self.function_target = get_target_method_statement(func_elem)
@@ -435,7 +435,7 @@ def _search_static_factory_method(classname,
         possible_target.imports_to_add.update(_handle_import(func_elem))
 
         # Remove [] character and argument list from function name
-        # Method name in .data.yaml for jvm: [className].methodName(methodParameterList)
+        # Method name in .data.yaml for java: [className].methodName(methodParameterList)
         call = func_elem['functionName'].split('(')[0]
         call = call.replace('[', '').replace(']', '')
 
@@ -1073,7 +1073,7 @@ def _generate_heuristic_1(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-1"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-1"
 
     _, _, _, static_method_list = method_tuple
 
@@ -1139,7 +1139,7 @@ def _generate_heuristic_2(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-2"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-2"
 
     init_dict, method_list, _, _ = method_tuple
 
@@ -1221,7 +1221,7 @@ def _generate_heuristic_3(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-3"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-3"
 
     init_dict, method_list, _, static_method_list = method_tuple
     for func_elem in method_list:
@@ -1297,7 +1297,7 @@ def _generate_heuristic_4(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-4"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-4"
 
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
     for func_elem in method_list:
@@ -1370,7 +1370,7 @@ def _generate_heuristic_6(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-6"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-6"
 
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
     for func_elem in method_list:
@@ -1458,7 +1458,7 @@ def _generate_heuristic_7(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-7"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-7"
 
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
     for func_elem in method_list + static_method_list:
@@ -1577,7 +1577,7 @@ def _generate_heuristic_8(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-8"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-8"
 
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
     for func_elem in method_list:
@@ -1667,7 +1667,7 @@ def _generate_heuristic_9(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-9"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-9"
 
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
     for func_elem in method_list:
@@ -1759,7 +1759,7 @@ def _generate_heuristic_10(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-10"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-10"
 
     global need_param_combination
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
@@ -1875,7 +1875,7 @@ def _generate_heuristic_11(method_tuple, possible_targets, max_target):
     Will also add proper exception handling based on the exception list
     provided by the frontend code.
     """
-    HEURISTIC_NAME = "jvm-autofuzz-heuristics-11"
+    HEURISTIC_NAME = "java-autofuzz-heuristics-11"
 
     init_dict, method_list, instance_method_list, static_method_list = method_tuple
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -38,7 +38,7 @@ from fuzz_introspector import commands
 import base_files
 import oss_fuzz_manager
 import fuzz_driver_generation_python
-import fuzz_driver_generation_jvm
+import fuzz_driver_generation_java
 import post_process
 import utils
 from oss_fuzz_project import OSS_FUZZ_PROJECT
@@ -54,7 +54,7 @@ FUZZ_INTRO_BASE = basedir + "/../../"
 OSS_FUZZ_BASE = basedir + "/../../../oss-fuzz"
 FUZZ_INTRO_MAIN = {
     "python": os.path.join(FUZZ_INTRO_BASE, "frontends", "python", "main.py"),
-    "jvm": os.path.join(FUZZ_INTRO_BASE, "frontends", "java", "run.sh")
+    "java": os.path.join(FUZZ_INTRO_BASE, "frontends", "java", "run.sh")
 }
 
 if not os.path.isdir(FUZZ_INTRO_BASE):
@@ -63,7 +63,7 @@ if not os.path.isdir(FUZZ_INTRO_BASE):
 if not os.path.isfile(FUZZ_INTRO_MAIN["python"]):
     raise Exception("Could not find fuzz introspector runner for python")
 
-if not os.path.isfile(FUZZ_INTRO_MAIN["jvm"]):
+if not os.path.isfile(FUZZ_INTRO_MAIN["java"]):
     raise Exception("Could not find fuzz introspector runner for java")
 
 if not os.path.isdir(OSS_FUZZ_BASE):
@@ -103,7 +103,7 @@ def run_static_analysis_python(git_repo, oss_fuzz_base_project,
     return ret
 
 
-def build_jvm_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
+def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                       project_type):
     basedir = oss_fuzz_base_project.project_folder
     build_ret = False
@@ -114,7 +114,7 @@ def build_jvm_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
         # Order JDK15 (oss-fuzz default) -> JDK17 -> JDK11 -> JDK8
         for jdk in constants.JDK_HOME:
             jdk_dir = constants.JDK_HOME[jdk]
-            oss_fuzz_base_project.change_jvm_dockerfile(jdk, project_type)
+            oss_fuzz_base_project.change_java_dockerfile(jdk, project_type)
 
             build_ret = oss_fuzz_manager.copy_and_build_project(
                 basedir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
@@ -145,7 +145,7 @@ def build_jvm_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
     return (build_ret, jarfiles, jdk_base)
 
 
-def run_static_analysis_jvm(git_repo, oss_fuzz_base_project,
+def run_static_analysis_java(git_repo, oss_fuzz_base_project,
                             base_oss_fuzz_project_dir, project_type):
     basedir = oss_fuzz_base_project.project_folder
     project_name = oss_fuzz_base_project.project_name
@@ -153,7 +153,7 @@ def run_static_analysis_jvm(git_repo, oss_fuzz_base_project,
     possible_imports = set()
     curr_dir = os.getcwd()
 
-    build_ret, jarfiles, jdk_base = build_jvm_project(
+    build_ret, jarfiles, jdk_base = build_java_project(
         oss_fuzz_base_project, base_oss_fuzz_project_dir, project_type)
 
     if not build_ret:
@@ -180,7 +180,7 @@ def run_static_analysis_jvm(git_repo, oss_fuzz_base_project,
                               env=env_var,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.DEVNULL,
-                              cwd=os.path.dirname(FUZZ_INTRO_MAIN["jvm"]))
+                              cwd=os.path.dirname(FUZZ_INTRO_MAIN["java"]))
     except subprocess.TimeoutExpired:
         print("Fail to execute java frontend code.\n")
         return False, None
@@ -191,9 +191,9 @@ def run_static_analysis_jvm(git_repo, oss_fuzz_base_project,
     # Move data and data.yaml to working directory
     if not os.path.exists(os.path.join(basedir, "work")):
         os.mkdir(os.path.join(basedir, "work"))
-    data_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
+    data_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["java"]),
                             "fuzzerLogFile-Fuzz.data")
-    yaml_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["jvm"]),
+    yaml_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["java"]),
                             "fuzzerLogFile-Fuzz.data.yaml")
     data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data")
     yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data.yaml")
@@ -249,7 +249,7 @@ def build_and_test_single_possible_target(idx_folder,
     # Copy files from base OSS-Fuzz project
     utils.copy_core_oss_fuzz_project_files(oss_fuzz_base_project,
                                            dst_oss_fuzz_project)
-    if language == "jvm":
+    if language == "java":
         ant_path = os.path.join(oss_fuzz_base_project.project_folder,
                                 "ant.zip")
         ant_dst = os.path.join(dst_oss_fuzz_project.project_folder, "ant.zip")
@@ -328,9 +328,9 @@ def build_and_test_single_possible_target(idx_folder,
               "w") as summary_file:
         json.dump(summary, summary_file)
 
-    if language == "jvm":
+    if language == "java":
         # Change build.sh and Dockerfile back to normal
-        dst_oss_fuzz_project.change_jvm_dockerfile(jdk, project_build_type)
+        dst_oss_fuzz_project.change_java_dockerfile(jdk, project_build_type)
         dst_oss_fuzz_project.change_build_script(project_build_type)
 
     # Cleanup oss-fuzz artifacts
@@ -472,12 +472,12 @@ def autofuzz_project_from_github(github_url,
                              oss_fuzz_base_project.project_name)):
             return False
 
-    # If this is a jvm target download ant, maven and gradle once so we don't
+    # If this is a java target download ant, maven and gradle once so we don't
     # have to do it for each proejct. Also extract a class_list for java classes
     # in the repository before building the project. This class_list is used for
     # target method filtering in the target generation stage. Some project requires
     # protoc to generate java code, so protoc is also downloaded here.
-    if language == "jvm":
+    if language == "java":
         # Download OpenJDK:
         target_jdk_path = os.path.join(oss_fuzz_base_project.project_folder,
                                        "jdk15.tar.gz")
@@ -549,8 +549,8 @@ def autofuzz_project_from_github(github_url,
             static_res = run_static_analysis_python(github_url,
                                                     oss_fuzz_base_project,
                                                     base_oss_fuzz_project_dir)
-        elif language == "jvm":
-            static_res, jdk_base = run_static_analysis_jvm(
+        elif language == "java":
+            static_res, jdk_base = run_static_analysis_java(
                 github_url, oss_fuzz_base_project, base_oss_fuzz_project_dir,
                 project_build_type)
 
@@ -558,7 +558,7 @@ def autofuzz_project_from_github(github_url,
             # and avoid rebuild of project
             for key in constants.JDK_HOME:
                 if constants.JDK_HOME[key] == jdk_base:
-                    oss_fuzz_base_project.change_jvm_dockerfile(
+                    oss_fuzz_base_project.change_java_dockerfile(
                         key, project_build_type, False)
                     jdk = key
                     break
@@ -603,8 +603,8 @@ def autofuzz_project_from_github(github_url,
             if language == "python":
                 possible_targets = fuzz_driver_generation_python.generate_possible_targets(
                     oss_fuzz_base_project.project_folder)
-            elif language == "jvm":
-                possible_targets = fuzz_driver_generation_jvm.generate_possible_targets(
+            elif language == "java":
+                possible_targets = fuzz_driver_generation_java.generate_possible_targets(
                     oss_fuzz_base_project.project_folder, java_class_list,
                     constants.MAX_TARGET_PER_PROJECT_HEURISTIC,
                     param_combination)
@@ -720,20 +720,10 @@ if __name__ == "__main__":
     parser = get_cmdline_parser()
     args = parser.parse_args()
 
-    if args.language == 'python':
-        if (args.benchmark):
-            print("Benchmarking for python is not supported yet")
-        else:
-            github_projects = utils.get_target_repos(args.targets, 'python')
-            run_on_projects("python", github_projects, args.merge)
-    elif args.language == 'java':
-        if (args.benchmark):
-            projects = constants.benchmark['jvm']
-            benchmark = True
-        else:
-            projects = utils.get_target_repos(args.targets, 'jvm')
-            benchmark = False
-        run_on_projects("jvm", projects, args.merge, args.param_combination,
-                        benchmark)
+    projects = utils.get_target_repos(args.targets, args.language, args.benchmark)
+
+    if projects:
+        run_on_projects(args.language, projects, args.merge,
+                        args.param_combination, args.benchmark)
     else:
         print("Language not supported")

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -104,7 +104,7 @@ def run_static_analysis_python(git_repo, oss_fuzz_base_project,
 
 
 def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
-                      project_type):
+                       project_type):
     basedir = oss_fuzz_base_project.project_folder
     build_ret = False
     jarfiles = None
@@ -146,7 +146,7 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
 
 
 def run_static_analysis_java(git_repo, oss_fuzz_base_project,
-                            base_oss_fuzz_project_dir, project_type):
+                             base_oss_fuzz_project_dir, project_type):
     basedir = oss_fuzz_base_project.project_folder
     project_name = oss_fuzz_base_project.project_name
 
@@ -720,7 +720,8 @@ if __name__ == "__main__":
     parser = get_cmdline_parser()
     args = parser.parse_args()
 
-    projects = utils.get_target_repos(args.targets, args.language, args.benchmark)
+    projects = utils.get_target_repos(args.targets, args.language,
+                                      args.benchmark)
 
     if projects:
         run_on_projects(args.language, projects, args.merge,

--- a/tools/auto-fuzz/oss_fuzz_project.py
+++ b/tools/auto-fuzz/oss_fuzz_project.py
@@ -106,9 +106,9 @@ class OSS_FUZZ_PROJECT:
                     project_build_type=project_build_type))
 
     def change_java_dockerfile(self,
-                              jdk_version,
-                              project_build_type,
-                              build_project=True):
+                               jdk_version,
+                               project_build_type,
+                               build_project=True):
         with open(self.dockerfile, "w") as docker_file:
             docker_file.write(
                 base_files.gen_dockerfile(

--- a/tools/auto-fuzz/oss_fuzz_project.py
+++ b/tools/auto-fuzz/oss_fuzz_project.py
@@ -45,7 +45,7 @@ class OSS_FUZZ_PROJECT:
     def base_fuzzer(self):
         if self.language == "python":
             return self.project_folder + "/fuzz_1.py"
-        elif self.language == "jvm":
+        elif self.language == "java":
             return self.project_folder + "/Fuzz.java"
         else:
             # Temporary fail safe logic
@@ -59,7 +59,7 @@ class OSS_FUZZ_PROJECT:
     def oss_fuzz_fuzzer_namer(self):
         if self.language == "python":
             return os.path.basename(self.base_fuzzer).replace(".py", "")
-        elif self.language == "jvm":
+        elif self.language == "java":
             return os.path.basename(self.base_fuzzer).replace(".java", "")
         else:
             # Temporary fail safe logic
@@ -105,7 +105,7 @@ class OSS_FUZZ_PROJECT:
                     self.language,
                     project_build_type=project_build_type))
 
-    def change_jvm_dockerfile(self,
+    def change_java_dockerfile(self,
                               jdk_version,
                               project_build_type,
                               build_project=True):

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -43,8 +43,14 @@ def git_clone_project(github_url, destination):
     return True
 
 
-def get_target_repos(targets, language):
+def get_target_repos(targets, language, is_benchmark):
     """Retrieve list of target proejct url"""
+    if language not in constants.git_repos:
+        return None
+
+    if is_benchmark:
+        return constants.benchmark[language]
+
     if targets == "constants":
         return constants.git_repos[language]
     github_projects = []
@@ -68,8 +74,8 @@ def get_next_project_folder(base_dir):
     return os.path.join(base_dir, AUTOFUZZDIR + str(max_idx + 1))
 
 
-# JVM Project discovery utils
-#############################
+# Java Project discovery utils
+##############################
 def _find_dir_build_type(dir):
     """Determine the java build project type of the directory"""
 


### PR DESCRIPTION
This PR fixes the inconsistency language naming, in which "jvm" and "java" are used interchangeably. The new version changes all the use of "jvm" to "java" to keep it consistent throughout the code. This PR also modifies the language-specific branch in the main method of the manager.py.