### PR TITLE
disable sink analyzer by default

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
     report_parser.add_argument(
         "--output-json",
         nargs="+",
-        default=["SinkCoverageAnalyser", "FuzzEngineInputAnalysis"],
+        default=["FuzzEngineInputAnalysis"],
         help="State which analysis requires separate json report output")
 
     # Command for correlating binary files to fuzzerLog files


### PR DESCRIPTION
The results should not go in the main report file anymore (`summary.json`) but should be place in individual files. Disabling for now to prepare for this.