### PR TITLE
Sink analyser: Filter inaccessible callpath

### DIFF
--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -20,8 +20,8 @@ from bs4 import BeautifulSoup as bs
 
 from typing import (Any, List, Tuple, Dict)
 
-from fuzz_introspector import (analysis, code_coverage, cfg_load, html_helpers,
-                               json_report, utils)
+from fuzz_introspector import (analysis, code_coverage, constants, cfg_load,
+                               html_helpers, json_report, utils)
 
 from fuzz_introspector.analyses.data import (cwe_data)
 
@@ -371,19 +371,42 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
 
         return filename
 
+    def _filter_inaccessible_callpath(
+            self, callpath_list: List[List[function_profile.FunctionProfile]],
+            target_lang: str) -> List[List[function_profile.FunctionProfile]]:
+        """
+        If the target language of this project is jvm, use
+        the class and method information to filter out
+        call path that is not accessible. Other language
+        is not supported yet.
+        """
+        if target_lang == "jvm":
+            result = []
+
+            # Loop through the list of callpaths and
+            # filter out inaccessbile callpths
+            for callpath in callpath_list:
+                if callpath[0].accessible:
+                    result.append(callpath)
+
+            return result
+        else:
+            return callpath_list
+
     def _handle_callpath_dict(
             self,
             callpath_dict: Dict[function_profile.FunctionProfile,
                                 List[List[function_profile.FunctionProfile]]],
             proj_profile: project_profile.MergedProjectProfile,
-            target_func: function_profile.FunctionProfile) -> str:
+            target_func: function_profile.FunctionProfile,
+            target_lang: str) -> str:
         """
         Pretty print index of callpath and generate
         also generate separate html page for displaying
         callpath and add the links to the index.
         """
         if len(callpath_dict.keys()) == 0:
-            return "N/A"
+            return "No accessible call path found"
 
         html = ""
         count = 0
@@ -393,9 +416,14 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
                 parent_func, proj_profile, target_func.function_name)
             callpath_list = callpath_dict[parent_func]
 
-            # Sort callpath by its depth, assuming shallowest depth is
+            # Filter inaccessible callpaths and sort them
+            # by their depth, assuming shallowest depth is
             # the function call closest to the target function
+            callpath_list = self._filter_inaccessible_callpath(callpath_list, target_lang)
             callpath_list.sort(key=len)
+
+            if len(callpath_list) == 0:
+                return "No accessible call path found"
 
             for callpath in callpath_list:
                 count += 1
@@ -403,7 +431,7 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
                 callpath.append(target_func)
                 callpath_link = self._generate_callpath_page(
                     callpath, proj_profile)
-                if count <= 20:
+                if count <= constants.SINK_FUNCTION_CALLPATH_MAX_COUNT:
                     html += f"<a href='{callpath_link}'>Path {count}</a><br/>"
 
         return html
@@ -460,7 +488,8 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
 
             if len(fd.reached_by_fuzzers) == 0:
                 fuzzer_callpath = self._handle_callpath_dict(
-                    callpath_dict, proj_profile, fd)
+                    callpath_dict, proj_profile, fd, target_lang)
+
                 blocker = "N/A"
             else:
                 fuzzer_callpath = "N/A"

--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -419,7 +419,8 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
             # Filter inaccessible callpaths and sort them
             # by their depth, assuming shallowest depth is
             # the function call closest to the target function
-            callpath_list = self._filter_inaccessible_callpath(callpath_list, target_lang)
+            callpath_list = self._filter_inaccessible_callpath(
+                callpath_list, target_lang)
             callpath_list.sort(key=len)
 
             if len(callpath_list) == 0:

--- a/src/fuzz_introspector/constants.py
+++ b/src/fuzz_introspector/constants.py
@@ -56,3 +56,9 @@ COLOR_CONSTANTS = [(0, 1, "red", "#ff0000"), (1, 10, "gold", "#ffd700"),
 
 BLOCKLISTED_FUNCTION_NAMES = re.compile(
     r'^__sanitizer|^llvm\.|^__assert|.*printf$')
+
+# Use by SinkCoverageAnaylser in analyses/sink_analyser.py
+# Integer constants to limit the maximum number of callpaths
+# generated for each of the unreachable sink functions found
+# in the target project.
+SINK_FUNCTION_CALLPATH_MAX_COUNT = 2

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -120,7 +120,7 @@ class FunctionProfile:
 
     def is_function_acccessible(self, elem: Dict[Any, Any]) -> bool:
         # Currently only support jvm which accessible information is available
-        if "JavaMethodInfo" in elem and len(elem['JavaMethodInfo']) > 0:
+        if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
             if elem['JavaMethodInfo']['javaLibraryMethod']:
                 return False
             if elem['JavaMethodInfo']['classEnum']:

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -61,6 +61,9 @@ class FunctionProfile:
         self.functions_called = utils.load_func_names(elem['functionsReached'],
                                                       False)
 
+        # Check if this function is accessible
+        self.accessible = self.is_function_acccessible(elem)
+
         # Temporary handle for unreadable library method (JVM)
         # (jar missing or purposely ignored)
         if not self.cyclomatic_complexity:
@@ -114,3 +117,21 @@ class FunctionProfile:
             cs_loaded.update({callsite['Dst']: callsite_list})
 
         return cs_loaded
+
+    def is_function_acccessible(self, elem: Dict[Any, Any]) -> bool:
+        # Currently only support jvm which accessible information is available
+        if "JavaMethodInfo" in elem and len(elem['JavaMethodInfo']) > 0:
+            if elem['JavaMethodInfo']['javaLibraryMethod']:
+                return False
+            if elem['JavaMethodInfo']['classEnum']:
+                return False
+            if not elem['JavaMethodInfo']['public']:
+                return False
+            if not elem['JavaMethodInfo']['classPublic']:
+                return False
+            if not elem['JavaMethodInfo']['concrete']:
+                return False
+            if not elem['JavaMethodInfo']['classConcrete']:
+                return False
+
+        return True


### PR DESCRIPTION
Following #1358 and #1359, this PR further reduce possible redundant in sink function callpath generations by an additional filtering. From #1359, base accessible information for java methods is provided from the frontend result. This PR adds a new filter to avoid generating callpaths HTML files for inaccessible callpaths, that is callpaths start with methods that are not directly callable by users. These inaccessible call paths are filtered out to reduce the number of possible call paths for each sink function discovered. This PR also change the max count for call path generation per sink functions to a configurable value in constants.py and significantly decreases the default value to 2. This could help avoid flooding a long list of possible call paths which are useless for analysis purposes.