### PR TITLE
Update all-cross-references

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -757,7 +757,10 @@ def api_cross_references():
     target_function = get_function_from_func_signature(function_signature,
                                                        project_name)
     if target_function == None:
-        return {'result': 'error', 'msg': 'Function signature could not be found'}
+        return {
+            'result': 'error',
+            'msg': 'Function signature could not be found'
+        }
     function_name = target_function.raw_function_name
 
     # Get all of the functions

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -756,6 +756,8 @@ def api_cross_references():
     # Get function from function signature
     target_function = get_function_from_func_signature(function_signature,
                                                        project_name)
+    if target_function == None:
+        return {'result': 'error', 'msg': 'Function signature could not be found'}
     function_name = target_function.raw_function_name
 
     # Get all of the functions


### PR DESCRIPTION
Return error when a function signature can't be found.