### PR TITLE
core: add structured debug info handling for function signatures

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -14,7 +14,7 @@ index 8dcbdce6c..583427556 100644
  CMD ["compile"]
 \ No newline at end of file
 diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
-index 04ac1cc84..6db4134b4 100755
+index 04ac1cc84..91c1222c9 100755
 --- a/infra/base-images/base-builder/compile
 +++ b/infra/base-images/base-builder/compile
 @@ -19,10 +19,10 @@ echo "---------------------------------------------------------------"
@@ -32,6 +32,15 @@ index 04ac1cc84..6db4134b4 100755
  
  if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
    if [ "$FUZZING_ENGINE" != "libfuzzer" ] && [ "$FUZZING_ENGINE" != "wycheproof" ]; then
+@@ -272,7 +272,7 @@ if [ "$SANITIZER" = "introspector" ]; then
+   mkdir -p $SRC/inspector
+   find $SRC/ -name "fuzzerLogFile-*.data" -exec cp {} $SRC/inspector/ \;
+   find $SRC/ -name "fuzzerLogFile-*.data.yaml" -exec cp {} $SRC/inspector/ \;
+-  find $SRC/ -name "fuzzerLogFile-*.data.debug_info" -exec cp {} $SRC/inspector/ \;
++  find $SRC/ -name "fuzzerLogFile-*.data.debug_*" -exec cp {} $SRC/inspector/ \;
+   find $SRC/ -name "allFunctionsWithMain-*.yaml" -exec cp {} $SRC/inspector/ \;
+ 
+   # Move coverage report.
 diff --git a/infra/base-images/base-builder/compile_libfuzzer b/infra/base-images/base-builder/compile_libfuzzer
 index 7962bd366..769bb8e73 100755
 --- a/infra/base-images/base-builder/compile_libfuzzer

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -925,7 +925,6 @@ def convert_debug_info_to_signature_v2(function, introspector_func):
         param_string = convert_param_list_to_str_v2(
             function['func_signature_elems']['params'][idx])
         func_signature += param_string
-        #func_signature += " ".join(function['func_signature_elems']['params'][idx])
         if idx < len(function['func_signature_elems']['params']) - 1:
             func_signature += ', '
     func_signature += ')'

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -112,17 +112,20 @@ class IntrospectionProject():
         self.debug_files = data_loader.load_all_debug_files(self.base_folder)
         self.debug_type_files = data_loader.find_all_debug_all_types_files(
             self.base_folder)
-        self.debug_function_files = data_loader.find_all_debug_function_files(self.base_folder)
+        self.debug_function_files = data_loader.find_all_debug_function_files(
+            self.base_folder)
 
     def load_debug_report(self):
         self.debug_report = debug_info.load_debug_report(self.debug_files)
         self.debug_all_types = debug_info.load_debug_all_yaml_files(
             self.debug_type_files)
-        self.debug_all_functions = debug_info.load_debug_all_yaml_files(self.debug_function_files)
+        self.debug_all_functions = debug_info.load_debug_all_yaml_files(
+            self.debug_function_files)
 
         # Extract the raw function signature. This propagates types into all of
         # the debug functions.
-        debug_info.clean_extract_raw_all_debugged_function_signatures(self.debug_all_types, self.debug_all_functions)
+        debug_info.clean_extract_raw_all_debugged_function_signatures(
+            self.debug_all_types, self.debug_all_functions)
 
     def dump_debug_report(self):
         if self.debug_report is not None:
