### PR TITLE
Auto-fuzz: Fix problem for python fuzzer generation

### DIFF
--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
@@ -36,8 +36,9 @@ class PythonFuzzTarget(FuzzTarget):
 
         # Generate lines for importing necessary modules.
         import_to_add = "# Imports by the generated code\n"
-        for fuzz_import in self.imports_to_add:
-            import_to_add += "%s\n" % (fuzz_import)
+        for fuzz_import in set(self.imports_to_add):
+            if fuzz_import != "import ":
+                import_to_add += "%s\n" % (fuzz_import)
 
         # Open the base fuzzer and patch while reading through the file.
         with open(filename, "r") as f:
@@ -162,11 +163,11 @@ def cleanup_import(import_str):
 def give_right_path(import_str):
     split_import_str = import_str.split(".")
     try:
-        if split_import_str[1] == "src":
-            return ".".join(split_import_str[2:])
+        if split_import_str[0] == "src":
+            return ".".join(split_import_str[1:])
     except:
         pass
-    return ".".join(split_import_str[1:])
+    return ".".join(split_import_str)
 
 
 def get_arguments_to_provide(func_elem):
@@ -289,8 +290,7 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
             fuzzer_source_code += "  try:\n"
             fuzzer_source_code += "    %s(val_1)\n" % (r_fuzz_target)
             fuzzer_source_code += "  except ("
-            for exc in possible_target.exceptions_to_handle:
-                fuzzer_source_code += exc + ","
+            fuzzer_source_code += ",".join(possible_target.exceptions_to_handle)
             fuzzer_source_code += "):\n    pass\n"
             possible_target.fuzzer_source_code = fuzzer_source_code
 
@@ -352,8 +352,7 @@ def _generate_heuristic_3(yaml_dict, possible_targets):
             fuzzer_source_code += "  try:\n"
             fuzzer_source_code += "    %s(val_1)\n" % (func_name)
             fuzzer_source_code += "  except ("
-            for exc in possible_target.exceptions_to_handle:
-                fuzzer_source_code += exc + ","
+            fuzzer_source_code += ",".join(possible_target.exceptions_to_handle)
             fuzzer_source_code += "):\n    pass\n"
             possible_target.fuzzer_source_code = fuzzer_source_code
 
@@ -412,8 +411,7 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             fuzzer_source_code += "    c1.%s(val_1)\n" % (
                 possible_class_target_name)
             fuzzer_source_code += "  except("
-            for exc in exceptions_thrown:
-                fuzzer_source_code += exc + ","
+            fuzzer_source_code += ",".join(exceptions_thrown)
             fuzzer_source_code += "):\n"
             fuzzer_source_code += "    pass\n"
 
@@ -440,8 +438,7 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             fuzzer_source_code += "    c1.%s(val_2)\n" % (
                 possible_class_target_name)
             fuzzer_source_code += "  except("
-            for exc in exceptions_thrown:
-                fuzzer_source_code += exc + ","
+            fuzzer_source_code += ",".join(exceptions_thrown)
             fuzzer_source_code += "):\n"
             fuzzer_source_code += "    pass\n"
 
@@ -470,8 +467,7 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             fuzzer_source_code2 += "    c1.%s()\n" % (
                 possible_class_target_name)
             fuzzer_source_code2 += "  except("
-            for exc in exceptions_thrown:
-                fuzzer_source_code2 += exc + ","
+            fuzzer_source_code2 += ",".join(exceptions_thrown)
             fuzzer_source_code2 += "):\n"
             fuzzer_source_code2 += "    pass\n"
             possible_target2.fuzzer_source_code = fuzzer_source_code2
@@ -511,8 +507,7 @@ def impl_merge_heuristic_41(runs_to_merge):
 
     # Add exceptions
     fuzzer_source_code += "  except("
-    for exc in exceptions_thrown:
-        fuzzer_source_code += exc + ","
+    fuzzer_source_code += ",".join(exceptions_thrown)
     fuzzer_source_code += "):\n"
     fuzzer_source_code += "    pass\n"
 

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
@@ -59,21 +59,21 @@ class PythonFuzzTarget(FuzzTarget):
                     # First add the variables that should be seeded with fuzz data.
                     for var_name, var_type in self.variables_to_add:
                         if var_type == "str":
