### PR TITLE
webapp: Fix missing arguments for model Project constructor

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -367,15 +367,13 @@ def project_profile():
     all_build_status = data_storage.get_build_status()
     for build_status in all_build_status:
         if build_status.project_name == target_project_name:
-            project = models.Project(
-                name=build_status.project_name,
-                language=build_status.language,
-                date="",
-                fuzzer_count=0,
-                coverage_data=None,
-                introspector_data=None,
-                project_repository=None
-            )
+            project = models.Project(name=build_status.project_name,
+                                     language=build_status.language,
+                                     date="",
+                                     fuzzer_count=0,
+                                     coverage_data=None,
+                                     introspector_data=None,
+                                     project_repository=None)
 
             # Get statistics of the project
             project_statistics = data_storage.PROJECT_TIMESTAMPS

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -374,6 +374,7 @@ def project_profile():
                 fuzzer_count=0,
                 coverage_data=None,
                 introspector_data=None,
+                project_repository=None
             )
 
             # Get statistics of the project


### PR DESCRIPTION
In #1562, a new class property `project_repository` for the models.Project class has been added. Also, a new mandatory argument is added to the class constructor in order to set the value. But that PR does not fixed the call in routes.py and could cause error because it is a mandatory argument. This PR fixes by adding the None value to the constructor call.