### PR TITLE
webapp: Fix NoneType bug

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1184,10 +1184,7 @@ def api_oracle_1():
             break
 
     if not target_project:
-        return {
-            'result': 'error',
-            'extended_msgs': ['Project not found']
-        }
+        return {'result': 'error', 'extended_msgs': ['Project not found']}
 
     all_functions = data_storage.get_functions()
     all_projects = [target_project]

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1183,6 +1183,12 @@ def api_oracle_1():
             target_project = project
             break
 
+    if not target_project:
+        return {
+            'result': 'error',
+            'extended_msgs': ['Project not found']
+        }
+
     all_functions = data_storage.get_functions()
     all_projects = [target_project]
     raw_functions = oracle_1(all_functions, all_projects, 100)


### PR DESCRIPTION
When a project name not existed in the db is provided to /api/far-reach-low-cov-fuzz-keyword, the target_project will be None and that cause NoneType error in later call to function `oracle_1`. This PR fixes that by adding a NoneType check.