-                            content += f"  {var_name} = fdp.ConsumeUnicodeNoSurrogates(24)\n"
+                            content += f"    {var_name} = fdp.ConsumeUnicodeNoSurrogates(24)\n"
                         if var_type == "filename-b":
                             content += (
-                                f"  {var_name} = '/tmp/random_file.txt'\n"
-                                f"  with open({var_name}, 'wb') as f:\n"
-                                f"    f.write(fdp.ConsumeBytes(1024))\n")
+                                f"    {var_name} = '/tmp/random_file.txt'\n"
+                                f"    with open({var_name}, 'wb') as f:\n"
+                                f"        f.write(fdp.ConsumeBytes(1024))\n")
                         if var_type == "random-dict":
                             content += (
-                                f"  {var_name} = dict()\n"
-                                f"  {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeUnicodeNoSurrogates(24)\n"
-                                f"  {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeUnicodeNoSurrogates(24)\n"
-                                f"  {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeUnicodeNoSurrogates(24)\n"
-                                f"  {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = [fdp.ConsumeUnicodeNoSurrogates(24), 2]\n"
-                                f"  {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = 3\n"
-                                f"  {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeIntInRange(1, 10)\n"
+                                f"    {var_name} = dict()\n"
+                                f"    {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeUnicodeNoSurrogates(24)\n"
+                                f"    {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeUnicodeNoSurrogates(24)\n"
+                                f"    {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeUnicodeNoSurrogates(24)\n"
+                                f"    {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = [fdp.ConsumeUnicodeNoSurrogates(24), 2]\n"
+                                f"    {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = 3\n"
+                                f"    {var_name}[fdp.ConsumeUnicodeNoSurrogates(12)] = fdp.ConsumeIntInRange(1, 10)\n"
                             )
                         content += "\n"
 
@@ -222,12 +222,12 @@ def _generate_heuristic_1(yaml_dict, possible_targets):
 
                 # Create the actual source
                 fuzzer_source_code = ""
-                fuzzer_source_code += "  try:\n"
-                fuzzer_source_code += "    %s(val_1)\n" % (func_name)
-                fuzzer_source_code += "  except ("
+                fuzzer_source_code += "    try:\n"
+                fuzzer_source_code += "        %s(val_1)\n" % (func_name)
+                fuzzer_source_code += "    except ("
                 for exc in possible_target.exceptions_to_handle:
                     fuzzer_source_code += exc + ","
-                fuzzer_source_code += "):\n    pass\n"
+                fuzzer_source_code += "):\n        pass\n"
                 possible_target.fuzzer_source_code = fuzzer_source_code
 
                 # Set free variables and their types.
@@ -287,12 +287,12 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
 
             # Create the actual source
             fuzzer_source_code = ""
-            fuzzer_source_code += "  try:\n"
-            fuzzer_source_code += "    %s(val_1)\n" % (r_fuzz_target)
-            fuzzer_source_code += "  except ("
+            fuzzer_source_code += "    try:\n"
+            fuzzer_source_code += "        %s(val_1)\n" % (r_fuzz_target)
+            fuzzer_source_code += "    except ("
             fuzzer_source_code += ",".join(
                 possible_target.exceptions_to_handle)
-            fuzzer_source_code += "):\n    pass\n"
+            fuzzer_source_code += "):\n        pass\n"
             possible_target.fuzzer_source_code = fuzzer_source_code
 
             # Set free variables and their types.
@@ -350,12 +350,12 @@ def _generate_heuristic_3(yaml_dict, possible_targets):
 
             # Create the actual source
             fuzzer_source_code = ""
-            fuzzer_source_code += "  try:\n"
-            fuzzer_source_code += "    %s(val_1)\n" % (func_name)
-            fuzzer_source_code += "  except ("
+            fuzzer_source_code += "    try:\n"
+            fuzzer_source_code += "        %s(val_1)\n" % (func_name)
+            fuzzer_source_code += "    except ("
             fuzzer_source_code += ",".join(
                 possible_target.exceptions_to_handle)
-            fuzzer_source_code += "):\n    pass\n"
+            fuzzer_source_code += "):\n        pass\n"
             possible_target.fuzzer_source_code = fuzzer_source_code
 
             # Set free variables and their types.
