### PR TITLE
Auto-fuzz: Add serialising and deserialising for FuzzTarget object.

### DIFF
--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import json
 import yaml
 import constants
 import itertools
@@ -25,17 +26,18 @@ from objects.fuzz_target import FuzzTarget
 
 class JavaFuzzTarget(FuzzTarget):
 
-    def __init__(self, func_elem):
+    def __init__(self, func_elem=None):
         super().__init__()
 
-        # Method name in .data.yaml for java: [className].methodName(methodParameterList)
-        self.function_name = func_elem['functionName'].split('].')[1].split(
-            '(')[0]
-        self.function_target = get_target_method_statement(func_elem)
-        self.function_class = func_elem['functionSourceFile'].replace('$', '.')
-        self.exceptions_to_handle.extend(
-            func_elem['JavaMethodInfo']['exceptions'])
-        self.imports_to_add.extend(_handle_import(func_elem))
+        if func_elem:
+            # Method name in .data.yaml for java: [className].methodName(methodParameterList)
+            self.function_name = func_elem['functionName'].split('].')[1].split(
+                '(')[0]
+            self.function_target = get_target_method_statement(func_elem)
+            self.function_class = func_elem['functionSourceFile'].replace('$', '.')
+            self.exceptions_to_handle.extend(
+                func_elem['JavaMethodInfo']['exceptions'])
+            self.imports_to_add.extend(_handle_import(func_elem))
 
     def generate_patched_fuzzer(self, filename):
         """Patches the fuzzer in `filename`.
@@ -1360,4 +1362,11 @@ def generate_possible_targets(proj_folder, class_list, max_target,
         possible_targets, _ = _generate_heuristics(yaml_dict, max_target,
                                                    max_fuzzer, True)
 
-    return possible_targets
+    possible_targets_json_list = []
+    possible_targets_json_file = os.path.join(proj_folder, "possible_targets")
+    for possible_target in possible_targets:
+        possible_targets_json_list.append(possible_target.to_json())
+    with open(possible_targets_json_file, "w") as f:
+        f.write(json.dumps(possible_targets_json_list))
+
+    return possible_targets_json_file

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
@@ -31,10 +31,11 @@ class JavaFuzzTarget(FuzzTarget):
 
         if func_elem:
             # Method name in .data.yaml for java: [className].methodName(methodParameterList)
-            self.function_name = func_elem['functionName'].split('].')[1].split(
-                '(')[0]
+            self.function_name = func_elem['functionName'].split(
+                '].')[1].split('(')[0]
             self.function_target = get_target_method_statement(func_elem)
-            self.function_class = func_elem['functionSourceFile'].replace('$', '.')
+            self.function_class = func_elem['functionSourceFile'].replace(
+                '$', '.')
             self.exceptions_to_handle.extend(
                 func_elem['JavaMethodInfo']['exceptions'])
             self.imports_to_add.extend(_handle_import(func_elem))

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
@@ -612,4 +612,11 @@ def generate_possible_targets(proj_folder):
     _generate_heuristic_3(yaml_dict, possible_targets)
     _generate_heuristic_4(yaml_dict, possible_targets)
 
-    return possible_targets
+    possible_targets_json_list = []
+    possible_targets_json_file = os.path.join(proj_folder, "possible_targets")
+    for possible_target in possible_targets:
+        possible_targets_json_list.append(possible_target.to_json())
+    with open(possible_targets_json_file, "w") as f:
+        f.write(json.dumps(possible_targets_json_list))
+
+    return possible_targets_json_file

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import copy
 import stat
 import yaml
 import json
@@ -487,16 +488,24 @@ def autofuzz_project_from_github(github_url,
                 oss_fuzz_base_project.change_dockerfile(
                     jdk, project_build_type)
                 oss_fuzz_base_project.change_build_script(project_build_type)
-                possible_targets = fuzz_driver_generation_python.generate_possible_targets(
+                possible_targets_json_file = fuzz_driver_generation_python.generate_possible_targets(
                     oss_fuzz_base_project.project_folder)
+                base_object = fuzz_driver_generation_python.PythonFuzzTarget()
             elif language == "java":
                 projectdir = os.path.join(oss_fuzz_base_project.project_folder,
                                           oss_fuzz_base_project.project_name)
                 java_class_list = utils.extract_class_list(projectdir)
-                possible_targets = fuzz_driver_generation_java.generate_possible_targets(
+                possible_targets_json_file = fuzz_driver_generation_java.generate_possible_targets(
                     oss_fuzz_base_project.project_folder, java_class_list,
                     constants.MAX_TARGET_PER_PROJECT_HEURISTIC,
                     param_combination)
+                base_object = fuzz_driver_generation_java.JavaFuzzTarget()
+
+    with open(possible_targets_json_file, "r") as f:
+        for possible_target_str in json.loads(f.read()):
+            possible_target = copy.deepcopy(base_object)
+            possible_target.from_json(possible_target_str)
+            possible_targets.append(possible_target)
 
     print("Generated %d possible targets for %s." %
           (len(possible_targets), github_url))

--- a/tools/auto-fuzz/objects/fuzz_target.py
+++ b/tools/auto-fuzz/objects/fuzz_target.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import json
 import yaml
 import itertools
 
@@ -55,12 +56,32 @@ class FuzzTarget:
             "fuzzer_tear_down": ""
         }
 
-
-#    def __dict__(self):
-#        return {"function": self.function_target}
-
     def to_json(self):
-        return self.function_target
+        return json.dumps({
+            "function_class": self.function_class,
+            "function_name": self.function_name,
+            "fuzzer_source_code": self.fuzzer_source_code,
+            "function_target": self.function_target,
+            "exceptions_to_handle": self.exceptions_to_handle,
+            "variables_to_add": self.variables_to_add,
+            "imports_to_add": self.imports_to_add,
+            "heuristics_used": self.heuristics_used,
+            "class_field_list": self.class_field_list,
+            "extra_source_code": self.extra_source_code
+        })
+
+    def from_json(self, json_str):
+        obj = json.loads(json_str)
+        self.function_class = obj['function_class']
+        self.function_name = obj['function_name']
+        self.fuzzer_source_code = obj['fuzzer_source_code']
+        self.function_target = obj['function_target']
+        self.exceptions_to_handle = obj['exceptions_to_handle']
+        self.variables_to_add = obj['variables_to_add']
+        self.imports_to_add = obj['imports_to_add']
+        self.heuristics_used = obj['heuristics_used']
+        self.class_field_list = obj['class_field_list']
+        self.extra_source_code = obj['extra_source_code']
 
     def __str__(self):
         return self.function_target


### PR DESCRIPTION
This is the first PR aiming to move the fuzzer_generator process into docker containers. This PR adds additional functionality to allow serialising and deserialising of FuzzTarget object. This setting allows the fuzzer_generator of different language to store the result in a file (instead of directly returning a python list for possible targets) for the manager to process which make the fuzzer_generator possible to work in a docker image in later PRs.