### PR TITLE
Auto-Fuzz: Use OSS-Fuzz docker container to complete fuzzer generation

### DIFF
--- a/tools/auto-fuzz/README.md
+++ b/tools/auto-fuzz/README.md
@@ -18,16 +18,6 @@ cd $WORKDIR
 git clone https://github.com/google/oss-fuzz
 git clone https://github.com/ossf/fuzz-introspector
 
-cd fuzz-introspector
-git submodule init
-git submodule update
-
-python3 -m virtualenv .venv
-. .venv/bin/activate
-pip3 install -r ./requirements.txt
-cd frontends/python/PyCG
-pip3 install .
-
 # Go into auto-fuzz
 cd ../../../tools/auto-fuzz/
 

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_java.py
@@ -15,13 +15,13 @@
 import os
 import json
 import yaml
-import constants
 import itertools
 import sys
 import copy
 
 sys.path.append('..')
 from objects.fuzz_target import FuzzTarget
+import constants
 
 
 class JavaFuzzTarget(FuzzTarget):

--- a/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
+++ b/tools/auto-fuzz/fuzzer_generator/fuzz_driver_generation_python.py
@@ -594,7 +594,8 @@ def merge_stage_one_targets(target_runs):
     return []
 
 
-def generate_possible_targets(proj_folder):
+def generate_possible_targets(proj_folder, class_list, max_target,
+                              param_combination):
     """Generate all possible targets for a given project folder"""
 
     # Read the Fuzz Introspector generated data

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -495,7 +495,10 @@ def autofuzz_project_from_github(github_url,
             projectdir = os.path.join(oss_fuzz_base_project.project_folder,
                                       oss_fuzz_base_project.project_name)
             class_list = utils.extract_class_list(projectdir)
-            possible_targets_json_file = utils.generate_possible_targets(basedir, OSS_FUZZ_BASE, language, oss_fuzz_base_project.project_folder, class_list, param_combination)
+            possible_targets_json_file = utils.generate_possible_targets(
+                basedir, OSS_FUZZ_BASE, language,
+                oss_fuzz_base_project.project_folder, class_list,
+                param_combination)
 
     if possible_targets_json_file:
         with open(possible_targets_json_file, "r") as f:

--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -488,24 +488,22 @@ def autofuzz_project_from_github(github_url,
                 oss_fuzz_base_project.change_dockerfile(
                     jdk, project_build_type)
                 oss_fuzz_base_project.change_build_script(project_build_type)
-                possible_targets_json_file = fuzz_driver_generation_python.generate_possible_targets(
-                    oss_fuzz_base_project.project_folder)
                 base_object = fuzz_driver_generation_python.PythonFuzzTarget()
             elif language == "java":
-                projectdir = os.path.join(oss_fuzz_base_project.project_folder,
-                                          oss_fuzz_base_project.project_name)
-                java_class_list = utils.extract_class_list(projectdir)
-                possible_targets_json_file = fuzz_driver_generation_java.generate_possible_targets(
-                    oss_fuzz_base_project.project_folder, java_class_list,
-                    constants.MAX_TARGET_PER_PROJECT_HEURISTIC,
-                    param_combination)
                 base_object = fuzz_driver_generation_java.JavaFuzzTarget()
 
-    with open(possible_targets_json_file, "r") as f:
-        for possible_target_str in json.loads(f.read()):
-            possible_target = copy.deepcopy(base_object)
-            possible_target.from_json(possible_target_str)
-            possible_targets.append(possible_target)
+            projectdir = os.path.join(oss_fuzz_base_project.project_folder,
+                                      oss_fuzz_base_project.project_name)
+            class_list = utils.extract_class_list(projectdir)
+            possible_targets_json_file = utils.generate_possible_targets(basedir, OSS_FUZZ_BASE, language, oss_fuzz_base_project.project_folder, class_list, param_combination)
+
+    if possible_targets_json_file:
+        with open(possible_targets_json_file, "r") as f:
+            for possible_target_str in json.loads(f.read()):
+                possible_target = copy.deepcopy(base_object)
+
+                possible_target.from_json(possible_target_str)
+                possible_targets.append(possible_target)
 
     print("Generated %d possible targets for %s." %
           (len(possible_targets), github_url))

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -222,7 +222,8 @@ def copy_build_file(OSS_FUZZ_BASE, basedir, language):
 
 # Fuzzer generator utils
 ########################
-def generate_possible_targets(auto_fuzz_base, oss_fuzz_base, language, project_dir, class_list, param_combination):
+def generate_possible_targets(auto_fuzz_base, oss_fuzz_base, language,
+                              project_dir, class_list, param_combination):
     """Generator possible targets by calling fuzzer generator of different
     languages in a OSS-Fuzz docker container. The json serialised possible
     target list is stored in $OUT/possible_targets and is copied back to
@@ -238,17 +239,25 @@ def generate_possible_targets(auto_fuzz_base, oss_fuzz_base, language, project_d
         f.write(base_files.gen_dockerfile("", "", "fuzzer-generator"))
 
     with open(os.path.join(temp_dir, "build.py"), "w") as f:
-        f.write(base_files.gen_builder_1(language, fuzzer_generator=True, class_list=class_list, param_combination=param_combination))
+        f.write(
+            base_files.gen_builder_1(language,
+                                     fuzzer_generator=True,
+                                     class_list=class_list,
+                                     param_combination=param_combination))
 
     with open(os.path.join(temp_dir, "project.yaml"), "w") as f:
         f.write(base_files.gen_project_yaml("", "fuzzer-generator"))
 
     # Copy needed files for fuzzer generation
     copy_files = {
-        os.path.join(auto_fuzz_base, "fuzzer_generator") : os.path.join(temp_dir, "fuzzer_generator"),
-        os.path.join(auto_fuzz_base, "objects") : os.path.join(temp_dir, "objects"),
-        os.path.join(auto_fuzz_base, "constants.py") : os.path.join(temp_dir, "constants.py"),
-        os.path.join(project_dir, "work") : os.path.join(temp_dir, "work")
+        os.path.join(auto_fuzz_base, "fuzzer_generator"):
+        os.path.join(temp_dir, "fuzzer_generator"),
+        os.path.join(auto_fuzz_base, "objects"):
+        os.path.join(temp_dir, "objects"),
+        os.path.join(auto_fuzz_base, "constants.py"):
+        os.path.join(temp_dir, "constants.py"),
+        os.path.join(project_dir, "work"):
+        os.path.join(temp_dir, "work")
     }
     for src_file in copy_files:
         if os.path.isdir(src_file):
@@ -260,7 +269,8 @@ def generate_possible_targets(auto_fuzz_base, oss_fuzz_base, language, project_d
     oss_fuzz_manager.copy_and_build_project(temp_dir, oss_fuzz_base)
 
     # Copy $OUT/possible_targets to {project_dir}
-    out_dir = os.path.join(oss_fuzz_base, "build", "out", "temp-fuzzer-generator")
+    out_dir = os.path.join(oss_fuzz_base, "build", "out",
+                           "temp-fuzzer-generator")
     src_file = os.path.join(out_dir, "possible_targets")
     dst_file = os.path.join(project_dir, "possible_targets")
     try:
@@ -271,7 +281,8 @@ def generate_possible_targets(auto_fuzz_base, oss_fuzz_base, language, project_d
     # Clean temp_dir and directory in OSS-Fuzz
     try:
         shutil.rmtree(temp_dir)
-        shutil.rmtree(os.path.join(oss_fuzz_base, "projects", "temp-fuzzer-generator"))
+        shutil.rmtree(
+            os.path.join(oss_fuzz_base, "projects", "temp-fuzzer-generator"))
         oss_fuzz_manager.clean_project("temp-fuzzer-generator", oss_fuzz_base)
     except:
         pass

--- a/tools/auto-fuzz/utils.py
+++ b/tools/auto-fuzz/utils.py
@@ -16,6 +16,7 @@ import constants
 import os
 import shutil
 import subprocess
+import oss_fuzz_manager
 from templates import base_files
 
 
@@ -217,6 +218,68 @@ def copy_build_file(OSS_FUZZ_BASE, basedir, language):
                     return False
 
     return True
+
+
+# Fuzzer generator utils
+########################
+def generate_possible_targets(auto_fuzz_base, oss_fuzz_base, language, project_dir, class_list, param_combination):
+    """Generator possible targets by calling fuzzer generator of different
+    languages in a OSS-Fuzz docker container. The json serialised possible
+    target list is stored in $OUT/possible_targets and is copied back to
+    {project_dir} at the end."""
+
+    # Create a temp directory for the docker run
+    temp_dir = os.path.join(project_dir, "temp-fuzzer-generator")
+    if not os.path.exists(temp_dir):
+        os.mkdir(temp_dir)
+
+    # Generate base file for the temp directory
+    with open(os.path.join(temp_dir, "Dockerfile"), "w") as f:
+        f.write(base_files.gen_dockerfile("", "", "fuzzer-generator"))
+
+    with open(os.path.join(temp_dir, "build.py"), "w") as f:
+        f.write(base_files.gen_builder_1(language, fuzzer_generator=True, class_list=class_list, param_combination=param_combination))
+
+    with open(os.path.join(temp_dir, "project.yaml"), "w") as f:
+        f.write(base_files.gen_project_yaml("", "fuzzer-generator"))
+
+    # Copy needed files for fuzzer generation
+    copy_files = {
+        os.path.join(auto_fuzz_base, "fuzzer_generator") : os.path.join(temp_dir, "fuzzer_generator"),
+        os.path.join(auto_fuzz_base, "objects") : os.path.join(temp_dir, "objects"),
+        os.path.join(auto_fuzz_base, "constants.py") : os.path.join(temp_dir, "constants.py"),
+        os.path.join(project_dir, "work") : os.path.join(temp_dir, "work")
+    }
+    for src_file in copy_files:
+        if os.path.isdir(src_file):
+            shutil.copytree(src_file, copy_files[src_file])
+        elif os.path.isfile(src_file):
+            shutil.copy(src_file, copy_files[src_file])
+
+    # Copy and run the fuzzer generator in OSS-Fuzz docker container
+    oss_fuzz_manager.copy_and_build_project(temp_dir, oss_fuzz_base)
+
+    # Copy $OUT/possible_targets to {project_dir}
+    out_dir = os.path.join(oss_fuzz_base, "build", "out", "temp-fuzzer-generator")
+    src_file = os.path.join(out_dir, "possible_targets")
+    dst_file = os.path.join(project_dir, "possible_targets")
+    try:
+        shutil.copy(src_file, dst_file)
+    except:
+        pass
+
+    # Clean temp_dir and directory in OSS-Fuzz
+    try:
+        shutil.rmtree(temp_dir)
+        shutil.rmtree(os.path.join(oss_fuzz_base, "projects", "temp-fuzzer-generator"))
+        oss_fuzz_manager.clean_project("temp-fuzzer-generator", oss_fuzz_base)
+    except:
+        pass
+
+    if os.path.isfile(dst_file):
+        return dst_file
+    else:
+        return None
 
 
 # Project cleaning utils


### PR DESCRIPTION
Following #1312, this PR uses the newly created OSS-Fuzz base file templates to run the fuzzer generation process. This eliminate the need to install separate virtual environment and dependencies for the Auto-fuzz user.

This PR needs rebase after #1312 is merged in.