### PR TITLE
Auto-fuzz: Refine heuristics for java fuzzer generation

### DIFF
--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
@@ -316,10 +316,8 @@ def _handle_argument(argType,
         return []
 
 
-def _search_static_factory_method(classname,
-                                  static_method_list,
-                                  possible_target,
-                                  max_target):
+def _search_static_factory_method(classname, static_method_list,
+                                  possible_target, max_target):
     """
     Search for all factory methods of the target class that statisfy all:
         - Public
@@ -361,11 +359,8 @@ def _search_static_factory_method(classname,
         arg_list = []
         for argType in func_elem['argTypes']:
             arg_list.extend(
-                _handle_argument(argType.replace('$', '.'),
-                                 None,
-                                 possible_target,
-                                 max_target, [],
-                                 False))
+                _handle_argument(argType.replace('$', '.'), None,
+                                 possible_target, max_target, [], False))
 
         # Error in some parameters
         if len(arg_list) != len(func_elem['argTypes']):
@@ -752,11 +747,8 @@ def _handle_object_creation(classname,
                     handled.append(elem)
                     for argType in elem['argTypes']:
                         arg = _handle_argument(argType.replace('$', '.'),
-                                               init_dict,
-                                               possible_target,
-                                               max_target,
-                                               handled,
-                                               True)
+                                               init_dict, possible_target,
+                                               max_target, handled, True)
                         if arg:
                             arg_list.append(arg)
                     if len(arg_list) != len(elem['argTypes']):
@@ -1137,8 +1129,11 @@ def _generate_heuristic_2(method_tuple, possible_targets, max_target):
             _search_static_factory_method(func_class, static_method_list,
                                           possible_target, max_target))
         object_creation_list.extend(
-            _handle_object_creation(func_class, init_dict, possible_target,
-                                    max_target, [], class_field=True))
+            _handle_object_creation(func_class,
+                                    init_dict,
+                                    possible_target,
+                                    max_target, [],
+                                    class_field=True))
 
         for object_creation_item in list(set(object_creation_list)):
             # Create possible target for all possible object creation

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
@@ -1056,6 +1056,10 @@ def _generate_heuristic_1(method_tuple, possible_targets, max_target):
         if len(arg_tuple_list) != len(func_elem['argTypes']):
             continue
 
+        # Create the actual source
+        fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
+        fuzzer_source_code += "  // Target method: %s\n" % (target_method_name)
+
         # Create fix parameters from random data
         arg_counter = 1
         for arg_tuple in arg_tuple_list:
@@ -1064,9 +1068,6 @@ def _generate_heuristic_1(method_tuple, possible_targets, max_target):
             possible_target.variables_to_add.append("arg%d" % arg_counter)
             arg_counter += 1
 
-        # Create the actual source
-        fuzzer_source_code = "  // Heuristic name: %s\n" % (HEURISTIC_NAME)
-        fuzzer_source_code += "  // Target method: %s\n" % (target_method_name)
         fuzzer_source_code += "%METHODCALL1%"
         fuzzer_source_code += "%METHODCALL2%"
         fuzzer_source_code += "%ASSERT%"
@@ -1091,12 +1092,19 @@ def _generate_heuristic_1(method_tuple, possible_targets, max_target):
         if func_return_type and func_return_type != "void":
             assert_possible_target = copy.deepcopy(possible_target)
             assert_possible_target.fuzzer_source_code = fuzzer_source_code.replace(
-                "%METHODCALL1%", "  %s result1 = %s.%s($VARIABLE$);\n" % (func_return_type, func_class, func_name)).replace(
-                "%METHODCALL2%", "  %s result2 = %s.%s($VARIABLE$);\n" % (func_return_type, func_class, func_name)).replace(
-                "%ASSERT%", '  assert result1.equals(result2) : "Result not match.";\n')
+                "%METHODCALL1%", "  %s result1 = %s.%s($VARIABLE$);\n" %
+                (func_return_type, func_class, func_name)).replace(
+                    "%METHODCALL2%", "  %s result2 = %s.%s($VARIABLE$);\n" %
+                    (func_return_type, func_class, func_name)
+                ).replace(
+                    "%ASSERT%",
+                    '  assert result1.equals(result2) : "Result not match.";\n'
+                )
             possible_targets.append(assert_possible_target)
 
-        possible_target.fuzzer_source_code = fuzzer_source_code.replace("%METHODCALL1%", "").replace("%METHODCALL2%", "").replace("%ASSERT%", "")
+        possible_target.fuzzer_source_code = fuzzer_source_code.replace(
+            "%METHODCALL1%", "").replace("%METHODCALL2%",
+                                         "").replace("%ASSERT%", "")
         possible_targets.append(possible_target)
 
 
@@ -1152,8 +1160,10 @@ def _generate_heuristic_2(method_tuple, possible_targets, max_target):
         # Get all possible argument lists with different possible object creation combination
         arg_tuple_list = []
         for argType in func_elem['argTypes']:
-            arg_list = _handle_argument(argType.replace('$', '.'), init_dict,
-                                        possible_target, max_target, [],
+            arg_list = _handle_argument(argType.replace('$', '.'),
+                                        init_dict,
+                                        possible_target,
+                                        max_target, [],
                                         enum_object=True)
             if arg_list:
                 arg_tuple_list.append((argType.replace('$', '.'), arg_list[0]))
@@ -1226,8 +1236,10 @@ def _generate_heuristic_2(method_tuple, possible_targets, max_target):
             if setting_source_code:
                 setting_possible_target = copy.deepcopy(cloned_possible_target)
                 setting_possible_target.fuzzer_source_code = fuzzer_source_code.replace(
-                    "%SETTINGS%", setting_source_code).replace("%METHODCALL1%", "  obj.%s($VARIABLE$)" % (func_name)).replace(
-                    "%METHODCALL2%", "").replace("%ASSERT%", "")
+                    "%SETTINGS%", setting_source_code).replace(
+                        "%METHODCALL1%",
+                        "  obj.%s($VARIABLE$)" % (func_name)).replace(
+                            "%METHODCALL2%", "").replace("%ASSERT%", "")
                 possible_targets.append(setting_possible_target)
 
             # If target method have valid reutrn type, duplicate the possible
@@ -1235,13 +1247,24 @@ def _generate_heuristic_2(method_tuple, possible_targets, max_target):
             if func_return_type and func_return_type != "void":
                 assert_possible_target = copy.deepcopy(cloned_possible_target)
                 assert_possible_target.fuzzer_source_code = fuzzer_source_code.replace(
-                    "%SETTINGS%", "").replace("%METHODCALL1%", "  %s result1 = obj.%s($VARIABLE$);\n" % (
-                    func_return_type, func_name)).replace("%METHODCALL2%", "  %s result2 = obj.%s($VARIABLE$);\n" % (
-                    func_return_type, func_name)).replace("%ASSERT%", '  assert result1.equals(result2) : "Result not match.";\n')
+                    "%SETTINGS%", ""
+                ).replace(
+                    "%METHODCALL1%", "  %s result1 = obj.%s($VARIABLE$);\n" %
+                    (func_return_type, func_name)
+                ).replace(
+                    "%METHODCALL2%", "  %s result2 = obj.%s($VARIABLE$);\n" %
+                    (func_return_type, func_name)
+                ).replace(
+                    "%ASSERT%",
+                    '  assert result1.equals(result2) : "Result not match.";\n'
+                )
                 possible_targets.append(assert_possible_target)
 
             cloned_possible_target.fuzzer_source_code = fuzzer_source_code.replace(
-                "%SETTINGS%", "").replace("%METHODCALL1%", "  obj.%s($VARIABLE$)" % (func_name)).replace("%METHODCALL2%", "").replace("%ASSERT%", "")
+                "%SETTINGS%",
+                "").replace("%METHODCALL1%",
+                            "  obj.%s($VARIABLE$)" % (func_name)).replace(
+                                "%METHODCALL2%", "").replace("%ASSERT%", "")
             possible_targets.append(cloned_possible_target)
 
 
@@ -1649,9 +1672,6 @@ def _generate_heuristics(yaml_dict,
     possible_targets.extend(temp_targets)
     temp_targets = []
     _generate_heuristic_2(method_tuple, temp_targets, max_target)
-    possible_targets.extend(temp_targets)
-    temp_targets = []
-    _generate_heuristic_7(method_tuple, temp_targets, max_target)
     possible_targets.extend(temp_targets)
     temp_targets = []
     _generate_heuristic_8(method_tuple, temp_targets, max_target)


### PR DESCRIPTION
Following #1292, this PR continue to refine the heuristics for java fuzzer generation which include the following changes.

1. Merge heuristic 7 to heuristic 1 and 2.
2. Merge heuristic 8 to heuristic 2.
3. Merge heuristic 9 to heuristic 2.
4. Remove heuristic 10 and related logic because it handles class object parameters which are not possible to retrieve from the current Java frontend using Soot, which makes the fuzzers generated by this heuristic always fail.
5. Rename heuristic 11 to heuristic 3.

This is the last PR for heuristics refinement. As a result, there are only 3 heuristics left. Heuristic 1 targets all static methods in the target project. Heuristic 2 targets all non-static methods in the target project with different consideration of object creation approaches (old heuristic 2-4) and special parameters combination (old heuristic 6-9). Heuristic 3 targets all the class constructor of the target project.

After the merge, all the fuzzers from the original heuristic 10 are dropped. And the duplicate fuzzers from old heuristic 2-4 and 6-9 and also dropped.