### PR TITLE
[JVM] Add logic for filtering inaccessible and special methods

### DIFF
--- a/src/fuzz_introspector/analyses/sinks_analyser.py
+++ b/src/fuzz_introspector/analyses/sinks_analyser.py
@@ -408,7 +408,7 @@ class SinkCoverageAnalyser(analysis.AnalysisInterface):
             # Loop through the list of callpaths and
             # filter out inaccessbile callpths
             for callpath in callpath_list:
-                if callpath[0].accessible:
+                if callpath[0].is_accessible and not callpath[0].is_jvm_library:
                     result.append(callpath)
 
             return result

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -902,7 +902,8 @@ def correlate_introspector_func_to_debug_information(if_func,
 
 
 def correlate_introspection_functions_to_debug_info(all_functions_json_report,
-                                                    debug_all_functions):
+                                                    debug_all_functions,
+                                                    proj_lang):
     """Correlates function data collected by debug information to function
     data collected by LLVMs module, and uses the correlated data to generate
     function signatures for each function based on debug information."""
@@ -941,5 +942,8 @@ def correlate_introspection_functions_to_debug_info(all_functions_json_report,
             if_func['function_signature'] = func_sig
             if_func['debug_function_info'] = correlated_debug_function
         else:
-            if_func['function_signature'] = 'N/A'
+            if proj_lang == 'jvm':
+                if_func['function_signature'] = if_func['Func name']
+            else:
+                if_func['function_signature'] = 'N/A'
             if_func['debug_function_info'] = dict()

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -127,10 +127,10 @@ class FunctionProfile:
 
     def _is_function_acccessible(self, elem: Dict[Any, Any]) -> bool:
         if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
-            return (bool(elem['JavaMethodInfo']['public']) and
-                    bool(elem['JavaMethodInfo']['classPublic']) and
-                    bool(elem['JavaMethodInfo']['concrete']) and
-                    bool(elem['JavaMethodInfo']['classConcrete']))
+            return (bool(elem['JavaMethodInfo']['public'])
+                    and bool(elem['JavaMethodInfo']['classPublic'])
+                    and bool(elem['JavaMethodInfo']['concrete'])
+                    and bool(elem['JavaMethodInfo']['classConcrete']))
 
         return True
 

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -138,10 +138,10 @@ class FunctionProfile:
         if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
             return bool(elem['JavaMethodInfo']['javaLibraryMethod'])
 
-        return True
+        return False
 
     def _is_enum_class(self, elem: Dict[Any, Any]) -> bool:
         if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
             return bool(elem['JavaMethodInfo']['classEnum'])
 
-        return True
+        return False

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -62,8 +62,12 @@ class FunctionProfile:
         self.functions_called = utils.load_func_names(elem['functionsReached'],
                                                       False)
 
-        # Check if this function is accessible
-        self.accessible = self.is_function_acccessible(elem)
+        # Check if this function is accessible or contains special properties
+        # Currently, only JVM projects are using these parameters
+        # All functions of non-JVM projects will always get True for these parameters
+        self.is_accessible = self._is_function_acccessible(elem)
+        self.is_library = self._is_jvm_library(elem)
+        self.is_enum = self._is_enum_class(elem)
 
         # Temporary handle for unreadable library method (JVM)
         # (jar missing or purposely ignored)
@@ -119,20 +123,25 @@ class FunctionProfile:
 
         return cs_loaded
 
-    def is_function_acccessible(self, elem: Dict[Any, Any]) -> bool:
-        # Currently only support jvm which accessible information is available
+    ### Special functions for discovering accessibility and status for JVM methods. ###
+
+    def _is_function_acccessible(self, elem: Dict[Any, Any]) -> bool:
         if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
-            if elem['JavaMethodInfo']['javaLibraryMethod']:
-                return False
-            if elem['JavaMethodInfo']['classEnum']:
-                return False
-            if not elem['JavaMethodInfo']['public']:
-                return False
-            if not elem['JavaMethodInfo']['classPublic']:
-                return False
-            if not elem['JavaMethodInfo']['concrete']:
-                return False
-            if not elem['JavaMethodInfo']['classConcrete']:
-                return False
+            return (bool(elem['JavaMethodInfo']['public']) and
+                    bool(elem['JavaMethodInfo']['classPublic']) and
+                    bool(elem['JavaMethodInfo']['concrete']) and
+                    bool(elem['JavaMethodInfo']['classConcrete']))
+
+        return True
+
+    def _is_jvm_library(self, elem: Dict[Any, Any]) -> bool:
+        if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
+            return bool(elem['JavaMethodInfo']['javaLibraryMethod'])
+
+        return True
+
+    def _is_enum_class(self, elem: Dict[Any, Any]) -> bool:
+        if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
+            return bool(elem['JavaMethodInfo']['classEnum'])
 
         return True

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -66,7 +66,7 @@ class FunctionProfile:
         # Currently, only JVM projects are using these parameters
         # All functions of non-JVM projects will always get True for these parameters
         self.is_accessible = self._is_function_acccessible(elem)
-        self.is_library = self._is_jvm_library(elem)
+        self.is_jvm_library = self._is_jvm_library(elem)
         self.is_enum = self._is_enum_class(elem)
 
         # Temporary handle for unreadable library method (JVM)
@@ -123,7 +123,7 @@ class FunctionProfile:
 
         return cs_loaded
 
-    ### Special functions for discovering accessibility and status for JVM methods. ###
+    # Special functions for discovering accessibility and status for JVM methods. #
 
     def _is_function_acccessible(self, elem: Dict[Any, Any]) -> bool:
         if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -143,6 +143,9 @@ def create_all_function_table(
         json_copy['callsites'] = fd.callsite
         json_copy['source_line_begin'] = fd.function_linenumber
         json_copy['source_line_end'] = fd.function_line_number_end
+        json_copy['is_accessible'] = fd.is_accessible
+        json_copy['is_jvm_library'] = fd.is_jvm_library
+        json_copy['is_enum_class'] = fd.is_enum
         table_rows_json_report.append(json_copy)
 
     logger.info("Assembled a total of %d entries" %
@@ -759,7 +762,8 @@ def create_html_report(introspection_proj: analysis.IntrospectionProject,
 
     # Correlate debug info to introspector functions
     analysis.correlate_introspection_functions_to_debug_info(
-        all_functions_json_report, introspection_proj.debug_all_functions)
+        all_functions_json_report, introspection_proj.debug_all_functions,
+        proj_profile.target_lang)
 
     # Write various stats and all-functions data to summary.json
     proj_profile.write_stats_to_summary_file()

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -229,6 +229,9 @@ def extract_and_refine_functions(all_function_list, project_name, date_str):
             'function_signature', 'N/A')
         introspector_func['debug-function'] = func.get('debug_function_info',
                                                        dict())
+        introspector_func['is_accessible'] = func.get('is_accessible', True)
+        introspector_func['is_jvm_library'] = func.get('is_jvm_library', False)
+        introspector_func['is_enum_class'] = func.get('is_enum_class', False)
 
         refined_proj_list.append(introspector_func)
     return refined_proj_list

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -75,6 +75,9 @@ def load_db():
                 callsites=func.get('callsites', []),
                 func_signature=func.get('function-signature', 'N/A'),
                 debug_data=func.get('debug-function', 'N/A'),
+                is_accessible=func.get('is_accessible', True),
+                is_jvm_library=func.get('is_jvm_library', False),
+                is_enum_class=func.get('is_enum_class', False)
             ))
 
     print("Loadded %d functions" % (idx))

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -77,8 +77,7 @@ def load_db():
                 debug_data=func.get('debug-function', 'N/A'),
                 is_accessible=func.get('is_accessible', True),
                 is_jvm_library=func.get('is_jvm_library', False),
