### PR TITLE
webapp: Fix possible ValueError on invalid parameter

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -955,11 +955,17 @@ def api_project_source_code():
     if end_line == None:
         return {'result': 'error', 'msg': 'No end line provided'}
 
+    try:
+        begin_line = int(begin_line)
+        end_line = int(end_line)
+    except ValueError:
+        return {'result': 'error', 'msg': 'begin line or end line are not valid integer'}
+
     # If this is a local build do not look for project timestamps
     if is_local:
         source_code = extract_lines_from_source_code(project_name, '',
-                                                     filepath, int(begin_line),
-                                                     int(end_line))
+                                                     filepath, begin_line,
+                                                     end_line)
         if source_code == None:
             return {'result': 'error', 'msg': 'no source code'}
 

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -959,7 +959,10 @@ def api_project_source_code():
         begin_line = int(begin_line)
         end_line = int(end_line)
     except ValueError:
-        return {'result': 'error', 'msg': 'begin line or end line are not valid integer'}
+        return {
+            'result': 'error',
+            'msg': 'begin line or end line are not valid integer'
+        }
 
     # If this is a local build do not look for project timestamps
     if is_local:


### PR DESCRIPTION
The request parameter `begin_line` and `end_line` for the api `/api/project-source-code` is passed directly to `int()` without checking which could throw an unexpected ValueError if non-valid string is provided. This PR fixes that by capturing the possible ValueError and return an error message json instead.