### PR TITLE
Auto Fuzz: Combine java build and static analysis

### DIFF
--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -99,20 +99,24 @@ def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
     if project_build_type in constants.FILE_TO_PREPARE['java']:
         if build_project:
             introspector_dir = _get_template_directory("java", "introspector")
-            with open(os.path.join(introspector_dir, "Dockerfile-template"), "r") as file:
-                INTROSPECTOR_DOCKERFILE = file.read() % constants.FILE_TO_PREPARE['java']['maven']
+            with open(os.path.join(introspector_dir, "Dockerfile-template"),
+                      "r") as file:
+                INTROSPECTOR_DOCKERFILE = file.read(
+                ) % constants.FILE_TO_PREPARE['java']['maven']
 
             return BASE_DOCKERFILE % (
                 constants.FILE_TO_PREPARE['java'][project_build_type],
                 constants.FILE_TO_PREPARE['java']['protoc'],
-                constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
-                github_url, project_name, "#", "#", INTROSPECTOR_DOCKERFILE)
+                constants.JDK_URL[jdk_version],
+                constants.JDK_HOME[jdk_version], github_url, project_name, "#",
+                "#", INTROSPECTOR_DOCKERFILE)
         else:
             return BASE_DOCKERFILE % (
                 constants.FILE_TO_PREPARE['java'][project_build_type],
                 constants.FILE_TO_PREPARE['java']['protoc'],
-                constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
-                github_url, project_name, "", "", "")
+                constants.JDK_URL[jdk_version],
+                constants.JDK_HOME[jdk_version], github_url, project_name, "",
+                "", "")
 
     else:
         return ""
@@ -134,10 +138,12 @@ def _gen_builder_1_java(template_dir, build_project, project_build_type):
 
     if build_project:
         introspector_dir = _get_template_directory("java", "introspector")
-        with open(os.path.join(introspector_dir, "build.sh-template"), "r") as file:
+        with open(os.path.join(introspector_dir, "build.sh-template"),
+                  "r") as file:
             INTROSPECTOR_BUILDER = file.read()
 
-        return BASE_BUILDER % ("", "", ": <<'COMMENT'", "COMMENT", INTROSPECTOR_BUILDER)
+        return BASE_BUILDER % ("", "", ": <<'COMMENT'", "COMMENT",
+                               INTROSPECTOR_BUILDER)
     else:
         return BASE_BUILDER % (": <<'COMMENT'", "COMMENT", "", "", "")
 

--- a/tools/auto-fuzz/base_files.py
+++ b/tools/auto-fuzz/base_files.py
@@ -93,26 +93,27 @@ def _gen_dockerfile_python(github_url, project_name, template_dir):
 
 def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
                          template_dir, project_build_type):
-    if build_project:
-        comment = "#"
-    else:
-        comment = ""
-
     with open(os.path.join(template_dir, "Dockerfile-template"), "r") as file:
         BASE_DOCKERFILE = file.read()
 
-    if project_build_type == "introspector":
-        return BASE_DOCKERFILE % (constants.FILE_TO_PREPARE['java']['maven'],
-                                  constants.JDK_URL[jdk_version],
-                                  constants.JDK_HOME[jdk_version])
-
     if project_build_type in constants.FILE_TO_PREPARE['java']:
-        return BASE_DOCKERFILE % (
-            constants.FILE_TO_PREPARE['java'][project_build_type],
-            constants.FILE_TO_PREPARE['java']['protoc'],
-            constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
-            github_url, project_name, project_name, project_name, comment,
-            comment, project_name)
+        if build_project:
+            introspector_dir = _get_template_directory("java", "introspector")
+            with open(os.path.join(introspector_dir, "Dockerfile-template"), "r") as file:
+                INTROSPECTOR_DOCKERFILE = file.read() % constants.FILE_TO_PREPARE['java']['maven']
+
+            return BASE_DOCKERFILE % (
+                constants.FILE_TO_PREPARE['java'][project_build_type],
+                constants.FILE_TO_PREPARE['java']['protoc'],
+                constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
+                github_url, project_name, "#", "#", INTROSPECTOR_DOCKERFILE)
+        else:
+            return BASE_DOCKERFILE % (
+                constants.FILE_TO_PREPARE['java'][project_build_type],
+                constants.FILE_TO_PREPARE['java']['protoc'],
+                constants.JDK_URL[jdk_version], constants.JDK_HOME[jdk_version],
+                github_url, project_name, "", "", "")
+
     else:
         return ""
 
