### PR TITLE
Auto-fuzz: Add project clean and mute log

### DIFF
--- a/tools/auto-fuzz/manager.py
+++ b/tools/auto-fuzz/manager.py
@@ -278,6 +278,8 @@ def build_and_test_single_possible_target(idx_folder,
     # Cleanup oss-fuzz artifacts
     oss_fuzz_manager.cleanup_project(os.path.basename(auto_fuzz_proj_dir),
                                      OSS_FUZZ_BASE)
+    utils.cleanup_base_directory(auto_fuzz_proj_dir,
+                                 os.path.basename(auto_fuzz_proj_dir))
 
     # Cleanup source code folders in auto fuzz dir and in oss-fuzz dir.
     for src_dir in os.listdir(auto_fuzz_proj_dir):

--- a/tools/auto-fuzz/oss_fuzz_manager.py
+++ b/tools/auto-fuzz/oss_fuzz_manager.py
@@ -136,7 +136,9 @@ def cleanup_project(proj_name, oss_fuzz_base):
 
     oss_fuzz_docker_cmd.extend(oss_fuzz_project_docker_args)
     try:
-        subprocess.check_call(oss_fuzz_docker_cmd)
+        subprocess.check_call(oss_fuzz_docker_cmd,
+                              stderr=subprocess.DEVNULL,
+                              stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
         pass
 
@@ -151,7 +153,7 @@ def cleanup_project(proj_name, oss_fuzz_base):
 
     try:
         shutil.rmtree(os.path.join(oss_fuzz_base, "projects", proj_name))
-    except shutil.Error:
+    except:
         pass
 
     return True


### PR DESCRIPTION
This PR adds in project cleaning for the build_jar directory which are used to avoid rebuilding of projects. This PR also adds in logic to mute the oss_fuzz_manager calls to OSS-Fuzz.