### PR TITLE
Analyser: Add flag for html display of analyser

### DIFF
--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -61,8 +61,8 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
     name: str = "SinkCoverageAnalyser"
 
     def __init__(self) -> None:
-        self.json_string_result = "[]"
-        self.display_html = True
+        self.json_string_result = ""
+        self.display_html = False
         self.index = 0
 
     @classmethod
@@ -91,7 +91,9 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
             processing result of the analyser for future use
         :type json_string: str
         """
-        self.json_string_result = json_string
+        if len(self.json_string_result) > 0:
+            self.json_string_result = self.json_string_result + ", "
+        self.json_string_result = self.json_string_result + json_string
 
     def _get_source_file(self, callsite) -> str:
         """
@@ -597,12 +599,10 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
                 function_callsite_dict, proj_profile.runtime_coverage, cwe)
 
             self.set_json_string_result(json_row)
-            json_report.add_analysis_json_str_as_dict_to_report(
-                self.get_name(), self.get_json_string_result())
 
-            # If no html, this is our job done
+            # If no html, this is our job done for this cwe
             if not self.display_html:
-                return ""
+                continue
 
             html_string += html_helpers.html_add_header_with_link(
                 f"Sink functions/methods found for {cwe}",
@@ -632,5 +632,12 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
         html_string += "</div>"  # .collapsible
         html_string += "</div>"  # report-box
 
+        json_report.add_analysis_json_str_as_dict_to_report(
+            self.get_name(), self.get_json_string_result())
+
         logger.info(f" - Finish running analysis {self.get_name()}")
-        return html_string
+
+        if self.display_html:
+            return html_string
+        else:
+            return ""

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -62,7 +62,6 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
 
     def __init__(self) -> None:
         self.json_string_result = ""
-        self.display_html = False
         self.index = 0
 
     @classmethod
@@ -81,7 +80,7 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
             by this analyser
         :rtype: str
         """
-        return self.json_string_result
+        return f"[{self.json_string_result}]"
 
     def set_json_string_result(self, json_string):
         """Store the result of this analyser as json string result

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -112,6 +112,7 @@ class IntrospectionProject():
 class AnalysisInterface(abc.ABC):
     name: str = ""
     json_string_result: str = ""
+    display_html: bool = False
 
     @abc.abstractmethod
     def analysis_func(self,
@@ -166,8 +167,12 @@ class AnalysisInterface(abc.ABC):
 
     @abc.abstractmethod
     def set_json_string_result(self, string):
-        """Return json_string_result"""
+        """Set json_string_result"""
         pass
+
+    def set_display_html(self, is_display_html):
+        """Set display_html"""
+        self.display_html = is_display_html
 
 
 def instantiate_analysis_interface(cls: Type[AnalysisInterface]):

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -629,17 +629,22 @@ def create_section_optional_analyses(table_of_contents, analyses_to_run,
         x for x in output_json if x not in analyses_to_run
     ]
     for analysis_interface in analysis.get_all_analyses():
-        if analysis_interface.get_name() in combined_analyses:
+        analysis_name = analysis_interface.get_name()
+        if analysis_name in combined_analyses:
             analysis_instance = analysis.instantiate_analysis_interface(
                 analysis_interface)
             analysis_instance.dump_files = dump_files
+
+            # Set display_html flag for the analysis_instance
+            analysis_instance.set_display_html = analysis_name in analyses_to_run
+
             html_string = analysis_instance.analysis_func(
                 table_of_contents, tables, proj_profile, profiles, basefolder,
                 coverage_url, conclusions)
 
             # Only add the HTML content if it's an analysis that we want
             # the non-json output from.
-            if analysis_interface.get_name() in analyses_to_run:
+            if analysis_name in analyses_to_run:
                 html_report_core += html_string
     html_report_core += "</div>"  # .collapsible
     html_report_core += "</div>"  # report box

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -636,7 +636,7 @@ def create_section_optional_analyses(table_of_contents, analyses_to_run,
             analysis_instance.dump_files = dump_files
 
             # Set display_html flag for the analysis_instance
-            analysis_instance.set_display_html = analysis_name in analyses_to_run
+            analysis_instance.set_display_html(analysis_name in analyses_to_run)
 
             html_string = analysis_instance.analysis_func(
                 table_of_contents, tables, proj_profile, profiles, basefolder,

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -636,7 +636,8 @@ def create_section_optional_analyses(table_of_contents, analyses_to_run,
             analysis_instance.dump_files = dump_files
 
             # Set display_html flag for the analysis_instance
-            analysis_instance.set_display_html(analysis_name in analyses_to_run)
+            analysis_instance.set_display_html(
+                analysis_name in analyses_to_run)
 
             html_string = analysis_instance.analysis_func(
                 table_of_contents, tables, proj_profile, profiles, basefolder,


### PR DESCRIPTION
In the current logic, all analysers are executed during the post-processing period no matter if it is active or not. The only difference is that the html string result is included in the report.html while the html string result for those inactive analysers is discarded. This could result in additional actions for some of the analysers. For example, the sink analyser will generate a set of call path html files during analysing process and if the sink analyser is not active, those generated call path html files are not used and become redundant. This PR fixes the base AnalysisInterface class by adding a flag to indicate if an HTML display is needed for a specific analyser, the individual analyser can determine what to do with that flag and avoid redundant processes if html display is not needed.