### PR TITLE
json-reporting: add callsites dictionary to output

### DIFF
--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -140,6 +140,7 @@ def create_all_function_table(
         json_copy['Reached by Fuzzers'] = fd.reached_by_fuzzers
         json_copy['return_type'] = fd.return_type
         json_copy['raw-function-name'] = fd.raw_function_name
+        json_copy['callsites'] = fd.callsite
         table_rows_json_report.append(json_copy)
 
     logger.info("Assembled a total of %d entries" %


### PR DESCRIPTION
We have callsites for each function with respect to what functions they are calling. However, it's currently not output to `summary.json`. This fixes it. 

Ref: https://github.com/ossf/fuzz-introspector/issues/1343