### PR TITLE
webapp: do not dump introspector reports do disk

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -35,7 +35,7 @@ DB_JSON_ALL_FUNCTIONS = 'all-functions-db.json'
 DB_JSON_ALL_CURRENT_FUNCS = 'all-project-current.json'
 DB_JSON_ALL_BRANCH_BLOCKERS = 'all-branch-blockers.json'
 DB_BUILD_STATUS_JSON = 'build-status.json'
-DB_RAW_INTROSPECTOR_REPORTS = 'raw-introspector-reports'
+#DB_RAW_INTROSPECTOR_REPORTS = 'raw-introspector-reports'
 
 ALL_JSON_FILES = [
     DB_JSON_DB_TIMESTAMP,
@@ -87,12 +87,14 @@ def rename_annotated_cfg(original_annotated_cfg):
 
 
 def save_fuzz_introspector_report(introspector_report, project_name, date_str):
-    os.makedirs(DB_RAW_INTROSPECTOR_REPORTS, exist_ok=True)
+    # Disable for now to avoid growing the disk too much
+    #os.makedirs(DB_RAW_INTROSPECTOR_REPORTS, exist_ok=True)
 
-    report_dst = os.path.join(DB_RAW_INTROSPECTOR_REPORTS,
-                              '%s-%s.json' % (project_name, date_str))
-    with open(report_dst, 'w') as report_fd:
-        json.dump(introspector_report, report_fd)
+    #report_dst = os.path.join(DB_RAW_INTROSPECTOR_REPORTS,
+    #                          '%s-%s.json' % (project_name, date_str))
+    #with open(report_dst, 'w') as report_fd:
+    #    json.dump(introspector_report, report_fd)
+    return
 
 
 def save_debug_report(debug_report, project_name):
@@ -593,13 +595,15 @@ def update_db_files(db_timestamp, project_timestamps, function_list,
                              DB_JSON_ALL_PROJECT_TIMESTAMP,
                              compress_type=zipfile.ZIP_DEFLATED)
 
+        # Disable for now to avoid growing disk
         # ZIP the archived introspector reports
-        shutil.make_archive(DB_RAW_INTROSPECTOR_REPORTS, 'zip',
-                            DB_RAW_INTROSPECTOR_REPORTS)
+        #shutil.make_archive(DB_RAW_INTROSPECTOR_REPORTS, 'zip',
+        #                    DB_RAW_INTROSPECTOR_REPORTS)
 
+    # Disable for now to avoid growing disk
     # Cleanup DB_RAW_INTROSPECTOR_REPORTS
-    if os.path.isdir(DB_RAW_INTROSPECTOR_REPORTS):
-        shutil.rmtree(DB_RAW_INTROSPECTOR_REPORTS)
+    #if os.path.isdir(DB_RAW_INTROSPECTOR_REPORTS):
+    #    shutil.rmtree(DB_RAW_INTROSPECTOR_REPORTS)
 
 
 def update_build_status(build_dict):


### PR DESCRIPTION
We shouldn't store these on the webapp, but rather keep the webapp as light as possible to make deployments easier.

Instead, we could offer a simple script that downloads all of the reports. The downside of this is that it will take time for consumers.