### PR TITLE
web_app: Fix inconsistent naming for project-summary endpoint

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -477,8 +477,8 @@ def api_project_summary():
         'result': 'success',
         'project': {
             'name': project_name,
-            'runtime-coverage-data': project.coverage_data,
-            'introspector-data': project.introspector_data
+            'runtime_coverage_data': project.coverage_data,
+            'introspector_data': project.introspector_data
         }
     }
 

--- a/tools/web-fuzzing-introspection/app/webapp/templates/api.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/api.html
@@ -282,7 +282,7 @@ $ curl -L https://introspector.oss-fuzz.com/api/far-reach-but-low-coverage?proje
 <div class="card card-body">
   <pre>{
   "project": {
-    "introspector-data": {
+    "introspector_data": {
     "annotated_cfg": [ {
       "fuzzer_name": string,
       "destinations": [ {
@@ -298,7 +298,7 @@ $ curl -L https://introspector.oss-fuzz.com/api/far-reach-but-low-coverage?proje
       "src_file": string,
     } ],
     "branch_pairs": [ {
-      "blocked_runtime-coverage": integer,
+      "blocked_runtime_coverage": integer,
       "function_name": string,
       "project": string,
     } ],
@@ -310,7 +310,7 @@ $ curl -L https://introspector.oss-fuzz.com/api/far-reach-but-low-coverage?proje
     "static_reachability": number
   },
   "name": string,
-  "runtime-coverage-data": {
+  "runtime_coverage_data": {
       "coverage_url": string,
       "line_coverage": {
           "count": integer,
@@ -394,7 +394,7 @@ $ curl -L https://introspector.oss-fuzz.com/api/project-summary?project=json-c |
           "static_reachability": 63.40996168582376
       },
       "name": "json-c",
-      "runtime-coverage-data": {
+      "runtime_coverage_data": {
           "coverage_url": "https://storage.googleapis.com/oss-fuzz-coverage/json-c/reports/20231120/linux/report.html",
           "line_coverage": {
               "count": 3150,


### PR DESCRIPTION
Somehow these names where missed twice in the refactoring;
- #1322 
- #1319 

Ref: #1318 