### PR TITLE
webapp: Fix wrong coverage url

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -345,7 +345,6 @@ def project_profile():
                 'code_coverage':
                 func_of_interest.runtime_code_coverage,
                 'code_coverage_url':
-#                'https://storage.googleapis.com/oss-fuzz-coverage/' +
                 func_of_interest.code_coverage_url,
             })
 

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -345,7 +345,7 @@ def project_profile():
                 'code_coverage':
                 func_of_interest.runtime_code_coverage,
                 'code_coverage_url':
-                'https://storage.googleapis.com/oss-fuzz-coverage/' +
+#                'https://storage.googleapis.com/oss-fuzz-coverage/' +
                 func_of_interest.code_coverage_url,
             })
 


### PR DESCRIPTION
There is a bug in route.py for API /project-profile. The list of function of interest at the bottom of the page has a set of wrong coverage url which the initial is repeated and cause link error. This PR fixes the problem by removing the redundant string concatenation in the coverage url saving.