### PR TITLE
webapp: Ensure None checking for all cases

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1697,8 +1697,8 @@ def sample_cross_references():
                         if ps.introspector_data is not None:
                             latest_introspector_datestr = datestr
 
-        if latest_introspector_datestr is None:
-            return {'result': 'error', 'msg': 'No introspector builds.'}
+    if latest_introspector_datestr is None:
+        return {'result': 'error', 'msg': 'No introspector builds.'}
 
     source_code_xrefs = []
     for target_function in func_xrefs:


### PR DESCRIPTION
This PR fixes the None type checking for latest_introspector_datestr to ensure it has been checked for all branches. This is part of the work to fulfil the type checking when type is added in https://github.com/ossf/fuzz-introspector/pull/1601.