### PR TITLE
Auto-fuzz: Generalise and combine static analysis of multiple languages

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -70,146 +70,81 @@ if not os.path.isdir(OSS_FUZZ_BASE):
     raise Exception("Could not find OSS-Fuzz directory")
 
 
-def run_static_analysis_python(git_repo, oss_fuzz_base_project,
-                               base_oss_fuzz_project_dir):
-    # Generate the base Dockerfile, build.sh, project.yaml and fuzz_1.py
-    oss_fuzz_base_project.write_basefiles()
-
+def build_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
+                  project_build_type):
     basedir = oss_fuzz_base_project.project_folder
-    project_name = oss_fuzz_base_project.project_name
-
-    possible_imports = set()
-    curr_dir = os.getcwd()
-    os.chdir(basedir)
-    os.mkdir("work")
-    os.chdir("work")
-
-    # Copy the project directory from the basedir
-    try:
-        shutil.copytree(os.path.join(basedir, project_name),
-                        os.path.join(os.getcwd(), project_name),
-                        symlinks=True)
-    except:
-        print("Fail to retrieve github directory.")
-        return False
-
-    cmd = [
-        "python3", FUZZ_INTRO_MAIN["python"], "--fuzzer", "../fuzz_1.py",
-        "--package=%s" % (os.getcwd())
-    ]
-    ret = utils.run_cmd(" ".join(cmd), 1800)
-    if not os.path.isfile("fuzzerLogFile-fuzz_1.data.yaml"):
-        ret = False
-    ret = True
-
-    os.chdir(curr_dir)
-    return ret
-
-
-def build_java_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
-                       project_build_type):
-    basedir = oss_fuzz_base_project.project_folder
+    language = oss_fuzz_base_project.language
     build_ret = False
-    jardir = None
     jdk_key = None
     if basedir:
-        # Loop and use each JDK version in order in the previous failed.
-        # Order JDK15 (oss-fuzz default) -> JDK17 -> JDK11 -> JDK8
-        for jdk in constants.JDK_HOME:
-            jdk_dir = constants.JDK_HOME[jdk]
+        if language == "java":
+            # Loop and use each JDK version in order in the previous failed.
+            # Order JDK15 (oss-fuzz default) -> JDK17 -> JDK11 -> JDK8
+            for jdk in constants.JDK_HOME:
+                jdk_dir = constants.JDK_HOME[jdk]
 
-            oss_fuzz_base_project.change_java_dockerfile(
-                jdk, project_build_type)
-            oss_fuzz_base_project.change_build_script(project_build_type)
+                oss_fuzz_base_project.change_java_dockerfile(
+                    jdk, project_build_type)
+                oss_fuzz_base_project.change_build_script(project_build_type)
 