@@ -132,9 +133,13 @@ def _gen_builder_1_java(template_dir, build_project, project_build_type):
         return BASE_BUILDER
 
     if build_project:
-        return BASE_BUILDER % ("", "", ": <<'COMMENT'", "COMMENT")
+        introspector_dir = _get_template_directory("java", "introspector")
+        with open(os.path.join(introspector_dir, "build.sh-template"), "r") as file:
+            INTROSPECTOR_BUILDER = file.read()
+
+        return BASE_BUILDER % ("", "", ": <<'COMMENT'", "COMMENT", INTROSPECTOR_BUILDER)
     else:
-        return BASE_BUILDER % (": <<'COMMENT'", "COMMENT", "", "")
+        return BASE_BUILDER % (": <<'COMMENT'", "COMMENT", "", "", "")
 
 
 def _gen_base_fuzzer_python(template_dir):

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -118,7 +118,8 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
         for jdk in constants.JDK_HOME:
             jdk_dir = constants.JDK_HOME[jdk]
 
-            oss_fuzz_base_project.change_java_dockerfile(jdk, project_build_type)
+            oss_fuzz_base_project.change_java_dockerfile(
+                jdk, project_build_type)
             oss_fuzz_base_project.change_build_script(project_build_type)
 
             build_ret = oss_fuzz_manager.copy_and_build_project(
@@ -142,16 +143,20 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                     os.mkdir(os.path.join(basedir, "work"))
 
                 data_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data")
-                yaml_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data.yaml")
-                data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data")
-                yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data.yaml")
+                yaml_src = os.path.join(out_dir,
+                                        "fuzzerLogFile-Fuzz.data.yaml")
+                data_dst = os.path.join(basedir, "work",
+                                        "fuzzerLogFile-Fuzz.data")
+                yaml_dst = os.path.join(basedir, "work",
+                                        "fuzzerLogFile-Fuzz.data.yaml")
                 if os.path.isfile(data_src) and os.path.isfile(yaml_src):
                     try:
                         shutil.copy(data_src, data_dst)
                         shutil.copy(yaml_src, yaml_dst)
                     except:
                         pass
-                if not os.path.isfile(data_dst) or not os.path.isfile(yaml_dst):
+                if not os.path.isfile(data_dst) or not os.path.isfile(
+                        yaml_dst):
                     build_ret = False
                     break
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -107,7 +107,7 @@ def run_static_analysis_python(git_repo, oss_fuzz_base_project,
 
 
 def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
-                       project_type):
+                       project_build_type):
     basedir = oss_fuzz_base_project.project_folder
     build_ret = False
     jardir = None
@@ -117,7 +117,9 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
         # Order JDK15 (oss-fuzz default) -> JDK17 -> JDK11 -> JDK8
         for jdk in constants.JDK_HOME:
             jdk_dir = constants.JDK_HOME[jdk]
