### PR TITLE
Java-frontend: Fix method name bug

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -397,7 +397,6 @@ public class SootSceneTransformer extends SceneTransformer {
                   BlockGraphInfoUtils.handleMethodInvocationInStatement(
                       (Stmt) unit,
                       c.getFilePath(),
-                      this.isAutoFuzz,
                       this.sinkMethodMap,
                       this.reachedSinkMethodList,
                       this.excludeMethodList);

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/BlockGraphInfoUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/BlockGraphInfoUtils.java
@@ -42,7 +42,6 @@ public class BlockGraphInfoUtils {
    *
    * @param stmt the statement to handle
    * @param sourceFilePath the file path for the parent method
-   * @param isAutoFuzz a boolean value to indicate if this run is initiated by AutoFuzz
    * @param sinkMethodMap a map to store a set of sink methods names grouped by their containing
    *     classes
    * @param reachedSinkMethodList a list of sink methods which are reachable by the given entry
@@ -54,7 +53,6 @@ public class BlockGraphInfoUtils {
   public static Callsite handleMethodInvocationInStatement(
       Stmt stmt,
       String sourceFilePath,
-      Boolean isAutoFuzz,
       Map<String, Set<String>> sinkMethodMap,
       List<SootMethod> reachedSinkMethodList,
       List<String> excludeMethodList) {
@@ -71,12 +69,9 @@ public class BlockGraphInfoUtils {
         }
         if (!excludeMethodList.contains(target.getName())) {
           callsite.setSource(sourceFilePath + ":" + stmt.getJavaSourceStartLineNumber() + ",1");
-          if (isAutoFuzz) {
-            callsite.setMethodName(
-                "[" + tClass.getName() + "]." + target.getSubSignature().split(" ")[1]);
-          } else {
-            callsite.setMethodName("[" + tClass.getName() + "]." + target.getName());
-          }
+          callsite.setMethodName(
+              "[" + tClass.getName() + "]." + target.getSubSignature().split(" ")[1]);
+
           return callsite;
         }
       }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
@@ -194,7 +194,9 @@ public class FunctionElement {
   }
 
   public void addFunctionsReached(String functionsReached) {
-    this.functionsReached.add(functionsReached);
+    if (!this.functionsReached.contains(functionsReached)) {
+      this.functionsReached.add(functionsReached);
+    }
   }
 
   public void setFunctionsReached(List<String> functionsReached) {
@@ -228,6 +230,8 @@ public class FunctionElement {
   }
 
   public void addCallsite(Callsite callsite) {
+    this.addFunctionsReached(callsite.getMethodName());
+
     Boolean duplicate = false;
     for (Callsite item : this.callsites) {
       if (item.equals(callsite)) {

--- a/tests/java/test11/.config
+++ b/tests/java/test11/.config
@@ -1,6 +1,6 @@
 jarfile=$PWD/test11.jar
 entryclass=TestFuzzer
-reached=[java.lang.Runtime].exec(java.lang.String):[FunctionTest].functionSafe():[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider)
+reached=[java.lang.Runtime].exec(java.lang.String):[FunctionTest].functionSafe():[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[FunctionTest].functionSink()
 unreached=[FunctionTest].functionSafeDead():[java.lang.System].load(java.lang.String):[FunctionTest].functionSinkDead():[TestFuzzer].main(java.lang.String[])
 optimalreached=[java.lang.Runtime].exec(java.lang.String):[FunctionTest].functionSafe():[TestFuzzer].fuzzerTestOneInput(com.code_intelligence.jazzer.api.FuzzedDataProvider):[FunctionTest].functionSink()
 optimalunreached=[FunctionTest].functionSafeDead():[java.lang.System].load(java.lang.String):[FunctionTest].functionSinkDead():[TestFuzzer].main(java.lang.String[])


### PR DESCRIPTION
This PR fixes a bug in handling method names. The method name stored in the functionReached field of the YAML is not compatible with the functionName field, this causes some undiscovered functions reached in the searching process. This PR unify the method names for both field.