### PR TITLE
Auto-fuzz: Add new OSS-Fuzz template files for fuzzer generation

### DIFF
--- a/tools/auto-fuzz/templates/base_files.py
+++ b/tools/auto-fuzz/templates/base_files.py
@@ -50,7 +50,8 @@ def gen_builder_1(language="python",
                   param_combination=False):
     if fuzzer_generator:
         template_dir = _get_template_directory("fuzzer-generator", None)
-        return _gen_builder_1_generator(template_dir, language, class_list, param_combination)
+        return _gen_builder_1_generator(template_dir, language, class_list,
+                                        param_combination)
 
     template_dir = _get_template_directory(language, project_build_type)
 
@@ -168,7 +169,8 @@ def _gen_builder_1_java(template_dir, build_project, project_build_type):
         return BASE_BUILDER % (": <<'COMMENT'", "COMMENT", "", "", "")
 
 
-def _gen_builder_1_generator(template_dir, language, class_list, param_combination):
+def _gen_builder_1_generator(template_dir, language, class_list,
+                             param_combination):
     with open(os.path.join(template_dir, "build.py-template"), "r") as file:
         BASE_BUILDER = "#!/usr/bin/python3\n" + file.read()
 

--- a/tools/auto-fuzz/templates/base_files.py
+++ b/tools/auto-fuzz/templates/base_files.py
@@ -36,13 +36,22 @@ def gen_dockerfile(github_url,
         return _gen_dockerfile_java(github_url, project_name, jdk_version,
                                     build_project, template_dir,
                                     project_build_type)
+    elif language == "fuzzer-generator":
+        return _gen_dockerfile_generator(template_dir)
     else:
         return ""
 
 
 def gen_builder_1(language="python",
                   project_build_type=None,
-                  build_project=True):
+                  build_project=True,
+                  fuzzer_generator=False,
+                  class_list=[],
+                  param_combination=False):
+    if fuzzer_generator:
+        template_dir = _get_template_directory("fuzzer-generator", None)
+        return _gen_builder_1_generator(template_dir, language, class_list, param_combination)
+
     template_dir = _get_template_directory(language, project_build_type)
 
     if not template_dir:
@@ -128,6 +137,11 @@ def _gen_dockerfile_java(github_url, project_name, jdk_version, build_project,
         return ""
 
 
+def _gen_dockerfile_generator(template_dir):
+    with open(os.path.join(template_dir, "Dockerfile-template"), "r") as file:
+        return file.read()
+
+
 def _gen_builder_1_python(template_dir):
     with open(os.path.join(template_dir, "build.sh-template"), "r") as file:
         BASE_BUILDER = "#!/bin/bash -eu\n" + file.read()
@@ -152,6 +166,13 @@ def _gen_builder_1_java(template_dir, build_project, project_build_type):
                                INTROSPECTOR_BUILDER)
     else:
         return BASE_BUILDER % (": <<'COMMENT'", "COMMENT", "", "", "")
+
+
+def _gen_builder_1_generator(template_dir, language, class_list, param_combination):
+    with open(os.path.join(template_dir, "build.py-template"), "r") as file:
+        BASE_BUILDER = "#!/usr/bin/python3\n" + file.read()
+
+    return BASE_BUILDER % (language, ",".join(class_list), param_combination)
 
 
 def _gen_base_fuzzer_python(template_dir):

--- a/tools/auto-fuzz/templates/fuzzer-generator/Dockerfile-template
+++ b/tools/auto-fuzz/templates/fuzzer-generator/Dockerfile-template
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##########################################################################
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN pip3 install --upgrade pip && pip3 install cython
+
+RUN rm -rf /fuzz-introspector/tools/auto-fuzz/fuzzer_generator
+RUN rm -rf /fuzz-introspector/tools/auto-fuzz/objects
+COPY fuzzer_generator /fuzz-introspector/tools/auto-fuzz/fuzzer_generator
+COPY objects /fuzz-introspector/tools/auto-fuzz/objects
+COPY constants.py /fuzz-introspector/tools/auto-fuzz
+COPY work $SRC/work
+COPY build.py /fuzz-introspector/tools/auto-fuzz/fuzzer_generator/
+
+RUN cd /fuzz-introspector && \
+    pip3 install -r ./requirements.txt && \
+    echo "python3 /fuzz-introspector/tools/auto-fuzz/fuzzer_generator/build.py" > $SRC/build.sh
+
+WORKDIR /fuzz-introspector/tools/auto-fuzz/fuzzer_generator

--- a/tools/auto-fuzz/templates/fuzzer-generator/build.py-template
+++ b/tools/auto-fuzz/templates/fuzzer-generator/build.py-template
@@ -1,4 +1,4 @@
-# Copyright 2023 Fuzz Introspector Authors
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,24 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 ##########################################################################
-FROM ubuntu:22.04@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
+import fuzz_driver_generation_%s as generator
+import shutil
+import sys
+import os
 
-RUN apt-get update && \
-    apt-get install pip git -y
+sys.path.append('..')
+import constants
 
-ENV SRC /src
-ENV OUT /out
-
-RUN mkdir -p $SRC && \
-    mkdir -p $OUT
-
-COPY fuzz-introspector $SRC/fuzz-introspector
-COPY work $SRC/work
-
-RUN cd $SRC/fuzz-introspector && \
-    git submodule init && \
-    git submodule update && \
-    pip3 install -r ./requirements.txt
-
-WORKDIR $SRC/fuzz-introspector/tools/auto-fuzz
+class_list_str = "%s"
+project_dir = os.getenv("SRC")
+generator.generate_possible_targets(project_dir, class_list_str.split(","), constants.MAX_TARGET_PER_PROJECT_HEURISTIC, %s)
+shutil.copy(os.path.join(project_dir, "possible_targets"), os.getenv("OUT"))

--- a/tools/auto-fuzz/templates/fuzzer-generator/project.yaml
+++ b/tools/auto-fuzz/templates/fuzzer-generator/project.yaml
@@ -1,0 +1,10 @@
+homepage: https://github.com/ossf/fuzz-introspector
+main_repo: https://github.com/ossf/fuzz-introspector
+language: python
+fuzzing_engines:
+- libfuzzer
+sanitizers:
+- address
+- undefined
+primary_contacts: autofuzz@fuzz-introspector.com
+%s%s


### PR DESCRIPTION
This PR adds a new OSS-Fuzz base files template for fuzzer generation process. The new logics in the later PR uses the new template to run fuzzer generators for different language in the OSS-Fuzz docker container.