### PR TITLE
webapp: None type bug create possible DoS

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1134,6 +1134,12 @@ def api_oracle_2():
             target_project = project
             break
 
+    if target_project == None:
+        return {
+            'result': 'error',
+            'extended_msgs': ['Project not found.']
+        }
+
     all_functions = data_storage.get_functions()
     all_projects = [target_project]
 

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1135,10 +1135,7 @@ def api_oracle_2():
             break
 
     if target_project == None:
-        return {
-            'result': 'error',
-            'extended_msgs': ['Project not found.']
-        }
+        return {'result': 'error', 'extended_msgs': ['Project not found.']}
 
     all_functions = data_storage.get_functions()
     all_projects = [target_project]


### PR DESCRIPTION
If the provided project name is invalid, the target_project will be None and this will cause subsequent action in oracle_2 to process all functions for all projects because none of the project name matches. This create a possible DoS situation. This PR adds a None type checking and return an error message if target project not found.