@@ -855,19 +858,10 @@ def correlate_introspection_functions_to_debug_info(all_functions_json_report,
             if_func['debug_function_info'] = dict()
 
 
-
-
-
-
-
-
-
-
-
-
 def convert_debug_info_to_signature_v2(function, introspector_func):
     try:
-        return_type = convert_param_list_to_str_v2(function['func_signature_elems']['return_type'])
+        return_type = convert_param_list_to_str_v2(
+            function['func_signature_elems']['return_type'])
         func_signature = return_type + " "
     except KeyError:
         return 'N/A'
@@ -892,22 +886,28 @@ def convert_debug_info_to_signature_v2(function, introspector_func):
     if len(function['func_signature_elems']['params']) > 0:
         if len(namespace) > 1:
             # Constructor handling
-            if namespace[-1] == convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]).replace(" *", ""):
+            if namespace[-1] == convert_param_list_to_str_v2(
+                    function['func_signature_elems']['params'][0]).replace(
+                        " *", ""):
                 logger.info("Option 1")
                 func_name = "::".join(namespace[0:-1]) + "::"
                 param_idx += 1
             # Destructor handling
             elif "~" in namespace[-1] and namespace[-1].replace(
-                    "~", "") == convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]).replace(" *", ""):
+                    "~", "") == convert_param_list_to_str_v2(
+                        function['func_signature_elems']['params'][0]).replace(
+                            " *", ""):
                 logger.info("Option 2")
                 func_name = "::".join(namespace[0:-1]) + "::"
 
-                if not convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]) == '~':
+                if not convert_param_list_to_str_v2(
+                        function['func_signature_elems']['params'][0]) == '~':
                     function['name'] = '~' + function['name']
                 param_idx += 1
             # Class object handling
-            elif namespace[-2] == convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]).replace(
-                    " *", "").replace("const ", ""):
+            elif namespace[-2] == convert_param_list_to_str_v2(
+                    function['func_signature_elems']['params'][0]).replace(
+                        " *", "").replace("const ", ""):
                 logger.info("Option 3")
                 func_name = "::".join(namespace[0:-1]) + "::"
                 param_idx += 1
@@ -920,8 +920,10 @@ def convert_debug_info_to_signature_v2(function, introspector_func):
 
     func_signature += func_name
     func_signature += '('
-    for idx in range(param_idx, len(function['func_signature_elems']['params'])):
-        param_string = convert_param_list_to_str_v2(function['func_signature_elems']['params'][idx]) 
+    for idx in range(param_idx,
+                     len(function['func_signature_elems']['params'])):
+        param_string = convert_param_list_to_str_v2(
+            function['func_signature_elems']['params'][idx])
         func_signature += param_string
         #func_signature += " ".join(function['func_signature_elems']['params'][idx])
         if idx < len(function['func_signature_elems']['params']) - 1:
@@ -956,9 +958,8 @@ def convert_param_list_to_str_v2(param_list):
     return raw_sig.strip()
 
 
-
-def correlate_introspector_func_to_debug_information_v2(if_func,
-                                                     all_debug_functions):
+def correlate_introspector_func_to_debug_information_v2(
+        if_func, all_debug_functions):
     # Check if name matches. If so, this one is easy.
     for debug_function in all_debug_functions:
         if debug_function.get('name', '') == if_func['Func name']:
