### PR TITLE
webapp: Fix argument overwritten bug

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -490,7 +490,6 @@ def oracle_3(all_functions, all_projects):
         - less than a certain number of arguments (3 or below);
         - at least one argument.
     """
-    all_functions = data_storage.get_functions()
     functions_of_interest = []
     projects_added = dict()
 


### PR DESCRIPTION
This PR fixes a bug in oracle_3 function where the all_functions argument is being overwritten at the beginning accidentally.