### PR TITLE
tests: add non-fuzzer test

### DIFF
--- a/tests/simple-non-fuzz-test-0/.gitignore
+++ b/tests/simple-non-fuzz-test-0/.gitignore
@@ -1,0 +1,7 @@
+fuzzerLogFile*
+fuzzer
+work
+*.o
+*.bc
+*.ll
+*.yaml

--- a/tests/simple-non-fuzz-test-0/build_all.sh
+++ b/tests/simple-non-fuzz-test-0/build_all.sh
@@ -1,0 +1,25 @@
+# Copyright 2024 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Make sure we analyze non-fuzztest binaries.
+export FUZZ_INTROSPECTOR_AUTO_FUZZ=1
+export FUZZ_INTROSPECTOR=1
+
+rm -rf ./work
+mkdir work
+cd work
+
+../../../build/llvm-build/bin/clang -flto -g ../fake-test.c -o fake-test

--- a/tests/simple-non-fuzz-test-0/fake-test.c
+++ b/tests/simple-non-fuzz-test-0/fake-test.c
@@ -1,0 +1,45 @@
+/* Copyright 2024 Fuzz Introspector Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <strings.h>
+
+
+int obvious_fuzzer_entrypoint(const char *data, size_t size) {
+    // Parse complex data etc.
+    if (size == 5) {
+        return 2;
+    }
+    if (size < 2) {
+        return 0;
+    }
+    return strlen(data);
+}
+
+void test1() {
+    fuzz_entry("lorem ipsum dolor sit amet", 123);
+}
+
+void test2() {
+    fuzz_entry("lorem amet", 12);
+}
+
+int main() {
+    test1();
+    test2();
+}

--- a/tests/simple-non-fuzz-test-0/fake-test.c
+++ b/tests/simple-non-fuzz-test-0/fake-test.c
@@ -32,11 +32,11 @@ int obvious_fuzzer_entrypoint(const char *data, size_t size) {
 }
 
 void test1() {
-    fuzz_entry("lorem ipsum dolor sit amet", 123);
+    obvious_fuzzer_entrypoint("lorem ipsum dolor sit amet", 123);
 }
 
 void test2() {
-    fuzz_entry("lorem amet", 12);
+    obvious_fuzzer_entrypoint("lorem amet", 12);
 }
 
 int main() {


### PR DESCRIPTION
Recently the option of analyzing non-fuzzer binaries was added [here](https://github.com/ossf/fuzz-introspector/pull/1280).

This adds a test for this logic.