### PR TITLE
frontends: python: adjust python importer for 3.9

### DIFF
--- a/frontends/python/prepare_fuzz_imports.py
+++ b/frontends/python/prepare_fuzz_imports.py
@@ -20,6 +20,7 @@ import importlib.util
 
 
 class FuzzerVisitor(ast.NodeVisitor):
+
     def __init__(self, ast_content):
         print("Hello")
         self.ast_content = ast_content
@@ -137,10 +138,10 @@ class FuzzerVisitor(ast.NodeVisitor):
                     if specs.submodule_search_locations:
                         for elem in specs.submodule_search_locations:
                             print("Checking --- %s" % (elem))
-                            if (
-                                ("/usr/local/lib/" in elem or "/usr/lib/" in elem)
-                                and "site-packages" not in elem
-                            ):
+                            if (("/usr/local/lib/" in elem
+                                 or "/usr/lib/" in elem)
+                                    and "site-packages" not in elem
+                                    and "dist-packages" not in elem):
                                 # skip packages that are builtin packacges
                                 # Check if we can refine
                                 if elem.count(".") > 1:


### PR DESCRIPTION
Similar fix to what we have done with code coverage: https://github.com/google/oss-fuzz/pull/10409

Ref: https://github.com/google/oss-fuzz/pull/11150