### PR TITLE
webapp: Temporary disable API to avoid errors

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1442,9 +1442,7 @@ def all_project_header_files():
 def type_at_addr():
     # Temporary disabling this API because of size limit.
     # @arthurscchan 14/6/2024
-    return {
-       'result': 'error', 'extended_msgs': ['Temporary disabled']
-    }
+    return {'result': 'error', 'extended_msgs': ['Temporary disabled']}
     project = request.args.get('project', None)
     if project == None:
         return {

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1440,6 +1440,11 @@ def all_project_header_files():
 
 @blueprint.route('/api/addr-to-recursive-dwarf-info')
 def type_at_addr():
+    # Temporary disabling this API because of size limit.
+    # @arthurscchan 14/6/2024
+    return {
+       'result': 'error', 'extended_msgs': ['Temporary disabled']
+    }
     project = request.args.get('project', None)
     if project == None:
         return {


### PR DESCRIPTION
This PR temporary disabled api `/api/addr-to-recursive-dwarf-info` to avoid internal server error because of missing type json. This type json is temporary disabled for saving storage space in the server.