@@ -408,14 +408,14 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             possible_class_target_name = elem['functionName'].split(".")[-1]
 
             fuzzer_source_code = "  # Class target.\n"
-            fuzzer_source_code += "  try:\n"
-            fuzzer_source_code += "    c1 = %s()\n" % (class_path)
-            fuzzer_source_code += "    c1.%s(val_1)\n" % (
+            fuzzer_source_code += "    try:\n"
+            fuzzer_source_code += "        c1 = %s()\n" % (class_path)
+            fuzzer_source_code += "        c1.%s(val_1)\n" % (
                 possible_class_target_name)
-            fuzzer_source_code += "  except("
+            fuzzer_source_code += "    except("
             fuzzer_source_code += ",".join(exceptions_thrown)
             fuzzer_source_code += "):\n"
-            fuzzer_source_code += "    pass\n"
+            fuzzer_source_code += "        pass\n"
 
             possible_target.fuzzer_source_code = fuzzer_source_code
             possible_target.imports_to_add.append("import %s" %
@@ -435,14 +435,14 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             possible_class_target_name = elem['functionName'].split(".")[-1]
 
             fuzzer_source_code = "  # Class target.\n"
-            fuzzer_source_code += "  try:\n"
-            fuzzer_source_code += "    c1 = %s(val_1)\n" % (class_path)
-            fuzzer_source_code += "    c1.%s(val_2)\n" % (
+            fuzzer_source_code += "    try:\n"
+            fuzzer_source_code += "        c1 = %s(val_1)\n" % (class_path)
+            fuzzer_source_code += "        c1.%s(val_2)\n" % (
                 possible_class_target_name)
-            fuzzer_source_code += "  except("
+            fuzzer_source_code += "    except("
             fuzzer_source_code += ",".join(exceptions_thrown)
             fuzzer_source_code += "):\n"
-            fuzzer_source_code += "    pass\n"
+            fuzzer_source_code += "        pass\n"
 
             possible_target3.fuzzer_source_code = fuzzer_source_code
             possible_target3.imports_to_add.append(
@@ -464,14 +464,14 @@ def _generate_heuristic_4(yaml_dict, possible_targets):
             fuzzer_source_code2 = "  # Class target.\n"
             fuzzer_source_code2 += "  # Heuristic name: %s .1\n" % (
                 HEURISTIC_NAME)
-            fuzzer_source_code2 += "  try:\n"
-            fuzzer_source_code2 += "    c1 = %s(val_1)\n" % (class_path)
-            fuzzer_source_code2 += "    c1.%s()\n" % (
+            fuzzer_source_code2 += "    try:\n"
+            fuzzer_source_code2 += "        c1 = %s(val_1)\n" % (class_path)
+            fuzzer_source_code2 += "        c1.%s()\n" % (
                 possible_class_target_name)
-            fuzzer_source_code2 += "  except("
+            fuzzer_source_code2 += "    except("
             fuzzer_source_code2 += ",".join(exceptions_thrown)
             fuzzer_source_code2 += "):\n"
-            fuzzer_source_code2 += "    pass\n"
+            fuzzer_source_code2 += "        pass\n"
             possible_target2.fuzzer_source_code = fuzzer_source_code2
             possible_target2.function_target = "%s.%s" % (
                 class_path, possible_class_target_name)
@@ -496,22 +496,22 @@ def impl_merge_heuristic_41(runs_to_merge):
             imports_to_add.add(im)
 
     fuzzer_source_code = "  # Class target.\n"
-    fuzzer_source_code += "  try:\n"
-    fuzzer_source_code += "    c1 = %s()\n" % (class_path)
+    fuzzer_source_code += "    try:\n"
+    fuzzer_source_code += "        c1 = %s()\n" % (class_path)
 
     # Add all functions
     variables_to_add = list()
     for func_to_hit in functions_to_hit:
         variable_to_add = ("val_%d" % (len(variables_to_add)), "str")
         variables_to_add.append(variable_to_add)
-        fuzzer_source_code += "    c1.%s(%s)\n" % (func_to_hit,
-                                                   variable_to_add[0])
+        fuzzer_source_code += "        c1.%s(%s)\n" % (func_to_hit,
+                                                       variable_to_add[0])
 
     # Add exceptions
-    fuzzer_source_code += "  except("
+    fuzzer_source_code += "    except("
     fuzzer_source_code += ",".join(exceptions_thrown)
     fuzzer_source_code += "):\n"
-    fuzzer_source_code += "    pass\n"
+    fuzzer_source_code += "        pass\n"
 
     print("=" * 60)
     print(fuzzer_source_code)

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
@@ -290,7 +290,8 @@ def _generate_heuristic_2(yaml_dict, possible_targets):
             fuzzer_source_code += "  try:\n"
             fuzzer_source_code += "    %s(val_1)\n" % (r_fuzz_target)
             fuzzer_source_code += "  except ("
-            fuzzer_source_code += ",".join(possible_target.exceptions_to_handle)
+            fuzzer_source_code += ",".join(
+                possible_target.exceptions_to_handle)
             fuzzer_source_code += "):\n    pass\n"
             possible_target.fuzzer_source_code = fuzzer_source_code
 
@@ -352,7 +353,8 @@ def _generate_heuristic_3(yaml_dict, possible_targets):
             fuzzer_source_code += "  try:\n"
             fuzzer_source_code += "    %s(val_1)\n" % (func_name)
             fuzzer_source_code += "  except ("
-            fuzzer_source_code += ",".join(possible_target.exceptions_to_handle)
+            fuzzer_source_code += ",".join(
+                possible_target.exceptions_to_handle)
             fuzzer_source_code += "):\n    pass\n"
             possible_target.fuzzer_source_code = fuzzer_source_code
 

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -484,7 +484,8 @@ def autofuzz_project_from_github(github_url,
             if language == "python":
                 # Change build.sh and Dockerfile
                 project_build_type = None
-                oss_fuzz_base_project.change_dockerfile(jdk, project_build_type)
+                oss_fuzz_base_project.change_dockerfile(
+                    jdk, project_build_type)
                 oss_fuzz_base_project.change_build_script(project_build_type)
                 possible_targets = fuzz_driver_generation_python.generate_possible_targets(
                     oss_fuzz_base_project.project_folder)

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -83,7 +83,7 @@ def build_project(oss_fuzz_base_project, base_oss_fuzz_project_dir,
             for jdk in constants.JDK_HOME:
                 jdk_dir = constants.JDK_HOME[jdk]
 
-                oss_fuzz_base_project.change_java_dockerfile(
+                oss_fuzz_base_project.change_dockerfile(
                     jdk, project_build_type)
                 oss_fuzz_base_project.change_build_script(project_build_type)
 
@@ -270,10 +270,9 @@ def build_and_test_single_possible_target(idx_folder,
               "w") as summary_file:
         json.dump(summary, summary_file)
 
-    if language == "java":
-        # Change build.sh and Dockerfile back to normal
-        dst_oss_fuzz_project.change_java_dockerfile(jdk, project_build_type)
-        dst_oss_fuzz_project.change_build_script(project_build_type)
+    # Change build.sh and Dockerfile back to normal
+    dst_oss_fuzz_project.change_dockerfile(jdk, project_build_type)
+    dst_oss_fuzz_project.change_build_script(project_build_type)
 
     # Cleanup oss-fuzz artifacts
     oss_fuzz_manager.cleanup_project(os.path.basename(auto_fuzz_proj_dir),
@@ -440,7 +439,7 @@ def autofuzz_project_from_github(github_url,
             # and avoid rebuild of project
             for key in constants.JDK_HOME:
                 if constants.JDK_HOME[key] == jdk_base:
-                    oss_fuzz_base_project.change_java_dockerfile(
+                    oss_fuzz_base_project.change_dockerfile(
                         key, project_build_type, False)
                     jdk = key
                     break
@@ -483,6 +482,10 @@ def autofuzz_project_from_github(github_url,
         if do_static_analysis and static_res:
             print("Generating fuzzers for %s" % (github_url))
             if language == "python":
+                # Change build.sh and Dockerfile
+                project_build_type = None
+                oss_fuzz_base_project.change_dockerfile(jdk, project_build_type)
+                oss_fuzz_base_project.change_build_script(project_build_type)
                 possible_targets = fuzz_driver_generation_python.generate_possible_targets(
                     oss_fuzz_base_project.project_folder)
             elif language == "java":

--- a/tools/auto-fuzz/objects/oss_fuzz_project.py
+++ b/tools/auto-fuzz/objects/oss_fuzz_project.py
@@ -108,10 +108,9 @@ class OSS_FUZZ_PROJECT:
                     self.language,
                     project_build_type=project_build_type))
 
-    def change_java_dockerfile(self,
-                               jdk_version,
-                               project_build_type,
-                               build_project=True):
+    def change_dockerfile(self, jdk_version=None,
+                          project_build_type=None,
+                          build_project=True):
         with open(self.dockerfile, "w") as docker_file:
             docker_file.write(
                 base_files.gen_dockerfile(

--- a/tools/auto-fuzz/objects/oss_fuzz_project.py
+++ b/tools/auto-fuzz/objects/oss_fuzz_project.py
@@ -108,7 +108,8 @@ class OSS_FUZZ_PROJECT:
                     self.language,
                     project_build_type=project_build_type))
 
-    def change_dockerfile(self, jdk_version=None,
+    def change_dockerfile(self,
+                          jdk_version=None,
                           project_build_type=None,
                           build_project=True):
         with open(self.dockerfile, "w") as docker_file:

--- a/tools/auto-fuzz/templates/python-introspector/fuzz_1.py
+++ b/tools/auto-fuzz/templates/python-introspector/fuzz_1.py
@@ -20,14 +20,14 @@ import atheris
 
 @atheris.instrument_func
 def TestOneInput(data):
-  fdp = atheris.FuzzedDataProvider(data)
+    fdp = atheris.FuzzedDataProvider(data)
 
 
 def main():
-  atheris.instrument_all()
-  atheris.Setup(sys.argv, TestOneInput)
-  atheris.Fuzz()
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/tools/auto-fuzz/templates/python-introspector/fuzz_1.py
+++ b/tools/auto-fuzz/templates/python-introspector/fuzz_1.py
@@ -1,19 +1,33 @@
 #!/usr/bin/python3
-
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
 import sys
 import atheris
 
 
 @atheris.instrument_func
 def TestOneInput(data):
-    fdp = atheris.FuzzedDataProvider(data)
+  fdp = atheris.FuzzedDataProvider(data)
 
 
 def main():
-    atheris.instrument_all()
-    atheris.Setup(sys.argv, TestOneInput)
-    atheris.Fuzz()
+  atheris.instrument_all()
+  atheris.Setup(sys.argv, TestOneInput)
+  atheris.Fuzz()
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/tools/auto-fuzz/templates/python/fuzz_1.py
+++ b/tools/auto-fuzz/templates/python/fuzz_1.py
@@ -20,14 +20,14 @@ import atheris
 
 @atheris.instrument_func
 def TestOneInput(data):
-  fdp = atheris.FuzzedDataProvider(data)
+    fdp = atheris.FuzzedDataProvider(data)
 
 
 def main():
-  atheris.instrument_all()
-  atheris.Setup(sys.argv, TestOneInput)
-  atheris.Fuzz()
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/tools/auto-fuzz/templates/python/fuzz_1.py
+++ b/tools/auto-fuzz/templates/python/fuzz_1.py
@@ -1,19 +1,33 @@
 #!/usr/bin/python3
-
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
 import sys
 import atheris
 
 
 @atheris.instrument_func
 def TestOneInput(data):
-    fdp = atheris.FuzzedDataProvider(data)
+  fdp = atheris.FuzzedDataProvider(data)
 
 
 def main():
-    atheris.instrument_all()
-    atheris.Setup(sys.argv, TestOneInput)
-    atheris.Fuzz()
+  atheris.instrument_all()
+  atheris.Setup(sys.argv, TestOneInput)
+  atheris.Fuzz()
 
 
 if __name__ == "__main__":
-    main()
+  main()


### PR DESCRIPTION
This PR fixes a few problems (as follows) for auto-fuzz generation on python project.

1. Wrong line indentation for generated fuzz_1.py
2. Missing license in fuzz_1.py template
3. Empty import statement for some heuristics
4. Incomplete exception list ending with comma
5. Wrong template files used after static analysis
6. Wrong stripping of class path.