### PR TITLE
webapp: Fix bug for wrong variable use

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -193,7 +193,7 @@ def extract_new_introspector_constructors(project_name, date_str):
     # Read the introspector artifact
     try:
         raw_introspector_json_request = requests.get(
-            introspector_functions_url, timeout=10)
+            introspector_constructor_url, timeout=10)
         introspector_constructors = json.loads(
             raw_introspector_json_request.text)
     except:


### PR DESCRIPTION
This PR fixes a bug in extract_new_introspector_constructors() which calls to a wrong url variable.