### PR TITLE
Auto-fuzz: Fix bug in target file retrieval

### DIFF
--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -55,7 +55,7 @@ def get_target_repos(targets, language, is_benchmark):
     if targets == "constants":
         return constants.git_repos[language]
     github_projects = []
-    with open(args.targets, 'r') as f:
+    with open(targets, 'r') as f:
         for line in f:
             github_projects.append(line.replace("\n", "").strip())
     return github_projects


### PR DESCRIPTION
This PR fixes a bug in retrieving a list of target project urls from provided `--target` argument.