### PR TITLE
webapp: Fix wrong port type bug

### DIFF
--- a/tools/web-fuzzing-introspection/app/main.py
+++ b/tools/web-fuzzing-introspection/app/main.py
@@ -56,4 +56,4 @@ def create_app():
 if __name__ == "__main__":
     create_app().run(debug=False,
                      host="0.0.0.0",
-                     port=os.environ.get("WEBAPP_PORT", 8080))
+                     port=int(os.environ.get("WEBAPP_PORT", '8080')))


### PR DESCRIPTION
This PR fixes a possible wrong variable type for port because os.environ always return a dict with string keys and values.