### PR TITLE
Auto-fuzz: Fix post processing bug

### DIFF
--- a/tools/auto-fuzz/post_process.py
+++ b/tools/auto-fuzz/post_process.py
@@ -210,6 +210,7 @@ def get_cov_ranked_trial_runs(trial_runs):
 
 def run_on_all_dirs(args):
     max_idx_number = 0
+    have_result = False
     for autofuzz_project_dir in os.listdir("."):
         if "autofuzz-" in autofuzz_project_dir:
             try:
@@ -217,9 +218,15 @@ def run_on_all_dirs(args):
                 max_idx_number = max(idx_number, max_idx_number)
             except:
                 continue
+            have_result = True
+
+    # Skip the process if no result directory is found
+    if not have_result:
+        return
+
     print("Max idx number: %d" % (max_idx_number))
     projects_to_display = []
-    for idx in range(max_idx_number):
+    for idx in range(max_idx_number + 1):
         autofuzz_project_dir = "autofuzz-%d" % (idx)
         if os.path.isdir(autofuzz_project_dir):
             proj_yaml, trial_runs = interpret_autofuzz_run(


### PR DESCRIPTION
This PR fixes a bug in the post-processing `run` command. The post-processing logic uses `range(int)` to loop through the directory and `range(int)` will only loop from `0` to `int - 1`, thus the results from the last idx directory are missed. If there is only one result directory, it will not be displayed at all. This PR fixes the logic by adding a flag to indicate if any result directory exists, if yes, loop through the max idx number + 1 to make the post-processing work for all existing directories.