+                build_ret = oss_fuzz_manager.copy_and_build_project(
+                    basedir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
+
+                # Check if the build success with the current JDK version
+                # and record that for future process and oss-fuzz test
+                if build_ret:
+                    jdk_key = jdk
+                    break
+        elif language == "python":
             build_ret = oss_fuzz_manager.copy_and_build_project(
                 basedir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
+        else:
+            return (False, None)
 
-            # Check if the build success with the current JDK version
-            # and record that for future process and oss-fuzz test
-            # Also copied built jar files for static analysis
-            if build_ret:
-                have_jar = False
-                jardir = os.path.join(basedir, "build-jar")
-                if not os.path.exists(jardir):
-                    os.mkdir(jardir)
-
-                project_name = os.path.basename(basedir)
-                out_dir = os.path.join(OSS_FUZZ_BASE, "build", "out",
-                                       project_name)
-
-                # Check and copy data and data.yaml files
-                if not os.path.exists(os.path.join(basedir, "work")):
-                    os.mkdir(os.path.join(basedir, "work"))
-
-                data_src = os.path.join(out_dir, "fuzzerLogFile-Fuzz.data")
-                yaml_src = os.path.join(out_dir,
-                                        "fuzzerLogFile-Fuzz.data.yaml")
-                data_dst = os.path.join(basedir, "work",
-                                        "fuzzerLogFile-Fuzz.data")
-                yaml_dst = os.path.join(basedir, "work",
-                                        "fuzzerLogFile-Fuzz.data.yaml")
-                if os.path.isfile(data_src) and os.path.isfile(yaml_src):
-                    try:
-                        shutil.copy(data_src, data_dst)
-                        shutil.copy(yaml_src, yaml_dst)
-                    except:
-                        pass
-                if not os.path.isfile(data_dst) or not os.path.isfile(
-                        yaml_dst):
-                    build_ret = False
-                    break
-
-                # Check and copy build jar files
-                for file in os.listdir(out_dir):
-                    if file.endswith(".jar") and not os.path.exists(
-                            os.path.join(jardir, file)):
-                        shutil.copy(os.path.join(out_dir, file), jardir)
-                        have_jar = True
-                if not have_jar:
-                    jardir = None
-
-                jdk_key = jdk
-                break
-
-    oss_fuzz_manager.cleanup_project("base-autofuzz", OSS_FUZZ_BASE)
-    return (build_ret, jardir, jdk_key)
+    return (build_ret, jdk_key)
 
 
-def run_static_analysis_java(git_repo, oss_fuzz_base_project,
-                             base_oss_fuzz_project_dir):
+def run_static_analysis(oss_fuzz_base_project, base_oss_fuzz_project_dir):
 
     # Get project_dir
-    projectdir = os.path.join(oss_fuzz_base_project.project_folder,
-                              oss_fuzz_base_project.project_name)
+    project_dir = os.path.join(oss_fuzz_base_project.project_folder,
+                               oss_fuzz_base_project.project_name)
 
-    # Find project type
-    project_build_type = utils.find_project_build_type(
-        projectdir, oss_fuzz_base_project.project_name)
+    language = oss_fuzz_base_project.language
 
-    if project_build_type:
-        # Generate the base Dockerfile, build.sh, project.yaml and Fuzz.java
-        oss_fuzz_base_project.write_basefiles(project_build_type)
-    else:
-        print("Unknown project build type.\n")
+    project_build_type = utils.write_base_file(oss_fuzz_base_project, project_dir, language)
+    if not project_build_type:
+        print("Fail to generate base files\n")
         return False, None, None
 
     basedir = oss_fuzz_base_project.project_folder
     project_name = oss_fuzz_base_project.project_name
 
-    possible_imports = set()
-    curr_dir = os.getcwd()
+    build_ret, jdk_key = build_project(oss_fuzz_base_project,
+                                       base_oss_fuzz_project_dir,
+                                       project_build_type)
 
-    build_ret, jardir, jdk_key = build_java_project(oss_fuzz_base_project,
-                                                    base_oss_fuzz_project_dir,
-                                                    project_build_type)
-    jdk_base = constants.JDK_HOME[jdk_key]
+    if jdk_key:
+        jdk_base = constants.JDK_HOME[jdk_key]
+    else:
+        jdk_base = None
 
     if not build_ret:
         print("Project build fail or static analysis fail.\n")
         return False, None, None
 
-    os.chdir(curr_dir)
+    static_ret = utils.check_and_copy_static_analysis_file(OSS_FUZZ_BASE, basedir, language)
+
+    if not static_ret:
+        print("Static analysis fail.\n")
+        return False, None, None
+
+    copy_ret = utils.copy_build_file(OSS_FUZZ_BASE, basedir, language)
+
+    if not static_ret:
+        print("Project build file copy fail.\n")
+        return False, None, None
+
     return build_ret, jdk_base, project_build_type
 
 
@@ -485,14 +420,14 @@ def autofuzz_project_from_github(github_url,
     jdk = "jdk15"
     if do_static_analysis:
         print("Running static analysis on %s" % (github_url))
-        if language == "python":
-            static_res = run_static_analysis_python(github_url,
-                                                    oss_fuzz_base_project,
-                                                    base_oss_fuzz_project_dir)
-        elif language == "java":
-            static_res, jdk_base, project_build_type = run_static_analysis_java(
-                github_url, oss_fuzz_base_project, base_oss_fuzz_project_dir)
+        static_res, jdk_base, project_build_type = run_static_analysis(
+            oss_fuzz_base_project, base_oss_fuzz_project_dir)
 
+        # Clean static analysis oss-fuzz directory
+#        oss_fuzz_manager.cleanup_project(
+#            os.path.basename(oss_fuzz_base_project.project_folder), OSS_FUZZ_BASE)
+
+        if jdk_base:
             # Overwrite dockerfile with correct jdk version
             # and avoid rebuild of project
             for key in constants.JDK_HOME:

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -112,7 +112,8 @@ def run_static_analysis(oss_fuzz_base_project, base_oss_fuzz_project_dir):
 
     language = oss_fuzz_base_project.language
 
-    project_build_type = utils.write_base_file(oss_fuzz_base_project, project_dir, language)
+    project_build_type = utils.write_base_file(oss_fuzz_base_project,
+                                               project_dir, language)
     if not project_build_type:
         print("Fail to generate base files\n")
         return False, None, None
@@ -133,7 +134,8 @@ def run_static_analysis(oss_fuzz_base_project, base_oss_fuzz_project_dir):
         print("Project build fail or static analysis fail.\n")
         return False, None, None
 
-    static_ret = utils.check_and_copy_static_analysis_file(OSS_FUZZ_BASE, basedir, language)
+    static_ret = utils.check_and_copy_static_analysis_file(
+        OSS_FUZZ_BASE, basedir, language)
 
     if not static_ret:
         print("Static analysis fail.\n")
@@ -424,8 +426,8 @@ def autofuzz_project_from_github(github_url,
             oss_fuzz_base_project, base_oss_fuzz_project_dir)
 
         # Clean static analysis oss-fuzz directory
-#        oss_fuzz_manager.cleanup_project(
-#            os.path.basename(oss_fuzz_base_project.project_folder), OSS_FUZZ_BASE)
+        #        oss_fuzz_manager.cleanup_project(
+        #            os.path.basename(oss_fuzz_base_project.project_folder), OSS_FUZZ_BASE)
 
         if jdk_base:
             # Overwrite dockerfile with correct jdk version

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -163,7 +163,7 @@ def write_base_file(oss_fuzz_base_project, projectdir, language):
     """Retrieve and create base file for static analysis"""
     if language == "python":
         project_build_type = "introspector"
-    elif language =="java":
+    elif language == "java":
         project_build_type = _find_project_build_type(
             projectdir, oss_fuzz_base_project.project_name)
     else:

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -91,7 +91,7 @@ def _find_dir_build_type(dir):
         return None
 
 
-def find_project_build_type(dir, proj_name):
+def _find_project_build_type(dir, proj_name):
     """Search for base project directory to detect project build type"""
     # Search for current directory first
     project_build_type = _find_dir_build_type(dir)
@@ -157,20 +157,66 @@ def copy_oss_fuzz_project_source(src_oss_project, dst_oss_project):
                      dst_oss_project.project_name))
 
 
-# Static anaylsis base file utils
-#################################
-def gen_introspector_dockerfile(dir, language):
-    with open(os.path.join(dir, "Dockerfile"), "w") as file:
-        file.write(
-            base_files.gen_dockerfile(None,
-                                      None,
-                                      language,
-                                      project_build_type="introspector"))
+# Static anaylsis preprocessing and postprocessing utils
+########################################################
+def write_base_file(oss_fuzz_base_project, projectdir, language):
+    """Retrieve and create base file for static analysis"""
+    if language == "python":
+        project_build_type = "introspector"
+    elif language =="java":
+        project_build_type = _find_project_build_type(
+            projectdir, oss_fuzz_base_project.project_name)
+    else:
+        return None
+
+    oss_fuzz_base_project.write_basefiles(project_build_type)
+    return project_build_type
 
 
-def gen_introspector_build_script(dir, language):
-    with open(os.path.join(dir, "build.sh"), "w") as file:
-        file.write(base_files.gen_builder_1(language, "introspector"))
+def check_and_copy_static_analysis_file(OSS_FUZZ_BASE, basedir, language):
+    """Check and copy static analysis output files to working directory"""
+    project_name = os.path.basename(basedir)
+    out_dir = os.path.join(OSS_FUZZ_BASE, "build", "out", project_name)
+    work_dir = os.path.join(basedir, "work")
+
+    if not os.path.exists(work_dir):
+        os.mkdir(work_dir)
+
+    for file in constants.STATIC_ANALYSIS_FILE[language]:
+        src_file = os.path.join(out_dir, file)
+        dst_file = os.path.join(work_dir, file)
+
+        try:
+            shutil.copy(src_file, dst_file)
+        except:
+            pass
+        if not os.path.isfile(dst_file):
+            return False
+
+    return True
+
+
+def copy_build_file(OSS_FUZZ_BASE, basedir, language):
+    """Copy build files to correct location for reuse"""
+    project_name = os.path.basename(basedir)
+    out_dir = os.path.join(OSS_FUZZ_BASE, "build", "out", project_name)
+
+    for build_file_property in constants.BUILD_FILE_PROPERTY[language]:
+        src_file = build_file_property['src_file']
+        dst_dir = os.path.join(basedir, build_file_property['dst_dir'])
+
+        if not os.path.exists(dst_dir):
+            os.mkdir(dst_dir)
+
+        for file in os.listdir(out_dir):
+            if file.endswith(src_file) and not os.path.exists(
+                    os.path.join(dst_dir, file)):
+                try:
+                    shutil.copy(os.path.join(out_dir, file), dst_dir)
+                except:
+                    return False
+
+    return True
 
 
 # Project cleaning utils
@@ -207,24 +253,3 @@ def cleanup_base_directory(base_dir, project_name):
     for dir in dir_to_clean:
         if os.path.isdir(os.path.join(base_dir, dir)):
             shutil.rmtree(os.path.join(base_dir, dir))
-
-
-# Local command execution
-#########################
-def run_cmd(cmd, timeout_sec):
-    """Execute script in the local environment"""
-    #print("Running command %s" % (cmd))
-    proc = subprocess.Popen(shlex.split(cmd),
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    timer = threading.Timer(timeout_sec, proc.kill)
-    try:
-        timer.start()
-        stdout, stderr = proc.communicate()
-        #print(stdout)
-        #print("---------")
-        #print(stderr)
-    finally:
-        no_timeout = timer.is_alive()
-        timer.cancel()
-    return no_timeout


### PR DESCRIPTION
This PR makes use of the new constants properties and OSS-Fuzz templates for different languages to perform project build and static analysis of the target project in one OSS-Fuzz run. It removes the need to have separate language branches for the static analysis process. It also removes the need to rebuild project in later testing process by reusing some build files (currently only for java).