-                is_enum_class=func.get('is_enum_class', False)
-            ))
+                is_enum_class=func.get('is_enum_class', False)))
 
     print("Loadded %d functions" % (idx))
     print("Len %d" % (len(data_storage.FUNCTIONS)))

--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -100,7 +100,10 @@ class Function:
                  source_line_end=-1,
                  callsites=[],
                  func_signature='',
-                 debug_data=dict()):
+                 debug_data=dict(),
+                 is_accessible = True,
+                 is_jvm_library = False,
+                 is_enum_class = False):
         self.name = name
         self.function_filename = function_filename
         self.project = project
@@ -121,6 +124,9 @@ class Function:
         self.callsites = callsites
         self.func_signature = func_signature
         self.debug_data = debug_data
+        self.is_accessible = is_accessible
+        self.is_jvm_library = is_jvm_library
+        self.is_enum_class = is_enum_class
 
     def __dict__(self):
         return {
@@ -135,7 +141,10 @@ class Function:
             'accummulated_cyclomatic_complexity':
             self.accummulated_cyclomatic_complexity,
             'undiscovered_complexity': self.undiscovered_complexity,
-            'function_filename': self.function_filename
+            'function_filename': self.function_filename,
+            'is_accessible': self.is_accessible,
+            'is_jvm_library': self.is_jvm_library,
+            'is_enum_class': self.is_enum_class
         }
 
 

