### PR TITLE
webapp: Ensure datestr is not None

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -395,7 +395,7 @@ def project_profile():
                             build_status.project_name, datestr)
                         latest_introspector_datestr = datestr
 
-            if len(real_stats) > 0:
+            if datestr and len(real_stats) > 0:
                 latest_coverage_report = get_coverage_report_url(
                     build_status.project_name, datestr, build_status.language)
             else:


### PR DESCRIPTION
This PR adds a None type checking to ensure datestr must not be None. This is part of the work to fulfil the type checking when type is added in https://github.com/ossf/fuzz-introspector/pull/1601.