### PR TITLE
auto-fuzz: add poc for c-cpp fuzzer

### DIFF
--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -1350,6 +1350,24 @@ bool FuzzIntrospector::shouldRunIntrospector(Module &M) {
               "library, and thus we do not care about it. We only want to "
               "study the "
               "actual fuzzers. Exiting this run.\n");
+
+    if (getenv("FUZZ_INTROSPECTOR_AUTO_FUZZ")) {
+      logPrintf(L1, "Forcing analysis of all functions. This in auto-fuzz mode");
+
+      std::string TargetLogName;
+      std::string RandomStr = GenRandom(10);
+      int Idx = 0;
+      std::string prefix = "";
+      if (getenv("FUZZINTRO_OUTDIR")) {
+        prefix = std::string(getenv("FUZZINTRO_OUTDIR")) + "/";
+      }
+      do {
+        TargetLogName = formatv("{0}allFunctionsWithMain-{1}-{2}.yaml", prefix,
+                                std::to_string(Idx++), RandomStr);
+      } while (llvm::sys::fs::exists(TargetLogName));
+
+      extractAllFunctionDetailsToYaml(TargetLogName, M);
+    }
     return false;
   }
 


### PR DESCRIPTION
Adds setup such that the c/cpp now has a working PoC generating valid and good fuzzers for a simple project.

One of the changes needed for this is making some of fuzz introspector's functionality work with non-fuzzer binaries, i.e. to analyze libraries using the program analysis for fuzz introspector. There'll probably be more changes/improvements to this analysis.

The code is rough but am making a PR considering it now works. Will adjust in follow-up PR.s

When run on https://github.com/salzaverde/cppsimpleuri generates OSS-Fuzz integrations such as:


1)
`build.sh`:
```sh
#!/bin/bash
rm -rf //src/test-fuzz-build-1
cp -rf /src/cppsimpleuri /src/test-fuzz-build-1
cd /src/test-fuzz-build-1
mkdir fuzz-build
cd fuzz-build
cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" ../
make || true

$CXX $CXXFLAGS $LIB_FUZZING_ENGINE /src/empty-fuzzer.cpp /src/test-fuzz-build-1/fuzz-build/libcppsimpleuri.a -I/src/test-fuzz-build-1/include/salzaverde/detail -I/src/test-fuzz-build-1/include/salzaverde  -o /src/generated-fuzzer

```

```cpp
#include <iostream>
#include <stdlib.h>
#include <fuzzer/FuzzedDataProvider.h>

#include <query.h>
#include <encoder.h>
#include <uri.h>


extern "C" int 
LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
  FuzzedDataProvider fdp(data, size);
            
auto a0 = fdp.ConsumeRandomLengthString();
auto a1 = fdp.ConsumeRandomLengthString();
salzaverde::Query::parse(a0,a1);
return 0;
}

```

2)
 
 ```sh
 #!/bin/bash
rm -rf //src/test-fuzz-build-1
cp -rf /src/cppsimpleuri /src/test-fuzz-build-1
cd /src/test-fuzz-build-1
mkdir fuzz-build
cd fuzz-build
cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" ../
make || true

$CXX $CXXFLAGS $LIB_FUZZING_ENGINE /src/empty-fuzzer.cpp /src/test-fuzz-build-1/fuzz-build/libcppsimpleuri.a -I/src/test-fuzz-bui
ld-1/include/salzaverde/detail -I/src/test-fuzz-build-1/include/salzaverde  -o /src/generated-fuzzer

 ```
 
 ```cpp
 #include <iostream>
#include <stdlib.h>
#include <fuzzer/FuzzedDataProvider.h>

#include <query.h>
#include <encoder.h>
#include <uri.h>


extern "C" int 
LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
  FuzzedDataProvider fdp(data, size);
            
auto a0 = fdp.ConsumeRandomLengthString();
salzaverde::parseComponent(a0);
return 0;
}

 ```