### PR TITLE
oss-fuzz-gen-script: Fix missing dependency

### DIFF
--- a/scripts/oss-fuzz-gen-e2e/build_all.sh
+++ b/scripts/oss-fuzz-gen-e2e/build_all.sh
@@ -20,7 +20,7 @@ mkdir -p workdir
 cd workdir
 WORKDIR=$PWD
 
-python3.11 -m virtualenv .venv
+python3 -m virtualenv .venv
 . .venv/bin/activate
 
 
@@ -28,6 +28,7 @@ python3.11 -m virtualenv .venv
 # builder logic.
 cd $ROOT_FI
 python3 -m pip install -r ./requirements.txt
+python3 -m pip install -r ./tools/web-fuzzing-introspection/requirements.txt
 cd oss_fuzz_integration
 ./build_post_processing.sh
 


### PR DESCRIPTION
The `build_all.py` installs the dependencies for the fuzz-introspector in the virtual environment. But it misses the installation of the dependencies from the webapp which is also needed for running the oss-fuzz-gen script. This PR fixes that by adding an additional requirement installation statement in `build_all.py` to avoid execution error in the `run_all.sh` when some dependencies specifically for the webapp (like flask) is missing. This PR also changed the python3.11 to the general python3 to allow backward compatibility.