@@ -972,11 +973,14 @@ def correlate_introspector_func_to_debug_information_v2(if_func,
     most_likely_func = None
     for dfunction in all_debug_functions:
         try:
-            dline = int(dfunction['func_signature_elems']['source_location'].get('line', '-1'))
+            dline = int(
+                dfunction['func_signature_elems']['source_location'].get(
+                    'line', '-1'))
         except ValueError:
             continue
 
-        if dfunction['func_signature_elems']['source_location'].get('file', '') == if_func['Functions filename']:
+        if dfunction['func_signature_elems']['source_location'].get(
+                'file', '') == if_func['Functions filename']:
 
             # Match based on containment, as there can be discrepancies between function
             # signatur start (as from frunc_to_match) and the lines of code of the first
@@ -1001,7 +1005,9 @@ def correlate_introspector_func_to_debug_information_v2(if_func,
     # Could not find the relevant stuff
     return None, None
 
-def correlate_introspection_functions_to_debug_info_v2(all_functions_json_report, debug_all_functions):
+
+def correlate_introspection_functions_to_debug_info_v2(
+        all_functions_json_report, debug_all_functions):
     for if_func in all_functions_json_report:
         func_sig, correlated_debug_function = correlate_introspector_func_to_debug_information_v2(
             if_func, debug_all_functions)
@@ -1012,4 +1018,3 @@ def correlate_introspection_functions_to_debug_info_v2(all_functions_json_report
         else:
             if_func['function_signature_v2'] = 'N/A'
             if_func['debug_function_info_v2'] = dict()
-

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -112,11 +112,17 @@ class IntrospectionProject():
         self.debug_files = data_loader.load_all_debug_files(self.base_folder)
         self.debug_type_files = data_loader.find_all_debug_all_types_files(
             self.base_folder)
+        self.debug_function_files = data_loader.find_all_debug_function_files(self.base_folder)
 
     def load_debug_report(self):
         self.debug_report = debug_info.load_debug_report(self.debug_files)
-        self.debug_all_types = debug_info.load_debug_all_types_files(
+        self.debug_all_types = debug_info.load_debug_all_yaml_files(
             self.debug_type_files)
+        self.debug_all_functions = debug_info.load_debug_all_yaml_files(self.debug_function_files)
+
+        # Extract the raw function signature. This propagates types into all of
+        # the debug functions.
+        debug_info.clean_extract_raw_all_debugged_function_signatures(self.debug_all_types, self.debug_all_functions)
 
     def dump_debug_report(self):
         if self.debug_report is not None:
@@ -847,3 +853,163 @@ def correlate_introspection_functions_to_debug_info(all_functions_json_report,
         else:
             if_func['function_signature'] = 'N/A'
             if_func['debug_function_info'] = dict()
+
+
+
+
+
+
+
+
+
+
+
+
+def convert_debug_info_to_signature_v2(function, introspector_func):
+    try:
+        return_type = convert_param_list_to_str_v2(function['func_signature_elems']['return_type'])
+        func_signature = return_type + " "
+    except KeyError:
+        return 'N/A'
+
+    # Assess if there is a namespace and if we have more args than what there
+    # should be, e.g. if this is a method on an object. We need to identify
+    # this because we want the function signature to be equal to what developers
+    # see.
+
+    # First step: Identify namespae
+    # 1) demangle raw name
+    # 2) identify namespace
+    # 3) identify if namespace last part matches first argument
+    # 4) assemble
+    namespace = extract_namespace(introspector_func['raw-function-name'],
+                                  return_type)
+
+    func_name = ''
+    param_idx = 0
+    logger.info("Namespace: %s" % (str(namespace)))
+    # Is this a class function?
+    if len(function['func_signature_elems']['params']) > 0:
+        if len(namespace) > 1:
+            # Constructor handling
+            if namespace[-1] == convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]).replace(" *", ""):
+                logger.info("Option 1")
+                func_name = "::".join(namespace[0:-1]) + "::"
+                param_idx += 1
+            # Destructor handling
+            elif "~" in namespace[-1] and namespace[-1].replace(
+                    "~", "") == convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]).replace(" *", ""):
+                logger.info("Option 2")
+                func_name = "::".join(namespace[0:-1]) + "::"
+
+                if not convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]) == '~':
+                    function['name'] = '~' + function['name']
+                param_idx += 1
+            # Class object handling
+            elif namespace[-2] == convert_param_list_to_str_v2(function['func_signature_elems']['params'][0]).replace(
+                    " *", "").replace("const ", ""):
+                logger.info("Option 3")
+                func_name = "::".join(namespace[0:-1]) + "::"
+                param_idx += 1
+            else:
+                # Simple function in namespace but not in a class
+                # No increasae in param_idx, since we don't eat the object
+                # instance pointer.
+                func_name = "::".join(namespace[0:-1]) + "::"
+    func_name += function['name']
+
+    func_signature += func_name
+    func_signature += '('
+    for idx in range(param_idx, len(function['func_signature_elems']['params'])):
+        param_string = convert_param_list_to_str_v2(function['func_signature_elems']['params'][idx]) 
+        func_signature += param_string
+        #func_signature += " ".join(function['func_signature_elems']['params'][idx])
+        if idx < len(function['func_signature_elems']['params']) - 1:
+            func_signature += ', '
+    func_signature += ')'
+    return func_signature
+
+
+def convert_param_list_to_str_v2(param_list):
+    pre = ""
+    med = ""
+    post = ""
+    for param in param_list:
+        if param == "DW_TAG_pointer_type":
+            post += "*"
+        elif param == 'DW_TAG_reference_type':
+            post += '&'
+        elif param == 'DW_TAG_structure_type':
+            continue
+        elif param == "DW_TAG_base_type":
+            continue
+        elif param == "DW_TAG_typedef":
+            continue
+        elif param == 'DW_TAG_class_type':
+            continue
+        elif param == "DW_TAG_const_type":
+            pre += "const "
+        else:
+            med += param
+
+    raw_sig = pre.strip() + " " + med + " " + post
+    return raw_sig.strip()
+
+
+
+def correlate_introspector_func_to_debug_information_v2(if_func,
+                                                     all_debug_functions):
+    # Check if name matches. If so, this one is easy.
+    for debug_function in all_debug_functions:
+        if debug_function.get('name', '') == if_func['Func name']:
+            func_signature = convert_debug_info_to_signature_v2(
+                debug_function, if_func)
+            return func_signature, debug_function
+
+    # We could not find the right one, let's search more broadly for it.
+    target_minimum = 999999
+    tfunc_signature = None
+    most_likely_func = None
+    for dfunction in all_debug_functions:
+        try:
+            dline = int(dfunction['func_signature_elems']['source_location'].get('line', '-1'))
+        except ValueError:
+            continue
+
+        if dfunction['func_signature_elems']['source_location'].get('file', '') == if_func['Functions filename']:
+
+            # Match based on containment, as there can be discrepancies between function
+            # signatur start (as from frunc_to_match) and the lines of code of the first
+            # instruction.
+            distance_between_beginnings = int(
+                if_func['source_line_begin']) - dline
+
+            if distance_between_beginnings == 0 and dline != 0:
+                func_signature = convert_debug_info_to_signature_v2(
+                    dfunction, if_func)
+                return func_signature, dfunction
+
+            elif distance_between_beginnings > 0 and distance_between_beginnings < target_minimum:
+                tfunc_signature = convert_debug_info_to_signature_v2(
+                    dfunction, if_func)
+                most_likely_func = dfunction
+                target_minimum = distance_between_beginnings
+
+    if most_likely_func is not None:
+        return tfunc_signature, most_likely_func
+
+    # Could not find the relevant stuff
+    return None, None
+
+def correlate_introspection_functions_to_debug_info_v2(all_functions_json_report, debug_all_functions):
+    for if_func in all_functions_json_report:
+        func_sig, correlated_debug_function = correlate_introspector_func_to_debug_information_v2(
+            if_func, debug_all_functions)
+
+        if func_sig is not None:
+            if_func['function_signature_v2'] = func_sig
+            if_func['debug_function_info_v2'] = correlated_debug_function
+        else:
+            if_func['function_signature_v2'] = 'N/A'
+            if_func['debug_function_info_v2'] = dict()
+

