### PR TITLE
Fix constructor display in summary.json

### DIFF
--- a/src/fuzz_introspector/constants.py
+++ b/src/fuzz_introspector/constants.py
@@ -20,6 +20,7 @@ GIT_BRANCH_URL = f"{GIT_REPO}/blob/main"
 ENGINE_INPUT_FILE = "fuzz-introspector-engine-input.json"
 SUMMARY_FILE = "summary.json"
 ALL_FUNCTIONS_JSON = 'all-fuzz-introspector-functions.json'
+ALL_JVM_CONSTRUCTOR_JSON = 'all-fuzz-introspector-jvm-constructor.json'
 BRANCH_BLOCKERS_FILE = 'branch-blockers.json'
 
 HTML_REPORT = "fuzz_report.html"

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -555,13 +555,15 @@ class FuzzerProfile:
                     f"May have non-normalised function: {elem['functionName']}"
                 )
 
-            if self.target_lang == "jvm" and "<init>" in elem['functionName']:
-                logger.debug("Skipping <init> method for JVM")
-                continue
-
             func_profile = function_profile.FunctionProfile(elem)
             logger.debug(f"Adding {func_profile.function_name}")
-            self.all_class_functions[func_profile.function_name] = func_profile
+
+            if self.target_lang == "jvm" and "<init>" in elem['functionName']:
+                # Store JVM constructor separately
+                self.all_class_constructors[func_profile.function_name] = func_profile
+            else:
+                # Store the functions
+                self.all_class_functions[func_profile.function_name] = func_profile
 
     def _is_func_name_missing_normalisation(self, func_name: str) -> bool:
         if "." in func_name:

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -562,10 +562,12 @@ class FuzzerProfile:
 
             if self.target_lang == "jvm" and "<init>" in elem['functionName']:
                 # Store JVM constructor separately
-                self.all_class_constructors[func_profile.function_name] = func_profile
+                self.all_class_constructors[
+                    func_profile.function_name] = func_profile
             else:
                 # Store the functions
-                self.all_class_functions[func_profile.function_name] = func_profile
+                self.all_class_functions[
+                    func_profile.function_name] = func_profile
 
     def _is_func_name_missing_normalisation(self, func_name: str) -> bool:
         if "." in func_name:

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -49,6 +49,8 @@ class FuzzerProfile:
         self.coverage: Optional[code_coverage.CoverageProfile] = None
         self.all_class_functions: Dict[
             str, function_profile.FunctionProfile] = dict()
+        self.all_class_constructors: Dict[
+            str, function_profile.FunctionProfile] = dict()
         self.branch_blockers: List[Any] = []
 
         self._target_lang = target_lang

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -1,3 +1,4 @@
+
 # Copyright 2022 Fuzz Introspector Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +43,8 @@ class MergedProjectProfile:
         self.profiles = profiles
         self.all_functions: Dict[str,
                                  function_profile.FunctionProfile] = dict()
+        self.all_constructors: Dict[str,
+                                 function_profile.FunctionProfile] = dict()
         self.unreached_functions = set()
         self.functions_reached = set()
         self.coverage_url = "#"
@@ -68,6 +71,12 @@ class MergedProjectProfile:
         logger.info("Creating all_functions dictionary")
         excluded_functions = {"sanitizer", "llvm", "LLVMFuzzerTestOneInput"}
         for profile in profiles:
