### PR TITLE
webapp: Fix possible unbound bs variable

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1300,6 +1300,16 @@ def far_reach_but_low_coverage():
         err_msgs.append('No functions found.')
         bs = get_build_status_of_project(project_name)
 
+        if bs == None:
+            return {
+                'result':
+                'error',
+                'extended_msgs': [
+                    'Project not in OSS-Fuzz (likely only contains a project.yaml file).'
+                ]
+            }
+        err_msgs.append('Missing a recent introspector build.')
+
         # Check that builds are failing
         if bs.introspector_build_status is False:
             err_msgs.append('No successful build: introspector.')

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1308,7 +1308,6 @@ def far_reach_but_low_coverage():
                     'Project not in OSS-Fuzz (likely only contains a project.yaml file).'
                 ]
             }
-        err_msgs.append('Missing a recent introspector build.')
 
         # Check that builds are failing
         if bs.introspector_build_status is False:


### PR DESCRIPTION
The get_build_status_of_project(str) function could return None type and cause the further access to the attributes of the bs object fails. This PR fixes the problem by adding a None check and return error before it is accessed.