### PR TITLE
Java-frontend: add non-reachable sink methods

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -60,7 +60,6 @@ public class SootSceneTransformer extends SceneTransformer {
   private List<String> excludeList;
   private List<String> excludeMethodList;
   private List<String> projectClassList;
-  private List<SootMethod> reachedSinkMethodList;
   private List<SootMethod> fullSinkMethodList;
   private List<FunctionElement> depthHandled;
   private Map<String, Set<String>> edgeClassMap;
@@ -93,7 +92,6 @@ public class SootSceneTransformer extends SceneTransformer {
     excludeList = new LinkedList<String>();
     excludeMethodList = new LinkedList<String>();
     projectClassList = new LinkedList<String>();
-    reachedSinkMethodList = new LinkedList<SootMethod>();
     fullSinkMethodList = new LinkedList<SootMethod>();
     edgeClassMap = new HashMap<String, Set<String>>();
     sinkMethodMap = new HashMap<String, Set<String>>();
@@ -185,8 +183,8 @@ public class SootSceneTransformer extends SceneTransformer {
       CalculationUtils.calculateAllCallDepth(this.methodList);
 
       if (!isAutoFuzz) {
-        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap);
-        CalltreeUtils.addSinkMethods(this.methodList, this.reachedSinkMethodList, this.isAutoFuzz);
+        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap, callGraph);
+        CalltreeUtils.addSinkMethods(this.methodList, this.fullSinkMethodList, this.isAutoFuzz);
       }
 
       // Extract call tree and write to .data
@@ -396,7 +394,6 @@ public class SootSceneTransformer extends SceneTransformer {
                       (Stmt) unit,
                       c.getFilePath(),
                       this.sinkMethodMap,
-                      this.reachedSinkMethodList,
                       this.excludeMethodList);
               if (callsite != null) {
                 element.addCallsite(callsite);

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -183,7 +183,7 @@ public class SootSceneTransformer extends SceneTransformer {
       CalculationUtils.calculateAllCallDepth(this.methodList);
 
       if (!isAutoFuzz) {
-        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap);
+        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap, callGraph);
         CalltreeUtils.addSinkMethods(this.methodList, this.fullSinkMethodList, this.isAutoFuzz);
       }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/SootSceneTransformer.java
@@ -183,7 +183,7 @@ public class SootSceneTransformer extends SceneTransformer {
       CalculationUtils.calculateAllCallDepth(this.methodList);
 
       if (!isAutoFuzz) {
-        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap, callGraph);
+        fullSinkMethodList = SinkDiscoveryUtils.discoverAllSinks(sinkMethodMap, projectClassMethodMap);
         CalltreeUtils.addSinkMethods(this.methodList, this.fullSinkMethodList, this.isAutoFuzz);
       }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/BlockGraphInfoUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/BlockGraphInfoUtils.java
@@ -44,8 +44,6 @@ public class BlockGraphInfoUtils {
    * @param sourceFilePath the file path for the parent method
    * @param sinkMethodMap a map to store a set of sink methods names grouped by their containing
    *     classes
-   * @param reachedSinkMethodList a list of sink methods which are reachable by the given entry
-   *     method
    * @param excludeMethodList a list to store all excluded method names for this run
    * @return the callsite object to store in the output yaml file, return null if Soot fails to
    *     resolve the invocation
@@ -54,7 +52,6 @@ public class BlockGraphInfoUtils {
       Stmt stmt,
       String sourceFilePath,
       Map<String, Set<String>> sinkMethodMap,
-      List<SootMethod> reachedSinkMethodList,
       List<String> excludeMethodList) {
     // Handle statements of a method
     try {
@@ -64,9 +61,6 @@ public class BlockGraphInfoUtils {
         SootMethod target = expr.getMethod();
         SootClass tClass = target.getDeclaringClass();
         Set<String> sink = sinkMethodMap.getOrDefault(tClass.getName(), Collections.emptySet());
-        if (sink.contains(target.getName())) {
-          reachedSinkMethodList.add(target);
-        }
         if (!excludeMethodList.contains(target.getName())) {
           callsite.setSource(sourceFilePath + ":" + stmt.getJavaSourceStartLineNumber() + ",1");
           callsite.setMethodName(

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
@@ -119,16 +119,27 @@ public class CalltreeUtils {
    * invoke the target method from the provided project callgraph.
    *
    * @param parentMap the list of parent methods mapped by all existing methods
+   * @param cg the full project call graph
    * @param target the SootMethod target object to look for
    * @param parentList the list of resulting SootMethod object
    */
-  public static void getAllParents(Map<SootMethod, List<SootMethod>> parentMap, SootMethod target, List<SootMethod> parentList) {
+  public static void getAllParents(Map<SootMethod, List<SootMethod>> parentMap, CallGraph cg, SootMethod target, List<SootMethod> parentList) {
     List<SootMethod> parents = parentMap.getOrDefault(target, Collections.emptyList());
 
     for (SootMethod parent : parents) {
       if (!parentList.contains(parent)) {
         parentList.add(parent);
-        getAllParents(parentMap, parent, parentList);
+        getAllParents(parentMap, cg, parent, parentList);
+      }
+    }
+
+    Iterator<Edge> iter = cg.edgesInto(target);
+
+    while (iter.hasNext()) {
+      SootMethod parent = iter.next().tgt();
+      if (!parentList.contains(parent)) {
+        parentList.add(parent);
+        getAllParents(parentMap, cg, parent, parentList);
       }
     }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
@@ -94,14 +94,14 @@ public class CalltreeUtils {
    * into the provided FunctionConfig object.
    *
    * @param methodList the FunctionConfig object that stores all the methods of this run
-   * @param reachedSinkMethodList the list of sink methods that are reachable in this run
+   * @param reachedMethodList the list of sink methods and parents that are reachable in this run
    * @param isAutoFuzz a boolean value indicates if this run is initiated by Auto-Fuzz
    */
   public static void addSinkMethods(
-      FunctionConfig methodList, List<SootMethod> reachedSinkMethodList, Boolean isAutoFuzz) {
+      FunctionConfig methodList, List<SootMethod> reachedMethodList, Boolean isAutoFuzz) {
     List<FunctionElement> eList = new LinkedList<FunctionElement>();
 
-    for (SootMethod method : reachedSinkMethodList) {
+    for (SootMethod method : reachedMethodList) {
       SootClass cl = method.getDeclaringClass();
 
       FunctionElement element = new FunctionElement();
@@ -113,6 +113,29 @@ public class CalltreeUtils {
     }
 
     methodList.addFunctionElements(eList);
+  }
+  /**
+   * The method recursively retrieves all methods that directlt or indirectly
+   * invoke the target method from the provided project callgraph.
+   *
+   * @param cg the CallGraph object describing the method relation of the target
+   * @param target the SootMethod target object to look for
+   * @param parentList the list of resulting SootMethod object
+   */
+  public static void getAllParents(CallGraph cg, SootMethod target, List<SootMethod> parentList) {
+    Iterator<Edge> iter = cg.edgesInto(target);
+
+    while (iter.hasNext()) {
+      SootMethod parent = iter.next().tgt();
+      if (!parentList.contains(parent)) {
+        parentList.add(parent);
+        getAllParents(cg, parent, parentList);
+      }
+    }
+
+    if (!parentList.contains(target)) {
+      parentList.add(target);
+    }
   }
 
   /**

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/CalltreeUtils.java
@@ -118,18 +118,17 @@ public class CalltreeUtils {
    * The method recursively retrieves all methods that directlt or indirectly
    * invoke the target method from the provided project callgraph.
    *
-   * @param cg the CallGraph object describing the method relation of the target
+   * @param parentMap the list of parent methods mapped by all existing methods
    * @param target the SootMethod target object to look for
    * @param parentList the list of resulting SootMethod object
    */
-  public static void getAllParents(CallGraph cg, SootMethod target, List<SootMethod> parentList) {
-    Iterator<Edge> iter = cg.edgesInto(target);
+  public static void getAllParents(Map<SootMethod, List<SootMethod>> parentMap, SootMethod target, List<SootMethod> parentList) {
+    List<SootMethod> parents = parentMap.getOrDefault(target, Collections.emptyList());
 
-    while (iter.hasNext()) {
-      SootMethod parent = iter.next().tgt();
+    for (SootMethod parent : parents) {
       if (!parentList.contains(parent)) {
         parentList.add(parent);
-        getAllParents(cg, parent, parentList);
+        getAllParents(parentMap, parent, parentList);
       }
     }
 

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
@@ -30,11 +30,12 @@ public class SinkDiscoveryUtils {
    *
    * @param sinkMethodMap the sink methods and classes to look for
    * @param projectClassMethodMap all methods and classes in the project
-   * @param cg the full project call graph
-   * @return a list of sink methods exist in the project
+   * @return a list of sink methods and their parent methods exist in the project
    */
-  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap, CallGraph cg) {
+  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap) {
     List<SootMethod> sinkMethods = new LinkedList<SootMethod>();
+    Map<SootMethod, List<SootMethod>> parentMap = BlockGraphInfoUtils.getAllMethodParents(projectClassMethodMap);
+
 
     // Loop through all classes and methods of the project
     for (SootClass c : projectClassMethodMap.keySet()) {
@@ -47,7 +48,7 @@ public class SinkDiscoveryUtils {
           if (sinkMethodMap.get(c.getName()).contains(m.getName())) {
             // Retrieve all the direct and indirect parents
             // of the found sink methods to the result list
-            CalltreeUtils.getAllParents(cg, m, sinkMethods);
+            CalltreeUtils.getAllParents(parentMap, m, sinkMethods);
           }
         }
       }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
@@ -30,12 +30,12 @@ public class SinkDiscoveryUtils {
    *
    * @param sinkMethodMap the sink methods and classes to look for
    * @param projectClassMethodMap all methods and classes in the project
+   * @param cg the full project call graph
    * @return a list of sink methods and their parent methods exist in the project
    */
-  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap) {
+  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap, CallGraph cg) {
     List<SootMethod> sinkMethods = new LinkedList<SootMethod>();
     Map<SootMethod, List<SootMethod>> parentMap = BlockGraphInfoUtils.getAllMethodParents(projectClassMethodMap);
-
 
     // Loop through all classes and methods of the project
     for (SootClass c : projectClassMethodMap.keySet()) {
@@ -48,7 +48,7 @@ public class SinkDiscoveryUtils {
           if (sinkMethodMap.get(c.getName()).contains(m.getName())) {
             // Retrieve all the direct and indirect parents
             // of the found sink methods to the result list
-            CalltreeUtils.getAllParents(parentMap, m, sinkMethods);
+            CalltreeUtils.getAllParents(parentMap, cg, m, sinkMethods);
           }
         }
       }

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/utils/SinkDiscoveryUtils.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import soot.SootClass;
 import soot.SootMethod;
+import soot.jimple.toolkits.callgraph.CallGraph;
 
 public class SinkDiscoveryUtils {
   /**
@@ -29,9 +30,10 @@ public class SinkDiscoveryUtils {
    *
    * @param sinkMethodMap the sink methods and classes to look for
    * @param projectClassMethodMap all methods and classes in the project
+   * @param cg the full project call graph
    * @return a list of sink methods exist in the project
    */
-  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap) {
+  public static List<SootMethod> discoverAllSinks(Map<String, Set<String>> sinkMethodMap, Map<SootClass, List<SootMethod>> projectClassMethodMap, CallGraph cg) {
     List<SootMethod> sinkMethods = new LinkedList<SootMethod>();
 
     // Loop through all classes and methods of the project
@@ -43,8 +45,9 @@ public class SinkDiscoveryUtils {
         mList.addAll(projectClassMethodMap.get(c));
         for (SootMethod m : mList) {
           if (sinkMethodMap.get(c.getName()).contains(m.getName())) {
-            // Add the found sink method to the result list
-            sinkMethods.add(m);
+            // Retrieve all the direct and indirect parents
+            // of the found sink methods to the result list
+            CalltreeUtils.getAllParents(cg, m, sinkMethods);
           }
         }
       }


### PR DESCRIPTION
This PR refines the Java frontend to include those sink methods exist in the target project but not statically reachable from any fuzzers. The methods in the project that reaches those sink methods are also included for reference. 