-            oss_fuzz_base_project.change_java_dockerfile(jdk, project_type)
+
+            oss_fuzz_base_project.change_java_dockerfile(jdk, project_build_type)
+            oss_fuzz_base_project.change_build_script(project_build_type)
 
             build_ret = oss_fuzz_manager.copy_and_build_project(
                 basedir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
@@ -134,6 +136,26 @@ def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                 project_name = os.path.basename(basedir)
                 out_dir = os.path.join(OSS_FUZZ_BASE, "build", "out",
                                        project_name)
+
+                # Check and copy data and data.yaml files
+                if not os.path.exists(os.path.join(basedir, "work")):
+                    os.mkdir(os.path.join(basedir, "work"))
+
+                data_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data")
+                yaml_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data.yaml")
+                data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data")
+                yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data.yaml")
+                if os.path.isfile(data_src) and os.path.isfile(yaml_src):
+                    try:
+                        shutil.copy(data_src, data_dst)
+                        shutil.copy(yaml_src, yaml_dst)
+                    except:
+                        pass
+                if not os.path.isfile(data_dst) or not os.path.isfile(yaml_dst):
+                    build_ret = False
+                    break
+
+                # Check and copy build jar files
                 for file in os.listdir(out_dir):
                     if file.endswith(".jar") and not os.path.exists(
                             os.path.join(jardir, file)):
@@ -163,6 +185,9 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
     if project_build_type:
         # Generate the base Dockerfile, build.sh, project.yaml and Fuzz.java
         oss_fuzz_base_project.write_basefiles(project_build_type)
+    else:
+        print("Unknown project build type.\n")
+        return False, None, None
 
     basedir = oss_fuzz_base_project.project_folder
     project_name = oss_fuzz_base_project.project_name
@@ -176,62 +201,11 @@ def run_static_analysis_java(git_repo, oss_fuzz_base_project,
     jdk_base = constants.JDK_HOME[jdk_key]
 
     if not build_ret:
-        print("Unknown project type or project build fail.\n")
+        print("Project build fail or static analysis fail.\n")
         return False, None, None
 
-    # Prepare OSS-Fuzz folder for static analysis
-    introspector_dir = os.path.join(basedir, "introspector")
-    if not os.path.exists(introspector_dir):
-        os.mkdir(introspector_dir)
-
-    utils.gen_introspector_dockerfile(introspector_dir, "java")
-    utils.gen_introspector_build_script(introspector_dir, "java")
-    shutil.copytree(os.path.join(basedir, project_name),
-                    os.path.join(introspector_dir, "proj"))
-    maven_path = os.path.join(oss_fuzz_base_project.project_folder,
-                              "maven.zip")
-    maven_dst = os.path.join(introspector_dir, "maven.zip")
-    shutil.copy(maven_path, maven_dst)
-    if jardir:
-        shutil.copytree(jardir, os.path.join(introspector_dir, "build-jar"))
-
-    introspector_ret = oss_fuzz_manager.copy_and_build_project(
-        introspector_dir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
-
-    if not introspector_ret:
-        print("Fail to execute java frontend code.\n")
-        ret = False
-
-    # Move data and data.yaml to working directory
-    if not os.path.exists(os.path.join(basedir, "work")):
-        os.mkdir(os.path.join(basedir, "work"))
-    out_dir = os.path.join(OSS_FUZZ_BASE, "build", "out", "introspector")
-    data_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data")
-    yaml_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data.yaml")
-    data_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data")
-    yaml_dst = os.path.join(basedir, "work", "fuzzerLogFile-Fuzz.data.yaml")
-    if os.path.isfile(data_src) and os.path.isfile(yaml_src):
-        ret = True
-        try:
-            shutil.copy(data_src, data_dst)
-            shutil.copy(yaml_src, yaml_dst)
-        except:
-            print("Fail to execute java frontend code.\n")
-            ret = False
-    else:
-        print("Fail to execute java frontend code.\n")
-        ret = False
-
-    # Clean introspector directory
-    try:
-        shutil.rmtree(introspector_dir)
-        oss_fuzz_manager.cleanup_project("introspector", OSS_FUZZ_BASE)
-    except:
-        # Ignore error for directory cleaning
-        pass
-
     os.chdir(curr_dir)
-    return ret, jdk_base, project_build_type
+    return build_ret, jdk_base, project_build_type
 
 
 def tick_tqdm_tracker():

--- a/tools/auto-fuzz/templates/java-ant/Dockerfile-template
+++ b/tools/auto-fuzz/templates/java-ant/Dockerfile-template
@@ -25,9 +25,10 @@ RUN unzip protoc.zip -d $SRC/protoc && rm ./protoc.zip
 ENV ANT $SRC/ant/apache-ant-1.10.13/bin/ant
 ENV JAVA_HOME="$SRC/%s"
 ENV PATH="$JAVA_HOME/bin:$SRC/protoc/bin:$PATH"
-#RUN git clone --depth 1 %s %s
-COPY %s %s
+#RUN git clone --depth 1 %s proj
+COPY %s proj
 COPY *.sh *.java $SRC/
 %sRUN mkdir -p $SRC/build_jar
 %sCOPY build-jar/*.jar $SRC/build_jar/
-WORKDIR $SRC/%s
+%s
+WORKDIR $SRC/proj

--- a/tools/auto-fuzz/templates/java-ant/build.sh-template
+++ b/tools/auto-fuzz/templates/java-ant/build.sh-template
@@ -116,3 +116,5 @@ do
 
   chmod u+x $OUT/$fuzzer_basename
 done
+
+%s

--- a/tools/auto-fuzz/templates/java-gradle/Dockerfile-template
+++ b/tools/auto-fuzz/templates/java-gradle/Dockerfile-template
@@ -26,9 +26,10 @@ ENV GRADLE_HOME $SRC/gradle/gradle-7.4.2
 ENV GRADLE_OPTS="-Dfile.encoding=utf-8"
 ENV JAVA_HOME="$SRC/%s"
 ENV PATH="$JAVA_HOME/bin:$SRC/gradle/gradle-7.4.2/bin:$SRC/protoc/bin:$PATH"
-#RUN git clone --depth 1 %s %s
-COPY %s %s
+#RUN git clone --depth 1 %s proj
+COPY %s proj
 COPY *.sh *.java $SRC/
 %sRUN mkdir -p $SRC/build_jar
 %sCOPY build-jar/*.jar $SRC/build_jar/
-WORKDIR $SRC/%s
+%s
+WORKDIR $SRC/proj

--- a/tools/auto-fuzz/templates/java-gradle/build.sh-template
+++ b/tools/auto-fuzz/templates/java-gradle/build.sh-template
@@ -129,3 +129,5 @@ do
 
   chmod u+x $OUT/$fuzzer_basename
 done
+
+%s

--- a/tools/auto-fuzz/templates/java-introspector/Dockerfile-template
+++ b/tools/auto-fuzz/templates/java-introspector/Dockerfile-template
@@ -1,28 +1,4 @@
-# Copyright 2023 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-##########################################################################
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
 #RUN curl -L %s -o maven.zip && unzip maven.zip -d $SRC/maven && rm -rf maven.zip
-RUN curl -L %s -o jdk.tar.gz && tar zxf jdk.tar.gz && rm -rf jdk.tar.gz
 COPY maven.zip $SRC/maven.zip
-RUN unzip maven.zip -d $SRC/maven && rm ./maven.zip
-ENV JAVA_HOME="$SRC/%s"
-ENV PATH="$JAVA_HOME/bin:$SRC/maven/apache-maven-3.6.3/bin:$PATH"
-RUN mkdir -p $SRC/build-jar
-COPY build-jar/*.jar $SRC/build-jar/
-RUN mkdir -p $SRC/proj
-COPY proj/* $SRC/proj/
-COPY build.sh $SRC/
-WORKDIR /fuzz-introspector/frontends/java
+RUN rm -rf $SRC/maven && unzip maven.zip -d $SRC/maven && rm ./maven.zip
+ENV PATH="$SRC/maven/apache-maven-3.6.3/bin:$PATH"

--- a/tools/auto-fuzz/templates/java-introspector/build.sh-template
+++ b/tools/auto-fuzz/templates/java-introspector/build.sh-template
@@ -1,19 +1,4 @@
-# Copyright 2023 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-##########################################################################
-./run.sh --jarfile $SRC/build-jar/*.jar: --entryclass Fuzz --src $SRC/proj --autofuzz
-
+cd /fuzz-introspector/frontends/java
+./run.sh --jarfile $OUT/*.jar: --entryclass Fuzz --src $SRC/proj --autofuzz
 cp ./fuzzerLogFile-Fuzz.data $OUT/
 cp ./fuzzerLogFile-Fuzz.data.yaml $OUT/

--- a/tools/auto-fuzz/templates/java-maven/Dockerfile-template
+++ b/tools/auto-fuzz/templates/java-maven/Dockerfile-template
@@ -25,9 +25,10 @@ RUN unzip protoc.zip -d $SRC/protoc && rm ./protoc.zip
 ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 ENV JAVA_HOME="$SRC/%s"
 ENV PATH="$JAVA_HOME/bin:$SRC/protoc/bin:$PATH"
-#RUN git clone --depth 1 %s %s
-COPY %s %s
+#RUN git clone --depth 1 %s proj
+COPY %s proj
 COPY *.sh *.java $SRC/
 %sRUN mkdir -p $SRC/build_jar
 %sCOPY build-jar/*.jar $SRC/build_jar/
-WORKDIR $SRC/%s
+%s
+WORKDIR $SRC/proj

--- a/tools/auto-fuzz/templates/java-maven/build.sh-template
+++ b/tools/auto-fuzz/templates/java-maven/build.sh-template
@@ -141,3 +141,5 @@ do
 
   chmod u+x $OUT/$fuzzer_basename
 done
+
+%s

--- a/tools/auto-fuzz/templates/python-introspector/Dockerfile-template
+++ b/tools/auto-fuzz/templates/python-introspector/Dockerfile-template
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-python
+#RUN pip3 install --upgrade pip && pip3 install cython
+#RUN git clone %s %s
+COPY %s %s
+COPY *.sh *py $SRC/
+WORKDIR $SRC/%s


### PR DESCRIPTION
In the current logic, the Java project build and static analysis are separated into two steps and two OSS-Fuzz project copy and build is needed. This PR combines the project build and static analysis of Java to a single OSS-Fuzz project build to remove unnecessary executions and prepare for generalizing the static analysis step.