### PR TITLE
Auto-fuzz: Add oss-fuzz docker support for java static analysis

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -49,7 +49,8 @@ def gen_builder_1(language="python",
     if language == "python":
         return _gen_builder_1_python(template_dir)
     elif language == "java":
-        return _gen_builder_1_java(template_dir, build_project, project_build_type)
+        return _gen_builder_1_java(template_dir, build_project,
+                                   project_build_type)
     else:
         return ""
 
@@ -101,9 +102,9 @@ def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
         BASE_DOCKERFILE = file.read()
 
     if project_build_type == "introspector":
-        return BASE_DOCKERFILE % (
-            constants.FILE_TO_PREPARE['java']['maven'],
-            constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version])
+        return BASE_DOCKERFILE % (constants.FILE_TO_PREPARE['java']['maven'],
+                                  constants.JDK_URL[jdk_version],
+                                  constants.JDK_HOME[jdk_version])
 
     if project_build_type in constants.FILE_TO_PREPARE['java']:
         return BASE_DOCKERFILE % (

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -49,7 +49,7 @@ def gen_builder_1(language="python",
     if language == "python":
         return _gen_builder_1_python(template_dir)
     elif language == "java":
-        return _gen_builder_1_java(template_dir, build_project)
+        return _gen_builder_1_java(template_dir, build_project, project_build_type)
     else:
         return ""
 
@@ -98,15 +98,20 @@ def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
         comment = ""
 
     with open(os.path.join(template_dir, "Dockerfile-template"), "r") as file:
-        BASE_DOCKERFILE = file.read() % (
-            "%s", constants.FILE_TO_PREPARE['java']['protoc'],
-            constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
-            github_url, project_name, project_name, project_name, comment,
-            comment, project_name)
+        BASE_DOCKERFILE = file.read()
+
+    if project_build_type == "introspector":
+        return BASE_DOCKERFILE % (
+            constants.FILE_TO_PREPARE['java']['maven'],
+            constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version])
 
     if project_build_type in constants.FILE_TO_PREPARE['java']:
         return BASE_DOCKERFILE % (
-            constants.FILE_TO_PREPARE['java'][project_build_type])
+            constants.FILE_TO_PREPARE['java'][project_build_type],
+            constants.FILE_TO_PREPARE['java']['protoc'],
+            constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
+            github_url, project_name, project_name, project_name, comment,
+            comment, project_name)
     else:
         return ""
 
@@ -118,9 +123,12 @@ def _gen_builder_1_python(template_dir):
     return BASE_BUILDER
 
 
-def _gen_builder_1_java(template_dir, build_project):
+def _gen_builder_1_java(template_dir, build_project, project_build_type):
     with open(os.path.join(template_dir, "build.sh-template"), "r") as file:
         BASE_BUILDER = "#!/bin/bash -eu\n" + file.read()
+
+    if project_build_type == "introspector":
+        return BASE_BUILDER
 
     if build_project:
         return BASE_BUILDER % ("", "", ": <<'COMMENT'", "COMMENT")

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -170,8 +170,9 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
     possible_imports = set()
     curr_dir = os.getcwd()
 
-    build_ret, jardir, jdk_key = build_java_project(
-        oss_fuzz_base_project, base_oss_fuzz_project_dir, project_build_type)
+    build_ret, jardir, jdk_key = build_java_project(oss_fuzz_base_project,
+                                                    base_oss_fuzz_project_dir,
+                                                    project_build_type)
     jdk_base = constants.JDK_HOME[jdk_key]
 
     if not build_ret:
@@ -192,8 +193,7 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
     maven_dst = os.path.join(introspector_dir, "maven.zip")
     shutil.copy(maven_path, maven_dst)
     if jardir:
-        shutil.copytree(jardir,
-                        os.path.join(introspector_dir, "build-jar"))
+        shutil.copytree(jardir, os.path.join(introspector_dir, "build-jar"))
 
     introspector_ret = oss_fuzz_manager.copy_and_build_project(
         introspector_dir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -110,7 +110,7 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                        project_type):
     basedir = oss_fuzz_base_project.project_folder
     build_ret = False
-    jarfiles = None
+    jardir = None
     jdk_key = None
     if basedir:
         # Loop and use each JDK version in order in the previous failed.
@@ -139,13 +139,14 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                             os.path.join(jardir, file)):
                         shutil.copy(os.path.join(out_dir, file), jardir)
                         have_jar = True
