### PR TITLE
examples: remove `-flegacy-pass-manager` usage

### DIFF
--- a/tests/simple-example-0/build_all.sh
+++ b/tests/simple-example-0/build_all.sh
@@ -20,5 +20,4 @@ rm -rf ./work
 mkdir work
 cd work
 
-#../../../build/llvm-build/bin/clang -flegacy-pass-manager -fsanitize=fuzzer -flegacy-pass-manager -flto -g ../fuzzer.c -o fuzzer
 ../../../build/llvm-build/bin/clang -fsanitize=fuzzer -flto -g ../fuzzer.c -o fuzzer

--- a/tests/simple-example-0/build_cov.sh
+++ b/tests/simple-example-0/build_cov.sh
@@ -21,7 +21,7 @@ if [ -d "work" ]; then
     cd work
 fi
 
-../../../build/llvm-build/bin/clang -flegacy-pass-manager -fprofile-instr-generate -fcoverage-mapping -fsanitize=fuzzer -g ../fuzzer.c -o fuzzer
+../../../build/llvm-build/bin/clang -fprofile-instr-generate -fcoverage-mapping -fsanitize=fuzzer -g ../fuzzer.c -o fuzzer
 ./fuzzer -max_total_time=3
 ../../../build/llvm-build/bin/llvm-profdata merge -sparse default.profraw -o merged_cov.profdata
 ../../../build/llvm-build/bin/llvm-cov show -instr-profile=merged_cov.profdata -object=./fuzzer -line-coverage-gt=0 > fuzzer.covreport


### PR DESCRIPTION
Otherwise you'll see: `clang: error: unknown argument: '-flegacy-pass-manager'` when running through `localbuild.md` and things wont work as expected. LLVM 18 has been used since #1440.