--- a/src/fuzz_introspector/data_loader.py
+++ b/src/fuzz_introspector/data_loader.py
@@ -90,6 +90,16 @@ def find_all_debug_all_types_files(target_folder: str):
     return debug_info_files
 
 
+def find_all_debug_function_files(target_folder: str):
+    """Loads all debug_all_functions files"""
+    debug_info_files = utils.get_all_files_in_tree_with_regex(
+        target_folder, ".*debug_all_functions$")
+    for file in debug_info_files:
+        print("debug info file: %s" % (file))
+    return debug_info_files
+
+
+
 def load_all_profiles(
         target_folder: str,
         language: str,

--- a/src/fuzz_introspector/data_loader.py
+++ b/src/fuzz_introspector/data_loader.py
@@ -99,7 +99,6 @@ def find_all_debug_function_files(target_folder: str):
     return debug_info_files
 
 
-
 def load_all_profiles(
         target_folder: str,
         language: str,

--- a/src/fuzz_introspector/debug_info.py
+++ b/src/fuzz_introspector/debug_info.py
@@ -327,17 +327,107 @@ def dump_debug_report(report_dict):
         debug_dump.write(json.dumps(report_dict))
 
 
-def load_debug_all_types_files(debug_all_types_files):
-    types_list = []
+def load_debug_all_yaml_files(debug_all_types_files):
+    elem_list = []
     yaml.SafeLoader = yaml.CSafeLoader  # type: ignore[assignment, misc]
     for filename in debug_all_types_files:
         with open(filename, 'r') as yaml_f:
             file_list = yaml.safe_load(yaml_f.read())
-            types_list += file_list
+            elem_list += file_list
+    return elem_list
+
+
+def find_type_with_addr(target_type, all_debug_types):
+    for debug_type in all_debug_types:
+        if int(debug_type['addr']) == int(target_type):
+            return debug_type
+    return None
+
+
+def extract_func_sig_friendly_type_tags(target_type, all_debug_types):
+    if int(target_type) == 0:
+        return ['void']
+    
+    tags = []
+    type_to_query = target_type
+    addresses_visited = set()
+    while True:
+        if type_to_query in addresses_visited:
+            tags.append("Infinite loop")
+            break
+
+        target_type = find_type_with_addr(type_to_query, all_debug_types)
+        if target_type is None:
+            tags.append("N/A")
+            break
+
+        # Provide the tag
+        tags.append(target_type['tag'])
+
+        name= target_type.get("name", "")
+        if name != "":
+            tags.append(name)
+            break
+
+        base_type_string = target_type.get("base_type_string", "")
+        if base_type_string != "":
+            tags.append(base_type_string)
+            break
+
+        addresses_visited.add(type_to_query)
+
+        type_to_query = target_type.get('base_type_addr', '')
+        if int(type_to_query) == 0:
+            tags.append("void")
+            break
+    
+    return tags
+
+
+def extract_debugged_function_signature(dfunc, all_debug_types):
+    return_type = extract_func_sig_friendly_type_tags(dfunc['type_arguments'][0], all_debug_types)
+    params = []
+
+    if len(dfunc['type_arguments']) > 1:
+        for i in range(1, len(dfunc['type_arguments'])):
+            params.append(extract_func_sig_friendly_type_tags(dfunc['type_arguments'][i], all_debug_types))
+
+    source_file = dfunc['file_location'].split(":")[0]
+    try:
+        source_line = dfunc['file_location'].split(":")[1]
+    except IndexError:
+        source_line = "-1"
+
+    function_signature_elements = {
+        'return_type': return_type,
+        'params': params,
+        'source_location': {
+            'file': source_file,
+            'line': source_line
+        }
+    }
+
+    return function_signature_elements
+
+
+def clean_extract_raw_all_debugged_function_signatures(all_debug_types, all_debug_functions):
+    print("Correlating")
+    for dfunc in all_debug_functions:
+        
+        func_signature_elems = extract_debugged_function_signature(dfunc, all_debug_types)
+        dfunc['func_signature_elems'] = func_signature_elems
+
+        #print(dfunc['name'])
+        #print(json.dumps(dfunc['func_signature_elems'], indent=2))
+        #print(json.dumps(dfunc, indent=2))
 
 
 if __name__ in "__main__":
     import sys
     print("Main")
-    debug_files = [sys.argv[1]]
-    load_debug_all_types_files(debug_files)
+    type_debug_files = [sys.argv[1]]
+    functions_debug_files = [sys.argv[1].replace("debug_all_types", "debug_all_functions")]
+    all_types = load_debug_all_yaml_files(type_debug_files)
+    all_funcs = load_debug_all_yaml_files(functions_debug_files)
+
+    #correlate_debug_information(all_types, all_funcs)

--- a/src/fuzz_introspector/debug_info.py
+++ b/src/fuzz_introspector/debug_info.py
@@ -385,7 +385,10 @@ def extract_func_sig_friendly_type_tags(target_type, all_debug_types):
 
 
 def extract_debugged_function_signature(dfunc, all_debug_types):
-    return_type = extract_func_sig_friendly_type_tags(dfunc['type_arguments'][0], all_debug_types)
+    try:
+        return_type = extract_func_sig_friendly_type_tags(dfunc['type_arguments'][0], all_debug_types)
+    except IndexError:
+        return_type = 'N/A'
     params = []
 
     if len(dfunc['type_arguments']) > 1:

--- a/src/fuzz_introspector/debug_info.py
+++ b/src/fuzz_introspector/debug_info.py
@@ -425,10 +425,6 @@ def clean_extract_raw_all_debugged_function_signatures(all_debug_types,
             dfunc, all_debug_types)
         dfunc['func_signature_elems'] = func_signature_elems
 
-        #print(dfunc['name'])
-        #print(json.dumps(dfunc['func_signature_elems'], indent=2))
-        #print(json.dumps(dfunc, indent=2))
-
 
 if __name__ in "__main__":
     import sys
@@ -439,5 +435,3 @@ if __name__ in "__main__":
     ]
     all_types = load_debug_all_yaml_files(type_debug_files)
     all_funcs = load_debug_all_yaml_files(functions_debug_files)
-
-    #correlate_debug_information(all_types, all_funcs)

--- a/src/fuzz_introspector/debug_info.py
+++ b/src/fuzz_introspector/debug_info.py
@@ -347,7 +347,7 @@ def find_type_with_addr(target_type, all_debug_types):
 def extract_func_sig_friendly_type_tags(target_type, all_debug_types):
     if int(target_type) == 0:
         return ['void']
-    
+
     tags = []
     type_to_query = target_type
     addresses_visited = set()
@@ -364,7 +364,7 @@ def extract_func_sig_friendly_type_tags(target_type, all_debug_types):
         # Provide the tag
         tags.append(target_type['tag'])
 
-        name= target_type.get("name", "")
+        name = target_type.get("name", "")
         if name != "":
             tags.append(name)
             break
@@ -380,20 +380,23 @@ def extract_func_sig_friendly_type_tags(target_type, all_debug_types):
         if int(type_to_query) == 0:
             tags.append("void")
             break
-    
+
     return tags
 
 
 def extract_debugged_function_signature(dfunc, all_debug_types):
     try:
-        return_type = extract_func_sig_friendly_type_tags(dfunc['type_arguments'][0], all_debug_types)
+        return_type = extract_func_sig_friendly_type_tags(
+            dfunc['type_arguments'][0], all_debug_types)
     except IndexError:
         return_type = 'N/A'
     params = []
 
     if len(dfunc['type_arguments']) > 1:
         for i in range(1, len(dfunc['type_arguments'])):
-            params.append(extract_func_sig_friendly_type_tags(dfunc['type_arguments'][i], all_debug_types))
+            params.append(
+                extract_func_sig_friendly_type_tags(dfunc['type_arguments'][i],
+                                                    all_debug_types))
 
     source_file = dfunc['file_location'].split(":")[0]
     try:
@@ -413,11 +416,13 @@ def extract_debugged_function_signature(dfunc, all_debug_types):
     return function_signature_elements
 
 
-def clean_extract_raw_all_debugged_function_signatures(all_debug_types, all_debug_functions):
+def clean_extract_raw_all_debugged_function_signatures(all_debug_types,
+                                                       all_debug_functions):
     print("Correlating")
     for dfunc in all_debug_functions:
-        
-        func_signature_elems = extract_debugged_function_signature(dfunc, all_debug_types)
+
+        func_signature_elems = extract_debugged_function_signature(
+            dfunc, all_debug_types)
         dfunc['func_signature_elems'] = func_signature_elems
 
         #print(dfunc['name'])
@@ -429,7 +434,9 @@ if __name__ in "__main__":
     import sys
     print("Main")
     type_debug_files = [sys.argv[1]]
-    functions_debug_files = [sys.argv[1].replace("debug_all_types", "debug_all_functions")]
+    functions_debug_files = [
+        sys.argv[1].replace("debug_all_types", "debug_all_functions")
+    ]
     all_types = load_debug_all_yaml_files(type_debug_files)
     all_funcs = load_debug_all_yaml_files(functions_debug_files)
 

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -758,6 +758,9 @@ def create_html_report(introspection_proj: analysis.IntrospectionProject,
     analysis.correlate_introspection_functions_to_debug_info(
         all_functions_json_report, introspection_proj.debug_report)
 
+    analysis.correlate_introspection_functions_to_debug_info_v2(
+        all_functions_json_report, introspection_proj.debug_all_functions)
+
     # Write various stats and all-functions data to summary.json
     proj_profile.write_stats_to_summary_file()
     json_report.add_project_key_value_to_report("all-functions",


### PR DESCRIPTION
This replaces the existing debug data handling. We now rely on yaml formats rather than the ad-hoc approach previously. Currently both are in place but we should switch to the new one.