-                if have_jar:
-                    jarfiles = [os.path.join(jardir, "*.jar")]
+                if not have_jar:
+                    jardir = None
+
                 jdk_key = jdk
                 break
 
     oss_fuzz_manager.cleanup_project("base-autofuzz", OSS_FUZZ_BASE)
-    return (build_ret, jarfiles, jdk_key)
+    return (build_ret, jardir, jdk_key)
 
 
 def run_static_analysis_java(git_repo, oss_fuzz_base_project,
@@ -169,7 +170,7 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
     possible_imports = set()
     curr_dir = os.getcwd()
 
-    build_ret, jarfiles, jdk_key = build_java_project(
+    build_ret, jardir, jdk_key = build_java_project(
         oss_fuzz_base_project, base_oss_fuzz_project_dir, project_build_type)
     jdk_base = constants.JDK_HOME[jdk_key]
 
@@ -177,47 +178,36 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
         print("Unknown project type or project build fail.\n")
         return False, None, None
 
-    # Prepare environment variable for found version of JDK
-    target_jdk_path = os.path.join(oss_fuzz_base_project.project_folder,
-                                   "jdk.tar.gz")
-    with open(target_jdk_path, 'wb') as jdkfile:
-        jdkfile.write(requests.get(constants.JDK_URL[jdk_key]).content)
-    with tarfile.open(os.path.join(basedir, "jdk.tar.gz"), "r:gz") as jdkfile:
-        jdkfile.extractall(os.path.join(basedir))
-    env_var = os.environ.copy()
-    env_var['JAVA_HOME'] = os.path.join(basedir, jdk_base)
-    env_var['PATH'] = os.path.join(
-        basedir, jdk_base, "bin") + ":" + os.path.join(
-            basedir, constants.MAVEN_PATH) + ":" + env_var['PATH']
+    # Prepare OSS-Fuzz folder for static analysis
+    introspector_dir = os.path.join(basedir, "introspector")
+    if not os.path.exists(introspector_dir):
+        os.mkdir(introspector_dir)
 
-    # Run the java frontend static analysis
-    cmd = [
-        "./run.sh", "--jarfile", '"' + ":".join(jarfiles) + '"',
-        "--entryclass", "Fuzz", "--src",
-        os.path.join(basedir, oss_fuzz_base_project.project_name), "--autofuzz"
-    ]
-    try:
-        subprocess.check_call(" ".join(cmd),
-                              shell=True,
-                              timeout=1800,
-                              env=env_var,
-                              stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL,
-                              cwd=os.path.dirname(FUZZ_INTRO_MAIN["java"]))
-    except subprocess.TimeoutExpired:
+    utils.gen_introspector_dockerfile(introspector_dir, "java")
+    utils.gen_introspector_build_script(introspector_dir, "java")
+    shutil.copytree(os.path.join(basedir, project_name),
+                    os.path.join(introspector_dir, "proj"))
+    maven_path = os.path.join(oss_fuzz_base_project.project_folder,
+                              "maven.zip")
+    maven_dst = os.path.join(introspector_dir, "maven.zip")
+    shutil.copy(maven_path, maven_dst)
+    if jardir:
+        shutil.copytree(jardir,
+                        os.path.join(introspector_dir, "build-jar"))
+
+    introspector_ret = oss_fuzz_manager.copy_and_build_project(
+        introspector_dir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
+
+    if not introspector_ret:
         print("Fail to execute java frontend code.\n")
-        return False, None, None
-    except subprocess.CalledProcessError:
-        print("Fail to execute java frontend code.\n")
-        return False, None, None
+        ret = False
 
     # Move data and data.yaml to working directory
     if not os.path.exists(os.path.join(basedir, "work")):
         os.mkdir(os.path.join(basedir, "work"))
-    data_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["java"]),
-                            "fuzzerLogFile-Fuzz.data")
-    yaml_src = os.path.join(os.path.dirname(FUZZ_INTRO_MAIN["java"]),
-                            "fuzzerLogFile-Fuzz.data.yaml")
+    out_dir = os.path.join(OSS_FUZZ_BASE, "build", "out", "introspector")
+    data_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data")
+    yaml_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data.yaml")
     data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data")
     yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data.yaml")
     if os.path.isfile(data_src) and os.path.isfile(yaml_src):
@@ -231,6 +221,14 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
     else:
         print("Fail to execute java frontend code.\n")
         ret = False
+
+    # Clean introspector directory
+    try:
+        shutil.rmtree(introspector_dir)
+        oss_fuzz_manager.cleanup_project("introspector", OSS_FUZZ_BASE)
+    except:
+        # Ignore error for directory cleaning
+        pass
 
     os.chdir(curr_dir)
     return ret, jdk_base, project_build_type

--- a/tools/auto-fuzz/templates/java-introspector/Dockerfile-template
+++ b/tools/auto-fuzz/templates/java-introspector/Dockerfile-template
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+#RUN curl -L %s -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
+RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
+COPY maven.zip $SRC/maven.zip
+RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
+ENV JAVA_HOME="$SRC/%s"
+ENV PATH="$JAVA_HOME/bin:$SRC/maven/apache-maven-3.6.3/bin:$PATH"
+RUN git clone --depth 1 https://github.com/ossf/fuzz-introspector introspector
+RUN mkdir -p $SRC/build-jar
+COPY build-jar/*.jar $SRC/build-jar/
+RUN mkdir -p $SRC/proj
+COPY proj/* $SRC/proj/
+COPY build.sh $SRC/
+WORKDIR $SRC/introspector/frontends/java

--- a/tools/auto-fuzz/templates/java-introspector/Dockerfile-template
+++ b/tools/auto-fuzz/templates/java-introspector/Dockerfile-template
@@ -20,10 +20,9 @@ COPY maven.zip $SRC/maven.zip
 RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
 ENV JAVA_HOME="$SRC/%s"
 ENV PATH="$JAVA_HOME/bin:$SRC/maven/apache-maven-3.6.3/bin:$PATH"
-RUN git clone --depth 1 https://github.com/ossf/fuzz-introspector introspector
 RUN mkdir -p $SRC/build-jar
 COPY build-jar/*.jar $SRC/build-jar/
 RUN mkdir -p $SRC/proj
 COPY proj/* $SRC/proj/
 COPY build.sh $SRC/
-WORKDIR $SRC/introspector/frontends/java
+WORKDIR /fuzz-introspector/frontends/java

--- a/tools/auto-fuzz/templates/java-introspector/build.sh-template
+++ b/tools/auto-fuzz/templates/java-introspector/build.sh-template
@@ -1,0 +1,19 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
+./run.sh --jarfile $SRC/build-jar/*.jar: --entryclass Fuzz --src $SRC/proj --autofuzz
+
+cp ./fuzzerLogFile-Fuzz.data $OUT/
+cp ./fuzzerLogFile-Fuzz.data.yaml $OUT/

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -161,7 +161,11 @@ def copy_oss_fuzz_project_source(src_oss_project, dst_oss_project):
 #################################
 def gen_introspector_dockerfile(dir, language):
     with open(os.path.join(dir, "Dockerfile"), "w") as file:
-        file.write(base_files.gen_dockerfile(None, None, language, project_build_type="introspector"))
+        file.write(
+            base_files.gen_dockerfile(None,
+                                      None,
+                                      language,
+                                      project_build_type="introspector"))
 
 
 def gen_introspector_build_script(dir, language):

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -16,6 +16,7 @@ import constants
 import os
 import shutil
 import subprocess
+import base_files
 
 
 # Project preparation utils
@@ -154,6 +155,18 @@ def copy_oss_fuzz_project_source(src_oss_project, dst_oss_project):
                      src_oss_project.project_name),
         os.path.join(dst_oss_project.project_folder,
                      dst_oss_project.project_name))
+
+
+# Static anaylsis base file utils
+#################################
+def gen_introspector_dockerfile(dir, language):
+    with open(os.path.join(dir, "Dockerfile"), "w") as file:
+        file.write(base_files.gen_dockerfile(None, None, language, project_build_type="introspector"))
+
+
+def gen_introspector_build_script(dir, language):
+    with open(os.path.join(dir, "build.sh"), "w") as file:
+        file.write(base_files.gen_builder_1(language, "introspector"))
 
 
 # Project cleaning utils


### PR DESCRIPTION
This PR changes the logic for static analysis of the Java project. Instead of running the static analysis in the local environment, the new logic builds an OSS-Fuzz directory to run the static analysis for the Java project in the OSS-Fuzz docker image. This allows more flexibility in the settings and dependencies that are required for the Java static analysis without the need to load and depend on the settings in the local environment. The next step is to make this part generalize for all languages.