+            # Handles jvm constructors
+            for fd in profile.all_class_constructors.values():
+                if fd.function_name not in self.all_constructors:
+                    self.all_constructors[fd.function_name] = fd
+
+            # Handles normal functions
             for fd in profile.all_class_functions.values():
                 # continue if the function is to be excluded
                 if any(to_exclude in fd.function_name
@@ -85,12 +94,16 @@ class MergedProjectProfile:
         # Gather complexity information about each function
         logger.info(
             "Gathering complexity and incoming references of each function")
-        for fp_obj in self.all_functions.values():
+        for fp_obj in {**self.all_functions, **self.all_constructors}.values():
             total_cyclomatic_complexity = 0
             total_new_complexity = 0
 
             for reached_func_name in fp_obj.functions_reached:
-                if reached_func_name not in self.all_functions:
+                if reached_func_name in self.all_functions:
+                    reached_func_obj = self.all_functions[reached_func_name]
+                elif reached_func_name in self.all_constructors:
+                    reached_func_obj = self.all_constructors[reached_func_name]
+                else:
                     if profile.target_lang == "jvm":
                         logger.debug(
                             f"{reached_func_name} not provided within classpath"
@@ -99,7 +112,6 @@ class MergedProjectProfile:
                         logger.debug(
                             f"Mismatched function name: {reached_func_name}")
                     continue
-                reached_func_obj = self.all_functions[reached_func_name]
                 reached_func_obj.incoming_references.append(
                     fp_obj.function_name)
                 total_cyclomatic_complexity += reached_func_obj.cyclomatic_complexity
@@ -155,6 +167,7 @@ class MergedProjectProfile:
         self._set_basefolder()
         self._set_fd_cache()
         logger.info("Completed creationg of merged profile")
+        logger.info(self.all_functions)
 
     def get_all_runtime_covered_functions(self) -> List[str]:
         """Gets the name of all functions that are covered by runtime

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -44,7 +44,7 @@ class MergedProjectProfile:
         self.all_functions: Dict[str,
                                  function_profile.FunctionProfile] = dict()
         self.all_constructors: Dict[str,
-                                 function_profile.FunctionProfile] = dict()
+                                    function_profile.FunctionProfile] = dict()
         self.unreached_functions = set()
         self.functions_reached = set()
         self.coverage_url = "#"

--- a/src/fuzz_introspector/datatypes/project_profile.py
+++ b/src/fuzz_introspector/datatypes/project_profile.py
@@ -1,4 +1,3 @@
-
 # Copyright 2022 Fuzz Introspector Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -791,7 +791,8 @@ def create_html_report(introspection_proj: analysis.IntrospectionProject,
             jvm_constructor_json_report.append(json_copy)
 
         if jvm_constructor_json_report:
-            json_report.create_all_jvm_constructor_json(jvm_constructor_json_report)
+            json_report.create_all_jvm_constructor_json(
+                jvm_constructor_json_report)
 
     if dump_files:
         write_content_to_html_files(html_full_doc, all_functions_json_html,

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -151,25 +151,6 @@ def create_all_function_table(
     logger.info("Assembled a total of %d entries" %
                 (len(table_rows_json_report)))
     html_string += ("</table>\n")
-
-    # If it is a JVM project, also include constructors in json report
-    if proj_profile.target_lang == 'jvm' and table_rows_json_report:
-        for fd in proj_profile.all_constructors.values():
-            json_copy = table_rows_json_report[-1].copy()
-            json_copy['Func name'] = fd.function_name
-            json_copy['Args'] = fd.arg_types
-            json_copy['ArgNames'] = fd.arg_names
-            json_copy['Reached by Fuzzers'] = fd.reached_by_fuzzers
-            json_copy['return_type'] = fd.return_type
-            json_copy['raw-function-name'] = fd.raw_function_name
-            json_copy['callsites'] = fd.callsite
-            json_copy['source_line_begin'] = fd.function_linenumber
-            json_copy['source_line_end'] = fd.function_line_number_end
-            json_copy['is_accessible'] = fd.is_accessible
-            json_copy['is_jvm_library'] = fd.is_jvm_library
-            json_copy['is_enum_class'] = fd.is_enum
-            table_rows_json_report.append(json_copy)
-
     return html_string, table_rows_json_html, table_rows_json_report
 
 
@@ -787,7 +768,31 @@ def create_html_report(introspection_proj: analysis.IntrospectionProject,
     # Write various stats and all-functions data to summary.json
     proj_profile.write_stats_to_summary_file()
 
+    # Write all functions to all-fuzz-introspector-functions.json
     json_report.create_all_fi_functions_json(all_functions_json_report)
+
+    # Write jvm constructor details to all-fuzz-introspector-jvm-constructor.json
+    if proj_profile.target_lang == 'jvm' and all_functions_json_report:
+        jvm_constructor_json_report = []
+        for fd in proj_profile.all_constructors.values():
+            json_copy = all_functions_json_report[-1].copy()
+            json_copy['Func name'] = fd.function_name
+            json_copy['Args'] = fd.arg_types
+            json_copy['ArgNames'] = fd.arg_names
+            json_copy['Reached by Fuzzers'] = fd.reached_by_fuzzers
+            json_copy['return_type'] = fd.return_type
+            json_copy['raw-function-name'] = fd.raw_function_name
+            json_copy['callsites'] = fd.callsite
+            json_copy['source_line_begin'] = fd.function_linenumber
+            json_copy['source_line_end'] = fd.function_line_number_end
+            json_copy['is_accessible'] = fd.is_accessible
+            json_copy['is_jvm_library'] = fd.is_jvm_library
+            json_copy['is_enum_class'] = fd.is_enum
+            jvm_constructor_json_report.append(json_copy)
+
+        if jvm_constructor_json_report:
+            json_report.create_all_jvm_constructor_json(jvm_constructor_json_report)
+
     if dump_files:
         write_content_to_html_files(html_full_doc, all_functions_json_html,
                                     fuzzer_table_data)

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -151,6 +151,25 @@ def create_all_function_table(
     logger.info("Assembled a total of %d entries" %
                 (len(table_rows_json_report)))
     html_string += ("</table>\n")
+
+    # If it is a JVM project, also include constructors in json report
+    if proj_profile.target_lang == 'jvm' and table_rows_json_report:
+        for fd in proj_profile.all_constructors.values():
+            json_copy = table_rows_json_report[-1].copy()
+            json_copy['Func name'] = fd.function_name
+            json_copy['Args'] = fd.arg_types
+            json_copy['ArgNames'] = fd.arg_names
+            json_copy['Reached by Fuzzers'] = fd.reached_by_fuzzers
+            json_copy['return_type'] = fd.return_type
+            json_copy['raw-function-name'] = fd.raw_function_name
+            json_copy['callsites'] = fd.callsite
+            json_copy['source_line_begin'] = fd.function_linenumber
+            json_copy['source_line_end'] = fd.function_line_number_end
+            json_copy['is_accessible'] = fd.is_accessible
+            json_copy['is_jvm_library'] = fd.is_jvm_library
+            json_copy['is_enum_class'] = fd.is_enum
+            table_rows_json_report.append(json_copy)
+
     return html_string, table_rows_json_html, table_rows_json_report
 
 

--- a/src/fuzz_introspector/json_report.py
+++ b/src/fuzz_introspector/json_report.py
@@ -108,6 +108,11 @@ def create_all_fi_functions_json(functions_dict) -> None:
         json.dump(functions_dict, f)
 
 
+def create_all_jvm_constructor_json(functions_dict) -> None:
+    with open(constants.ALL_JVM_CONSTRUCTOR_JSON, 'w') as f:
+        json.dump(functions_dict, f)
+
+
 def add_branch_blocker_key_value_to_report(profile_identifier, key,
                                            branch_blockers_list):
     """Returns the current json report on disk as a dictionary."""

--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -37,6 +37,11 @@ def get_introspector_report_url_all_functions(project_name, datestr):
         project_name, datestr) + "all-fuzz-introspector-functions.json"
 
 
+def get_introspector_report_url_jvm_constructor(project_name, datestr):
+    return get_introspector_report_url_base(
+        project_name, datestr) + "all-fuzz-introspector-jvm-constructor.json"
+
+
 def get_introspector_report_url_report(project_name, datestr):
     return get_introspector_report_url_base(project_name,
                                             datestr) + "fuzz_report.html"
@@ -115,6 +120,15 @@ def extract_local_introspector_function_list(project_name, oss_fuzz_folder):
     return function_list
 
 
+def extract_local_introspector_constructor_list(project_name, oss_fuzz_folder):
+    summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
+                                'inspector',
+                                'all-fuzz-introspector-jvm-constructor.json')
+    with open(summary_json, 'r') as f:
+        function_list = json.load(f)
+    return function_list
+
+
 def extract_local_introspector_report(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector', 'summary.json')
@@ -157,18 +171,30 @@ def extract_new_introspector_functions(project_name, date_str):
     introspector_functions_url = get_introspector_report_url_all_functions(
         project_name, date_str.replace("-", ""))
 
-    # Read the introspector atifact
+    # Read the introspector artifact
     try:
         raw_introspector_json_request = requests.get(
             introspector_functions_url, timeout=10)
-    except:
-        return None
-    try:
         introspector_functions = json.loads(raw_introspector_json_request.text)
     except:
         return None
 
     return introspector_functions
+
+
+def extract_new_introspector_constructors(project_name, date_str):
+    introspector_constructor_url = get_introspector_report_url_jvm_constructor(
+        project_name, date_str.replace("-", ""))
+
+    # Read the introspector artifact
+    try:
+        raw_introspector_json_request = requests.get(
+            introspector_functions_url, timeout=10)
+        introspector_constructors = json.loads(raw_introspector_json_request.text)
+    except:
+        return None
+
+    return introspector_constructors
 
 
 def extract_introspector_report(project_name, date_str):

--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -190,7 +190,8 @@ def extract_new_introspector_constructors(project_name, date_str):
     try:
         raw_introspector_json_request = requests.get(
             introspector_functions_url, timeout=10)
-        introspector_constructors = json.loads(raw_introspector_json_request.text)
+        introspector_constructors = json.loads(
+            raw_introspector_json_request.text)
     except:
         return None
 

--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -177,7 +177,7 @@ def extract_new_introspector_functions(project_name, date_str):
             introspector_functions_url, timeout=10)
         introspector_functions = json.loads(raw_introspector_json_request.text)
     except:
-        return None
+        return []
 
     return introspector_functions
 
@@ -193,7 +193,7 @@ def extract_new_introspector_constructors(project_name, date_str):
         introspector_constructors = json.loads(
             raw_introspector_json_request.text)
     except:
-        return None
+        return []
 
     return introspector_constructors
 

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -307,8 +307,8 @@ def extract_local_project_data(project_name, oss_fuzz_path,
 
     refined_proj_list = extract_and_refine_functions(all_function_list,
                                                      project_name, '')
-    refined_constructor_list = extract_and_refine_functions(all_constructor_list,
-                                                     project_name, '')
+    refined_constructor_list = extract_and_refine_functions(
+        all_constructor_list, project_name, '')
     annotated_cfg = extract_and_refine_annotated_cfg(introspector_report)
     branch_pairs = extract_and_refine_branch_blockers(introspector_report,
                                                       project_name)
@@ -632,7 +632,8 @@ def analyse_list_of_projects(date, projects_to_analyse,
             introspector_dictionary.pop('refined_proj_list')
 
             # Constructors
-            constructor_list += introspector_dictionary['refined_constructor_list']
+            constructor_list += introspector_dictionary[
+                'refined_constructor_list']
             # Remove the function list because we don't want it anymore.
             introspector_dictionary.pop('refined_constructor_list')
 
@@ -727,8 +728,7 @@ def extend_db_json_files(project_timestamps, output_directory):
 
 def extend_func_db(function_list, output_directory, target):
     if os.path.isfile(os.path.join(output_directory, target)):
-        with open(os.path.join(output_directory, target),
-                  'r') as f:
+        with open(os.path.join(output_directory, target), 'r') as f:
             existing_function_list = json.load(f)
     else:
         existing_function_list = []
@@ -751,14 +751,16 @@ def extend_func_db(function_list, output_directory, target):
         json.dump(all_functions, f)
 
 
-def update_db_files(db_timestamp, project_timestamps, function_list, constructor_list,
-                    output_directory, should_include_details):
+def update_db_files(db_timestamp, project_timestamps, function_list,
+                    constructor_list, output_directory,
+                    should_include_details):
     logger.info(
         "Updating the database with DB snapshot. Number of functions in total: %d"
         % (db_timestamp['function_count']))
     if should_include_details:
         extend_func_db(function_list, output_directory, DB_JSON_ALL_FUNCTIONS)
-        extend_func_db(constructor_list, output_directory, DB_JSON_ALL_CONSTRUCTORS)
+        extend_func_db(constructor_list, output_directory,
+                       DB_JSON_ALL_CONSTRUCTORS)
 
     extend_db_json_files(project_timestamps, output_directory)
     extend_db_timestamps(db_timestamp, output_directory)
@@ -1088,7 +1090,8 @@ def create_local_db(oss_fuzz_path):
             introspector_dictionary.pop('refined_proj_list')
 
             # Constructors
-            constructor_list += introspector_dictionary['refined_constructor_list']
+            constructor_list += introspector_dictionary[
+                'refined_constructor_list']
             # Remove the function list because we don't want it anymore.
             introspector_dictionary.pop('refined_constructor_list')
 

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -490,6 +490,7 @@ def extract_project_data(project_name, date_str, should_include_details,
 
         # Get details if needed and otherwise leave empty
         refined_proj_list = list()
+        refined_constructor_list = list()
         branch_pairs = list()
         annotated_cfg = dict()
         if should_include_details:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -32,6 +32,7 @@ import oss_fuzz
 DB_JSON_DB_TIMESTAMP = 'db-timestamps.json'
 DB_JSON_ALL_PROJECT_TIMESTAMP = 'all-project-timestamps.json'
 DB_JSON_ALL_FUNCTIONS = 'all-functions-db.json'
+DB_JSON_ALL_CONSTRUCTORS = 'all-constructors-db.json'
 DB_JSON_ALL_CURRENT_FUNCS = 'all-project-current.json'
 DB_JSON_ALL_BRANCH_BLOCKERS = 'all-branch-blockers.json'
 DB_BUILD_STATUS_JSON = 'build-status.json'
@@ -41,6 +42,7 @@ ALL_JSON_FILES = [
     DB_JSON_DB_TIMESTAMP,
     DB_JSON_ALL_PROJECT_TIMESTAMP,
     DB_JSON_ALL_FUNCTIONS,
+    DB_JSON_ALL_CONSTRUCTORS,
     DB_JSON_ALL_CURRENT_FUNCS,
 ]
 
@@ -290,6 +292,8 @@ def extract_local_project_data(project_name, oss_fuzz_path,
     # Refine the data
     all_function_list = oss_fuzz.extract_local_introspector_function_list(
         project_name, oss_fuzz_path)
+    all_constructor_list = oss_fuzz.extract_local_introspector_constructor_list(
+        project_name, oss_fuzz_path)
     project_stats = introspector_report['MergedProjectProfile']['stats']
     amount_of_fuzzers = project_stats['harness-count']
     number_of_functions = project_stats['total-functions']
@@ -302,6 +306,8 @@ def extract_local_project_data(project_name, oss_fuzz_path,
     annotated_cfg = dict()
 
     refined_proj_list = extract_and_refine_functions(all_function_list,
+                                                     project_name, '')
+    refined_constructor_list = extract_and_refine_functions(all_constructor_list,
                                                      project_name, '')
     annotated_cfg = extract_and_refine_annotated_cfg(introspector_report)
     branch_pairs = extract_and_refine_branch_blockers(introspector_report,
@@ -318,6 +324,7 @@ def extract_local_project_data(project_name, oss_fuzz_path,
         "function_count": len(all_function_list),
         "functions_covered_estimate": functions_covered_estimate,
         'refined_proj_list': refined_proj_list,
+        'refined_constructor_list': refined_constructor_list,
         'annotated_cfg': annotated_cfg,
     }
 
@@ -488,11 +495,16 @@ def extract_project_data(project_name, date_str, should_include_details,
         if should_include_details:
             # Extract all function list
             if all_function_list is None:
-                oss_fuzz.extract_new_introspector_functions(
+                all_function_list = oss_fuzz.extract_new_introspector_functions(
                     project_name, date_str)
+            all_constructor_list = oss_fuzz.extract_new_introspector_constructors(
+                project_name, date_str)
 
             refined_proj_list = extract_and_refine_functions(
                 all_function_list, project_name, date_str)
+            refined_constructor_list = extract_and_refine_functions(
+                all_constructor_list, project_name, date_str)
+
             annotated_cfg = extract_and_refine_annotated_cfg(
                 introspector_report)
             branch_pairs = extract_and_refine_branch_blockers(
@@ -511,6 +523,7 @@ def extract_project_data(project_name, date_str, should_include_details,
             "function_count": number_of_functions,
             "functions_covered_estimate": functions_covered_estimate,
             'refined_proj_list': refined_proj_list,
+            'refined_constructor_list': refined_constructor_list,
             'annotated_cfg': annotated_cfg,
         }
 
@@ -548,12 +561,14 @@ def analyse_list_of_projects(date, projects_to_analyse,
     Returns:
     - A db timestamp, which holds overall stats about the database on a given date.
     - A list of all functions for this date if `should_include_details` is True.
+    - A list of all constructors for this date if `should_include_details` is True.
     - A list of all branch blockers on this given date if `should_include_details` is True.
     - A list of project timestamps with information about each project.
       - This holds data relative to whether coverage and introspector builds succeeds.
 
     """
     function_list = list()
+    constructor_list = list()
     project_timestamps = list()
     accummulated_fuzzer_count = 0
     accummulated_function_count = 0
@@ -609,10 +624,17 @@ def analyse_list_of_projects(date, projects_to_analyse,
         # Accummulate all function list and branch blockers
         introspector_dictionary = project_timestamp.get(
             'introspector-data', None)
+
         if introspector_dictionary != None:
+            # Functions
             function_list += introspector_dictionary['refined_proj_list']
             # Remove the function list because we don't want it anymore.
             introspector_dictionary.pop('refined_proj_list')
+
+            # Constructors
+            constructor_list += introspector_dictionary['refined_constructor_list']
+            # Remove the function list because we don't want it anymore.
+            introspector_dictionary.pop('refined_constructor_list')
 
             # Accummulate various stats for the DB timestamp.
             db_timestamp['function_count'] += introspector_dictionary[
@@ -635,10 +657,10 @@ def analyse_list_of_projects(date, projects_to_analyse,
 
     # Return:
     # - all functions
-    # - all branch blockers
+    # - all constructors (maybe empty)
     # - a list of project timestamps
     # - the DB timestamp
-    return function_list, project_timestamps, db_timestamp
+    return function_list, constructor_list, project_timestamps, db_timestamp
 
 
 def extend_db_timestamps(db_timestamp, output_directory):
@@ -703,9 +725,9 @@ def extend_db_json_files(project_timestamps, output_directory):
         json.dump(project_timestamps, f)
 
 
-def extend_func_db(function_list, output_directory):
-    if os.path.isfile(os.path.join(output_directory, DB_JSON_ALL_FUNCTIONS)):
-        with open(os.path.join(output_directory, DB_JSON_ALL_FUNCTIONS),
+def extend_func_db(function_list, output_directory, target):
+    if os.path.isfile(os.path.join(output_directory, target)):
+        with open(os.path.join(output_directory, target),
                   'r') as f:
             existing_function_list = json.load(f)
     else:
@@ -725,17 +747,18 @@ def extend_func_db(function_list, output_directory):
     # Add new functions
     all_functions = functions_to_keep + function_list
 
-    with open(os.path.join(output_directory, DB_JSON_ALL_FUNCTIONS), 'w') as f:
+    with open(os.path.join(output_directory, target), 'w') as f:
         json.dump(all_functions, f)
 
 
-def update_db_files(db_timestamp, project_timestamps, function_list,
+def update_db_files(db_timestamp, project_timestamps, function_list, constructor_list,
                     output_directory, should_include_details):
     logger.info(
         "Updating the database with DB snapshot. Number of functions in total: %d"
         % (db_timestamp['function_count']))
     if should_include_details:
-        extend_func_db(function_list, output_directory)
+        extend_func_db(function_list, output_directory, DB_JSON_ALL_FUNCTIONS)
+        extend_func_db(constructor_list, output_directory, DB_JSON_ALL_CONSTRUCTORS)
 
     extend_db_json_files(project_timestamps, output_directory)
     extend_db_timestamps(db_timestamp, output_directory)
@@ -789,7 +812,7 @@ def is_date_in_db(date, output_directory):
 
 def analyse_set_of_dates(dates, projects_to_analyse, output_directory,
                          force_creation):
-    """Pe/rforms analysis of all projects in the projects_to_analyse argument for
+    """Performs analysis of all projects in the projects_to_analyse argument for
     the given set of dates. DB .json files are stored in output_directory.
     """
     idx = 1
@@ -814,11 +837,12 @@ def analyse_set_of_dates(dates, projects_to_analyse, output_directory,
         if force_creation:
             is_end = True
 
-        function_list, project_timestamps, db_timestamp = analyse_list_of_projects(
+        function_list, constructor_list, project_timestamps, db_timestamp = analyse_list_of_projects(
             date, projects_to_analyse, should_include_details=is_end)
         update_db_files(db_timestamp,
                         project_timestamps,
                         function_list,
+                        constructor_list,
                         output_directory,
                         should_include_details=is_end)
 
@@ -1008,6 +1032,7 @@ def get_dates_to_analyse(since_date, days_to_analyse, day_offset):
 def create_local_db(oss_fuzz_path):
     """Creates a database based of local runs."""
     function_list = list()
+    constructor_list = list()
     project_timestamps = list()
     accummulated_fuzzer_count = 0
     accummulated_function_count = 0
@@ -1057,9 +1082,15 @@ def create_local_db(oss_fuzz_path):
         introspector_dictionary = project_timestamp.get(
             'introspector-data', None)
         if introspector_dictionary != None:
+            # Functions
             function_list += introspector_dictionary['refined_proj_list']
             # Remove the function list because we don't want it anymore.
             introspector_dictionary.pop('refined_proj_list')
+
+            # Constructors
+            constructor_list += introspector_dictionary['refined_constructor_list']
+            # Remove the function list because we don't want it anymore.
+            introspector_dictionary.pop('refined_constructor_list')
 
             # Accummulate various stats for the DB timestamp.
             db_timestamp['function_count'] += introspector_dictionary[
@@ -1083,6 +1114,7 @@ def create_local_db(oss_fuzz_path):
     update_db_files(db_timestamp,
                     project_timestamps,
                     function_list,
+                    constructor_list,
                     os.getcwd(),
                     should_include_details=True)
 

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -24,7 +24,8 @@ def load_db():
     all_functions_file = os.path.join(
         os.path.dirname(__file__), "../static/assets/db/all-functions-db.json")
     all_constructors_file = os.path.join(
-        os.path.dirname(__file__), "../static/assets/db/all-constructors-db.json")
+        os.path.dirname(__file__),
+        "../static/assets/db/all-constructors-db.json")
     project_timestamps_file = os.path.join(
         os.path.dirname(__file__),
         "../static/assets/db/all-project-timestamps.json")

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -23,6 +23,8 @@ def load_db():
         os.path.dirname(__file__), "../static/assets/db/db-timestamps.json")
     all_functions_file = os.path.join(
         os.path.dirname(__file__), "../static/assets/db/all-functions-db.json")
+    all_constructors_file = os.path.join(
+        os.path.dirname(__file__), "../static/assets/db/all-constructors-db.json")
     project_timestamps_file = os.path.join(
         os.path.dirname(__file__),
         "../static/assets/db/all-project-timestamps.json")
@@ -48,39 +50,19 @@ def load_db():
                 accummulated_lines_total=ts['accummulated_lines_total'],
                 accummulated_lines_covered=ts['accummulated_lines_covered']))
 
+    # Load functions
     with open(all_functions_file, 'r') as f:
         all_function_list = json.load(f)
-    idx = 0
-    for func in all_function_list:
-        idx += 1
-        data_storage.FUNCTIONS.append(
-            models.Function(
-                name=func['name'],
-                project=func['project'],
-                runtime_code_coverage=func['code_cov'],
-                function_filename=func['filename'],
-                reached_by_fuzzers=func['reached-by-fuzzers'],
-                code_coverage_url=func['code_coverage_url'],
-                is_reached=func['is_reached'],
-                llvm_instruction_count=func['instr-count'],
-                accummulated_cyclomatic_complexity=func['acc_cc'],
-                undiscovered_complexity=func['u-cc'],
-                function_arguments=func['function-arguments'],
-                return_type=func['return-type'],
-                function_argument_names=func['function-argument-names'],
-                raw_function_name=func['raw-function-name'],
-                date_str=func.get('date-str', ''),
-                source_line_begin=func.get('source_line_begin', '-1'),
-                source_line_end=func.get('source_line_end', '-1'),
-                callsites=func.get('callsites', []),
-                func_signature=func.get('function-signature', 'N/A'),
-                debug_data=func.get('debug-function', 'N/A'),
-                is_accessible=func.get('is_accessible', True),
-                is_jvm_library=func.get('is_jvm_library', False),
-                is_enum_class=func.get('is_enum_class', False)))
-
-    print("Loadded %d functions" % (idx))
+    idx = load_functions(all_function_list, data_storage.FUNCTIONS)
+    print("Loaded %d functions" % (idx))
     print("Len %d" % (len(data_storage.FUNCTIONS)))
+
+    # Load constructors
+    with open(all_constructors_file, 'r') as f:
+        all_constructor_list = json.load(f)
+    idx = load_functions(all_constructor_list, data_storage.CONSTRUCTORS)
+    print("Loaded %d constructorss" % (idx))
+    print("Len %d" % (len(data_storage.CONSTRUCTORS)))
 
     with open(project_timestamps_file, 'r') as f:
         project_timestamps_json = json.load(f)
@@ -158,3 +140,37 @@ def load_db():
                     fuzz_build_log=project_dict['fuzz-build-log']))
 
     return
+
+
+def load_functions(function_list, target):
+    """Load functions or constructors into data storage"""
+    idx = 0
+    for func in function_list:
+        idx += 1
+        target.append(
+            models.Function(
+                name=func['name'],
+                project=func['project'],
+                runtime_code_coverage=func['code_cov'],
+                function_filename=func['filename'],
+                reached_by_fuzzers=func['reached-by-fuzzers'],
+                code_coverage_url=func['code_coverage_url'],
+                is_reached=func['is_reached'],
+                llvm_instruction_count=func['instr-count'],
+                accummulated_cyclomatic_complexity=func['acc_cc'],
+                undiscovered_complexity=func['u-cc'],
+                function_arguments=func['function-arguments'],
+                return_type=func['return-type'],
+                function_argument_names=func['function-argument-names'],
+                raw_function_name=func['raw-function-name'],
+                date_str=func.get('date-str', ''),
+                source_line_begin=func.get('source_line_begin', '-1'),
+                source_line_end=func.get('source_line_end', '-1'),
+                callsites=func.get('callsites', []),
+                func_signature=func.get('function-signature', 'N/A'),
+                debug_data=func.get('debug-function', 'N/A'),
+                is_accessible=func.get('is_accessible', True),
+                is_jvm_library=func.get('is_jvm_library', False),
+                is_enum_class=func.get('is_enum_class', False)))
+
+    return idx

--- a/tools/web-fuzzing-introspection/app/webapp/data_storage.py
+++ b/tools/web-fuzzing-introspection/app/webapp/data_storage.py
@@ -16,6 +16,8 @@ PROJECTS = []
 
 FUNCTIONS = []
 
+CONSTRUCTORS = []
+
 BLOCKERS = []
 
 BUILD_STATUS: List[BuildStatus] = []
@@ -29,6 +31,10 @@ def get_projects():
 
 def get_functions():
     return FUNCTIONS
+
+
+def get_constructors():
+    return CONSTRUCTORS
 
 
 def get_blockers():

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -148,6 +148,8 @@ def extract_lines_from_source_code(project_name,
 
 def get_functions_of_interest(project_name):
     all_functions = data_storage.get_functions()
+    all_functions.extend(data_storage.get_constructors())
+
     project_functions = []
     for function in all_functions:
         # Skipping non-related jvm methods and methods from enum classes


### PR DESCRIPTION
This PR aims to store constructor information separately for java projects. In original code, constructors of java proejcts are ignored in the all_functions dictionary. Instead of ignoring them, now these constructors (in FunctionProfile format) are stored in a separate dict and are then processed separately. Lastly, these processed constructors are then added into the summary.json as other normal functions for further process.