--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -101,9 +101,9 @@ class Function:
                  callsites=[],
                  func_signature='',
                  debug_data=dict(),
-                 is_accessible = True,
-                 is_jvm_library = False,
-                 is_enum_class = False):
+                 is_accessible=True,
+                 is_jvm_library=False,
+                 is_enum_class=False):
         self.name = name
         self.function_filename = function_filename
         self.project = project

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -135,6 +135,9 @@ def get_functions_of_interest(project_name):
     all_functions = data_storage.get_functions()
     project_functions = []
     for function in all_functions:
+        # Skipping non-related jvm methods and methods from enum classes
+        if not function.is_accessible or function.is_jvm_library or function.is_enum:
+            continue
         if function.project == project_name:
             if function.runtime_code_coverage < 20.0:
                 project_functions.append(function)
@@ -207,6 +210,9 @@ def get_all_related_functions(primary_function):
     all_functions = data_storage.get_functions()
     related_functions = []
     for function in all_functions:
+        # Skipping non-related jvm methods
+        if not function.is_accessible or function.is_jvm_library:
+            continue
         if function.name == primary_function.name and function.project != primary_function.project:
             related_functions.append(function)
     return related_functions

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -136,7 +136,7 @@ def get_functions_of_interest(project_name):
     project_functions = []
     for function in all_functions:
         # Skipping non-related jvm methods and methods from enum classes
-        if not function.is_accessible or function.is_jvm_library or function.is_enum:
+        if not function.is_accessible or function.is_jvm_library or function.is_enum_class:
             continue
         if function.project == project_name:
             if function.runtime_code_coverage < 20.0:


### PR DESCRIPTION
Some methods in a JVM project could be inaccessible because of different reasons. Also, the present of sink analyser tool also requires adding information of some sink methods in the JVM library for processing. This PR adds extra properties in the FunctionProfile to identify if the method is publicly accessible, belongs to the JVM base library or belongs to a Enum classes. Different logic is then using these new properties to consider if some of those special methods needed to be ignored. 
The following changes  have been made.
1. Add three additional boolean properties in FunctionProfile, the values of the properties is determined by the JavaMethodDetails in the data.yaml file for Java project, and default value is used for non-Java project which should not affect the logic.
2. Add the three additional properties into summary.json for each function.
3. Fix sink analyser by applying filters with these three properties .It should only affect Java project because non-Java project always passed the filter with the default value.
4. Fix models and __init__ for the webapps tool to extract and save the three additional properties.
5. Apply filters to function extraction for those apis using the additional properties. it should only affect Java project because non-Java project always passed the filter with the default value.