### PR TITLE
Auto-fuzz: Fix duplicate fuzzer bug

### DIFF
--- a/tools/auto-fuzz/templates/java-ant/build.sh-template
+++ b/tools/auto-fuzz/templates/java-ant/build.sh-template
@@ -58,6 +58,7 @@ done
 %s
 %s
 JARFILE_LIST=
+rm -f $SRC/build_jar/Fuzz.jar
 for JARFILE in `ls $SRC/build_jar/*.jar`
 do
   cp $JARFILE $OUT/

--- a/tools/auto-fuzz/templates/java-gradle/build.sh-template
+++ b/tools/auto-fuzz/templates/java-gradle/build.sh-template
@@ -57,6 +57,7 @@ fi
 
 
 JARFILE_LIST=
+rm -f $SRC/build_jar/Fuzz.jar
 for JARFILE in $(find ./  -name "*.jar")
 do
   if [[ "$JARFILE" == *"target/"* ]] || [[ "$JARFILE" == *"build/"* ]] || [[ "$JARFILE" == *"dist/"* ]]

--- a/tools/auto-fuzz/templates/java-maven/build.sh-template
+++ b/tools/auto-fuzz/templates/java-maven/build.sh-template
@@ -83,6 +83,7 @@ done
 %s
 %s
 JARFILE_LIST=
+rm -f $SRC/build_jar/Fuzz.jar
 for JARFILE in `ls $SRC/build_jar/*.jar`
 do
   cp $JARFILE $OUT/


### PR DESCRIPTION
In #1269, each Java target project are only build once before static analysis and all the build jar files are reused. The logic does not exclude the Fuzz.jar for storing the class file of the compiled plain Fuzz.java used in the static analysis. Thus the Fuzz.jar will also be copied to the generated folder for each of the possible targets and include in the class path for executing the generated Fuzzer. Since the Fuzz.jar appears early in the classpath list, the Fuzz.class inside the jar file are always used instead of the Fuzz.class compiled lively for the generated Fuzz.java. This cause the fuzzer validation stage always getting the result of fuzzing the plain Fuzz.java instead of the result of running the generated fuzzers. This PR fixes the bug by excluding the Fuzz.jar during the fuzzer validation stage to ensure the validation is done on the real generated fuzzer.