### PR TITLE
frontends: llvm: make it possible to force llvm analysis

### DIFF
--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -851,11 +851,14 @@ bool FuzzIntrospector::runOnModule(Module &M) {
   }
 
   logPrintf(L1, "Running introspector on %s\n", M.getName());
-  if (shouldRunIntrospector(M) == false) {
-    // Run the analysis on a non-fuzzer binary.
-    runIntrospectorOnNonFuzzerBinary(M);
-    return false;
+  if (!getenv("FUZZ_INTROSPECTOR_FORCE_RUN")) {
+    if (shouldRunIntrospector(M) == false) {
+      // Run the analysis on a non-fuzzer binary.
+      runIntrospectorOnNonFuzzerBinary(M);
+      return false;
+    }
   }
+
   // init randomness
   srand((unsigned)time(NULL) * getpid());
 


### PR DESCRIPTION
This is useful when you e.g. want to analyse a single .bc file, which seems more meaningful now that we also extract debug symbols and output data about each function in the .bc that can be input to program analysis tooling.