### PR TITLE
Auto-fuzz: Clean build directory for OSS-Fuzz after static analysis

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -95,6 +95,11 @@ def build_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                 if build_ret:
                     jdk_key = jdk
                     break
+                else:
+                    # Clean static analysis oss-fuzz directory
+                    folder = oss_fuzz_base_project.project_folder
+                    oss_fuzz_manager.cleanup_project(
+                        os.path.basename(folder), OSS_FUZZ_BASE)
         elif language == "python":
             build_ret = oss_fuzz_manager.copy_and_build_project(
                 basedir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
@@ -426,8 +431,8 @@ def autofuzz_project_from_github(github_url,
             oss_fuzz_base_project, base_oss_fuzz_project_dir)
 
         # Clean static analysis oss-fuzz directory
-        #        oss_fuzz_manager.cleanup_project(
-        #            os.path.basename(oss_fuzz_base_project.project_folder), OSS_FUZZ_BASE)
+        oss_fuzz_manager.cleanup_project(
+            os.path.basename(oss_fuzz_base_project.project_folder), OSS_FUZZ_BASE)
 
         if jdk_base:
             # Overwrite dockerfile with correct jdk version

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -98,8 +98,8 @@ def build_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
                 else:
                     # Clean static analysis oss-fuzz directory
                     folder = oss_fuzz_base_project.project_folder
-                    oss_fuzz_manager.cleanup_project(
-                        os.path.basename(folder), OSS_FUZZ_BASE)
+                    oss_fuzz_manager.cleanup_project(os.path.basename(folder),
+                                                     OSS_FUZZ_BASE)
         elif language == "python":
             build_ret = oss_fuzz_manager.copy_and_build_project(
                 basedir, OSS_FUZZ_BASE, log_dir=base_oss_fuzz_project_dir)
@@ -432,7 +432,8 @@ def autofuzz_project_from_github(github_url,
 
         # Clean static analysis oss-fuzz directory
         oss_fuzz_manager.cleanup_project(
-            os.path.basename(oss_fuzz_base_project.project_folder), OSS_FUZZ_BASE)
+            os.path.basename(oss_fuzz_base_project.project_folder),
+            OSS_FUZZ_BASE)
 
         if jdk_base:
             # Overwrite dockerfile with correct jdk version


### PR DESCRIPTION
Currently, the logic searches for build jar files from the OSS-Fuzz out directory after the project build and static analysis. As all project build and static analysis are done by using an OSS-Fuzz project with the name "base-autofuzz", the jar files in the $OUT directory will be accidentally used by the next project if it is not cleaned up after static analysis. This could cause errors if some project fails the static analysis because of errors in the jar files. This PR fixes the process by adding $OUT directory cleaning logic after static analysis to ensure static analysis of each project is done with a clean $OUT directory. 