### PR TITLE
webapp: show links to old coverage reports

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -89,6 +89,8 @@
                     <td>Code coverage report</td>
                       {% if has_project_details %}
                         <td><a href="{{ project.coverage_data.coverage_url }}">Report link</a></td>
+                      {% elif latest_coverage_report != None %}
+                      <td>(Latest report from {{coverage_date}}) <a href="{{ latest_coverage_report }}">Report link</a></td>
                       {% else %}
                         <td>N/A</td>
                       {% endif %}


### PR DESCRIPTION
This is useful for when projects no longer have working coverage builds, then we still have links to old coverage reports.