### PR TITLE
Java-frontend: Add base java info

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -359,9 +359,7 @@ public class SootSceneTransformer extends SceneTransformer {
 
         element.setFunctionName("[" + c.getFilePath() + "]." + m.getSubSignature().split(" ")[1]);
         element.setBaseInformation(m);
-        if (isAutoFuzz) {
-          element.setJavaMethodInfo(m);
-        }
+        element.setJavaMethodInfo(m, isAutoFuzz);
 
         // Retrieve and update incoming and outgoing edges of the target method
         EdgeUtils.updateIncomingEdges(callGraph, m, element);

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
@@ -80,7 +80,7 @@ public class CalltreeUtils {
         FunctionElement element = new FunctionElement();
         element.setFunctionName(name);
         element.setBaseInformation(method);
-        element.setJavaMethodInfo(method);
+        element.setJavaMethodInfo(method, true);
 
         eList.add(element);
       }
@@ -107,9 +107,7 @@ public class CalltreeUtils {
       FunctionElement element = new FunctionElement();
       element.setFunctionName("[" + cl.getName() + "]." + method.getSubSignature().split(" ")[1]);
       element.setBaseInformation(method);
-      if (isAutoFuzz) {
-        element.setJavaMethodInfo(method);
-      }
+      element.setJavaMethodInfo(method, isAutoFuzz);
 
       eList.add(element);
     }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
@@ -253,7 +253,7 @@ public class FunctionElement {
     return this.javaMethodInfo;
   }
 
-  public void setJavaMethodInfo(SootMethod m) {
+  public void setJavaMethodInfo(SootMethod m, boolean isAutoFuzz) {
     JavaMethodInfo methodInfo = new JavaMethodInfo();
     SootClass c = m.getDeclaringClass();
 
@@ -265,32 +265,36 @@ public class FunctionElement {
     methodInfo.setIsClassEnum(c.isEnum());
     methodInfo.setIsClassPublic(c.isPublic());
     methodInfo.setIsClassConcrete(c.isConcrete());
-    for (SootClass exception : m.getExceptions()) {
-      methodInfo.addException(exception.getFilePath());
-    }
 
-    // Extra class information for constructors
-    if (m.getName().equals("<init>")) {
-      if (c.hasSuperclass()) {
-        methodInfo.setSuperClass(c.getSuperclass().getName());
+    // Additional information for auto-fuzz process
+    if (isAutoFuzz) {
+      for (SootClass exception : m.getExceptions()) {
+        methodInfo.addException(exception.getFilePath());
       }
-      Iterator<SootClass> interfaces = c.getInterfaces().snapshotIterator();
-      while (interfaces.hasNext()) {
-        methodInfo.addInterface(interfaces.next().getName());
-      }
-      Iterator<SootField> fields = c.getFields().snapshotIterator();
-      while (fields.hasNext()) {
-        SootField field = fields.next();
-        ClassField classField = new ClassField();
 
-        classField.setFieldName(field.getName());
-        classField.setFieldType(field.getType().toString());
-        classField.setIsConcrete(field.isDeclared());
-        classField.setIsPublic(field.isPublic());
-        classField.setIsStatic(field.isStatic());
-        classField.setIsFinal(field.isFinal());
+      // Extra class information for constructors
+      if (m.getName().equals("<init>")) {
+        if (c.hasSuperclass()) {
+          methodInfo.setSuperClass(c.getSuperclass().getName());
+        }
+        Iterator<SootClass> interfaces = c.getInterfaces().snapshotIterator();
+        while (interfaces.hasNext()) {
+          methodInfo.addInterface(interfaces.next().getName());
+        }
+        Iterator<SootField> fields = c.getFields().snapshotIterator();
+        while (fields.hasNext()) {
+          SootField field = fields.next();
+          ClassField classField = new ClassField();
 
-        methodInfo.addClassField(classField);
+          classField.setFieldName(field.getName());
+          classField.setFieldType(field.getType().toString());
+          classField.setIsConcrete(field.isDeclared());
+          classField.setIsPublic(field.isPublic());
+          classField.setIsStatic(field.isStatic());
+          classField.setIsFinal(field.isFinal());
+
+          methodInfo.addClassField(classField);
+        }
       }
     }
 


### PR DESCRIPTION
This PR adds base Java method and class information even if the frontend code is not run by autofuzz. This set of base information helps the sink analyser filter out unreachable APIs for sink functions/methods called path generation.