### PR TITLE
webapp: show all projects with data in profile-overview

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -189,9 +189,11 @@ def project_profile():
         # Get statistics of the project
         project_statistics = data_storage.PROJECT_TIMESTAMPS
         real_stats = []
+        latest_statistics = None
         for ps in project_statistics:
             if ps.project_name == project.name:
                 real_stats.append(ps)
+                latest_statistics = ps
 
         # Get functions of interest for the project
         # Display a maximum of 10 functions of interest. Down the line, this
@@ -222,7 +224,8 @@ def project_profile():
                                has_project_stats=True,
                                project_build_status=project_build_status,
                                functions_of_interest=functions_of_interest,
-                               latest_coverage_report=None)
+                               latest_coverage_report=None,
+                               latest_statistics=latest_statistics)
 
     # Either this is a wrong project or we only have a build status for it
     all_build_status = data_storage.get_build_status()
@@ -236,14 +239,17 @@ def project_profile():
                 coverage_data=None,
                 introspector_data=None,
             )
+
             # Get statistics of the project
             project_statistics = data_storage.PROJECT_TIMESTAMPS
             real_stats = []
             datestr = None
+            latest_statistics = None
             for ps in project_statistics:
                 if ps.project_name == project.name:
                     real_stats.append(ps)
                     datestr = ps.date
+                    latest_statistics = ps
 
             if len(real_stats) > 0:
                 latest_coverage_report = get_coverage_report_url(
@@ -260,7 +266,8 @@ def project_profile():
                 project_build_status=build_status,
                 functions_of_interest=[],
                 latest_coverage_report=latest_coverage_report,
-                coverage_date=datestr)
+                coverage_date=datestr,
+                latest_statistics=latest_statistics)
     print("Nothing to do. We shuold probably have a 404")
     return redirect("/")
 
@@ -315,15 +322,17 @@ def function_search():
 
 @blueprint.route('/projects-overview')
 def projects_overview():
-    all_projects = data_storage.get_projects()
-    projects_to_use = []
-    # Only include fuzz introspector projects
-    for project in all_projects:
-        #if project.introspector_data != None:
-        projects_to_use.append(project)
+    # Get statistics of the project
+    project_statistics = data_storage.PROJECT_TIMESTAMPS
+    latest_coverage_profiles = dict()
+    real_stats = []
+    latest_statistics = None
+    for ps in project_statistics:
+        latest_coverage_profiles[ps.project_name] = ps
+
     return render_template('projects-overview.html',
                            gtag=gtag,
-                           all_projects=projects_to_use)
+                           all_projects=latest_coverage_profiles.values())
 
 
 def oracle_1(all_functions, all_projects):

--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -55,13 +55,19 @@
                   </tr>                                    
                   <tr>
                     <td>Fuzzer count</td>
-                      <td> {{ project.fuzzer_count }}</td>
+                    {% if latest_statistics != None %}
+                      <td> {{latest_statistics.fuzzer_count }}</td>
+                    {% else %}
+                    <td> 0 </td>
+                    {% endif %}
                   </tr>
                   <tr>
                     <td>Lines of code</td>
                     <td>
                       {% if project.coverage_data is not none %} 
                         {{ project.coverage_data.line_coverage.count }}
+                      {% elif latest_statistics != None %}
+                        {{ latest_statistics.coverage_data.line_coverage.count }}
                       {% else %}
                         N/A
                       {% endif %} 
@@ -72,6 +78,8 @@
                     <td>
                       {% if project.coverage_data is not none %}
                         {{ project.coverage_data.line_coverage.covered }}
+                      {% elif latest_statistics != None %}
+                        {{ latest_statistics.coverage_data.line_coverage.covered }}
                       {% else %}
                         N/A
                       {% endif %} 
@@ -79,11 +87,15 @@
                   </tr>
                   <tr>
                     <td>Code coverage</td>
+                    <td>
                     {% if has_project_details %}
-                      <td> {{ '%0.2f' % project.coverage_data.line_coverage.percent |float}}% </td>
+                      {{ '%0.2f' % project.coverage_data.line_coverage.percent |float}}%
+                    {% elif latest_statistics != None %}
+                        {{ latest_statistics.coverage_data.line_coverage.percent }}%
                     {% else %}
-                      <td>N/A</td>
+                      N/A
                     {% endif %}
+                  </td>
                   </tr>
                   <tr>
                     <td>Code coverage report</td>

--- a/tools/web-fuzzing-introspection/app/webapp/templates/projects-overview.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/projects-overview.html
@@ -35,7 +35,7 @@
                 <tbody>
                 {% for project in all_projects %}
                   <tr>
-                      <td> <a href="/project-profile?project={{project.name}}">{{ project.name }}</a> </td>
+                      <td> <a href="/project-profile?project={{project.project_name}}">{{ project.project_name }}</a> </td>
                       <td> {{ project.language }} </td>
                       <td> {{ project.fuzzer_count }} </td>
                       <td> {{ '%0.2f' % project.coverage_data.line_coverage.percent |float }}% </td>


### PR DESCRIPTION
This includes projects that do not have an up-to-date coverage build, meaning their data will be out of date. However, this makes it a lot easier to track all projects, and even projects without code coverage builds may have valuable historical data.