### PR TITLE
Java-frontend: Save full project class-method map

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -63,6 +63,7 @@ public class SootSceneTransformer extends SceneTransformer {
   private List<FunctionElement> depthHandled;
   private Map<String, Set<String>> edgeClassMap;
   private Map<String, Set<String>> sinkMethodMap;
+  private Map<SootClass, List<SootMethod>> projectClassMethodMap;
   private String entryClassStr;
   private String entryMethodStr;
   private SootMethod entryMethod;
@@ -93,6 +94,7 @@ public class SootSceneTransformer extends SceneTransformer {
     reachedSinkMethodList = new LinkedList<SootMethod>();
     edgeClassMap = new HashMap<String, Set<String>>();
     sinkMethodMap = new HashMap<String, Set<String>>();
+    projectClassMethodMap = new HashMap<SootClass, List<SootMethod>>();
     methodList = new FunctionConfig();
     analyseFinished = false;
 
@@ -229,6 +231,9 @@ public class SootSceneTransformer extends SceneTransformer {
       boolean isAutoFuzzIgnore = false;
       SootClass c = classIterator.next();
       String cname = c.getName();
+
+      // Add data for the full project class method map
+      this.projectClassMethodMap.put(c, c.getMethods());
 
       // Check for a list of classes of prefixes that must handled
       for (String prefix : includeList) {

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -36,6 +36,7 @@ import ossf.fuzz.introspector.soot.utils.BlockGraphInfoUtils;
 import ossf.fuzz.introspector.soot.utils.CalculationUtils;
 import ossf.fuzz.introspector.soot.utils.CalltreeUtils;
 import ossf.fuzz.introspector.soot.utils.EdgeUtils;
+import ossf.fuzz.introspector.soot.utils.SinkDiscoveryUtils;
 import ossf.fuzz.introspector.soot.yaml.Callsite;
 import ossf.fuzz.introspector.soot.yaml.FunctionConfig;
 import ossf.fuzz.introspector.soot.yaml.FunctionElement;
@@ -60,6 +61,7 @@ public class SootSceneTransformer extends SceneTransformer {
   private List<String> excludeMethodList;
   private List<String> projectClassList;
   private List<SootMethod> reachedSinkMethodList;
+  private List<SootMethod> fullSinkMethodList;
   private List<FunctionElement> depthHandled;
   private Map<String, Set<String>> edgeClassMap;
   private Map<String, Set<String>> sinkMethodMap;
@@ -92,6 +94,7 @@ public class SootSceneTransformer extends SceneTransformer {
     excludeMethodList = new LinkedList<String>();
     projectClassList = new LinkedList<String>();
     reachedSinkMethodList = new LinkedList<SootMethod>();
+    fullSinkMethodList = new LinkedList<SootMethod>();
     edgeClassMap = new HashMap<String, Set<String>>();
     sinkMethodMap = new HashMap<String, Set<String>>();
     projectClassMethodMap = new HashMap<SootClass, List<SootMethod>>();
@@ -182,6 +185,7 @@ public class SootSceneTransformer extends SceneTransformer {
       CalculationUtils.calculateAllCallDepth(this.methodList);
 
       if (!isAutoFuzz) {
+        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap);
         CalltreeUtils.addSinkMethods(this.methodList, this.reachedSinkMethodList, this.isAutoFuzz);
       }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
@@ -1,0 +1,55 @@
+// Copyright 2024 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////
+
+package ossf.fuzz.introspector.soot.utils;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import soot.SootClass;
+import soot.SootMethod;
+
+public class SinkDiscoveryUtils {
+  /**
+   * The method loop through all methods and classes for the target
+   * project and discover all sink methods existed in the project.
+   *
+   * @param sinkMethodMap the sink methods and classes to look for
+   * @param projectClassMethodMap all methods and classes in the project
+   * @return a list of sink methods exist in the project
+   */
+  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap) {
+    List<SootMethod> sinkMethods = new LinkedList<SootMethod>();
+
+    // Loop through all classes and methods of the project
+    for (SootClass c : projectClassMethodMap.keySet()) {
+      // Only process classes with sink methods
+      if (sinkMethodMap.containsKey(c.getName())) {
+        // Temporary SootMethod list to avoid concurrent modification
+        List<SootMethod> mList = new LinkedList<SootMethod>();
+        mList.addAll(projectClassMethodMap.get(c));
+        for (SootMethod m : mList) {
+          if (sinkMethodMap.get(c.getName()).contains(m.getName())) {
+            // Add the found sink method to the result list
+            sinkMethods.add(m);
+          }
+        }
+      }
+    }
+
+    return sinkMethods;
+  }
+}


### PR DESCRIPTION
This PR adds additional logic to the custom SootSceneTransformer to save the full project class-method map. The full project class-method map is needed to discover the call paths to sink methods in later enhancement PRs. This PR also adds an additional utility class for discovering all sink methods that are existed in the target project, no matter if it is statically reached by the fuzzers or not.