### PR TITLE
webapp: Ensure int typing for the lines

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1025,12 +1025,10 @@ def api_project_source_code():
     if filepath is None:
         return {'result': 'error', 'msg': 'No filepath provided'}
 
-    begin_line = 0
     begin_line_str = request.args.get('begin_line', None)
     if begin_line_str is None:
         return {'result': 'error', 'msg': 'No begin line provided'}
 
-    end_line = 0
     end_line_str = request.args.get('end_line', None)
     if end_line_str is None:
         return {'result': 'error', 'msg': 'No end line provided'}

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1025,17 +1025,19 @@ def api_project_source_code():
     if filepath is None:
         return {'result': 'error', 'msg': 'No filepath provided'}
 
-    begin_line = request.args.get('begin_line', None)
-    if begin_line is None:
+    begin_line = 0
+    begin_line_str = request.args.get('begin_line', None)
+    if begin_line_str is None:
         return {'result': 'error', 'msg': 'No begin line provided'}
 
-    end_line = request.args.get('end_line', None)
-    if end_line is None:
+    end_line = 0
+    end_line_str = request.args.get('end_line', None)
+    if end_line_str is None:
         return {'result': 'error', 'msg': 'No end line provided'}
 
     try:
-        begin_line = int(begin_line)
-        end_line = int(end_line)
+        begin_line = int(begin_line_str)
+        end_line = int(end_line_str)
     except ValueError:
         return {
             'result': 'error',


### PR DESCRIPTION
This PR fixes the typing for the lines variable to ensure it must be integer before use. This is part of the work to fulfil the type checking when type is added in #1601.