### PR TITLE
Fix coverage calculation for JVM projects

### DIFF
--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -321,7 +321,6 @@ class CoverageProfile:
 
         return
 
-
     def get_hit_summary(self,
                         funcname: str) -> Tuple[Optional[int], Optional[int]]:
         """Returns the hit summary of a give function.
@@ -677,7 +676,8 @@ def load_jvm_coverage(target_dir: str,
             line_list = []
             for line in src.findall('line'):
                 # Process each line
-                line_list.append((int(line.attrib['nr']), int(line.attrib['ci'])))
+                line_list.append(
+                    (int(line.attrib['nr']), int(line.attrib['ci'])))
             source_file_map[src.attrib["name"]] = line_list
 
         # Process all methods in all classes within this package
@@ -692,16 +692,16 @@ def load_jvm_coverage(target_dir: str,
                 # Determine method full signaturre
                 desc = method.attrib['desc'].split('(', 1)[1].split(')', 1)[0]
                 args = _interpret_jvm_arguments_type(desc)
-                name = '[{class_name}].{method.attrib["name"]}(",".join(args))'
+                name = f'[{class_name}].{method.attrib["name"]}({",".join(args)})'
 
                 start_line = int(method.attrib['line'])
                 total_line = 0
 
                 # Get total valid lines count of this method
                 for counter in method.findall('counter'):
-                    if counter.attrib('type') == 'LINE':
-                        missed_line = int(counter.attrib('missed'))
-                        covered_line = int(counter.attrib('covered'))
+                    if counter.attrib['type'] == 'LINE':
+                        missed_line = int(counter.attrib['missed'])
+                        covered_line = int(counter.attrib['covered'])
                         total_line = missed_line + covered_line
                         break
 
@@ -750,8 +750,14 @@ def _interpret_jvm_arguments_type(desc: str) -> List[str]:
       the one given in the jacoco.xml report with full argument list.
     """
     JVM_CLASS_MAPPING = {
-        'Z': 'boolean', 'B': 'byte', 'C': 'char', 'D': 'double',
-        'F': 'float', 'I': 'int', 'J': 'long', 'S': 'short'
+        'Z': 'boolean',
+        'B': 'byte',
+        'C': 'char',
+        'D': 'double',
+        'F': 'float',
+        'I': 'int',
+        'J': 'long',
+        'S': 'short'
     }
 
     args = []
@@ -760,39 +766,39 @@ def _interpret_jvm_arguments_type(desc: str) -> List[str]:
     next_arg = ''
     array_count = 0
     for c in desc:
-      if c == '(':
-        continue
-      if c == ')':
-        break
+        if c == '(':
+            continue
+        if c == ')':
+            break
 
-      if start:
-        if c == ';':
-          start = False
-          next_arg = arg.replace('/', '.')
+        if start:
+            if c == ';':
+                start = False
+                next_arg = arg.replace('/', '.')
+            else:
+                arg = arg + c
         else:
-          arg = arg + c
-      else:
-        if c == 'L':
-          start = True
-          if next_arg:
-            next_arg = f'{next_arg}{"[]" * array_count}'
-            array_count = 0
-            args.append(next_arg)
-          arg = ''
-          next_arg = ''
-        elif c == '[':
-          array_count += 1
-        else:
-          if c in JVM_CLASS_MAPPING:
-            if next_arg:
-              next_arg = f'{next_arg}{"[]" * array_count}'
-              array_count = 0
-              args.append(next_arg)
-            next_arg = JVM_CLASS_MAPPING[c]
+            if c == 'L':
+                start = True
+                if next_arg:
+                    next_arg = f'{next_arg}{"[]" * array_count}'
+                    array_count = 0
+                    args.append(next_arg)
+                arg = ''
+                next_arg = ''
+            elif c == '[':
+                array_count += 1
+            else:
+                if c in JVM_CLASS_MAPPING:
+                    if next_arg:
+                        next_arg = f'{next_arg}{"[]" * array_count}'
+                        array_count = 0
+                        args.append(next_arg)
+                    next_arg = JVM_CLASS_MAPPING[c]
 
     if next_arg:
-      next_arg = f'{next_arg}{"[]" * array_count}'
-      args.append(next_arg)
+        next_arg = f'{next_arg}{"[]" * array_count}'
+        args.append(next_arg)
     return args
 
 

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -321,40 +321,6 @@ class CoverageProfile:
 
         return
 
-    def correlate_jvm_method_with_coverage(
-        self,
-        function_list,
-    ) -> None:
-        logger.debug("Correlating JVM")
-
-        file_and_function_mappings: Dict[str, List[Tuple[str, int]]] = dict()
-        for (func_key, func) in function_list.items():
-            function_name = func.function_name
-            function_line = func.function_linenumber
-            class_name = func.function_source_file
-            logger.debug(
-                f"Correlated init: {class_name} ---- {function_name} ---- {function_line}"
-            )
-
-            if class_name not in self.file_map:
-                logger.debug("Fail to find matching class")
-                continue
-
-            if class_name not in file_and_function_mappings:
-                file_and_function_mappings[class_name] = []
-
-            file_and_function_mappings[class_name].append(
-                (function_name, function_line))
-
-        # Sort and retrieve line range of all functions
-        function_internals = self._retrieve_func_line(
-            file_and_function_mappings)
-
-        # Map the source codes of each line with coverage information.
-        # Store the result in covmap to be compatible with other languages.
-        self._map_func_covmap(function_internals)
-
-        return
 
     def get_hit_summary(self,
                         funcname: str) -> Tuple[Optional[int], Optional[int]]:
@@ -676,8 +642,9 @@ def load_jvm_coverage(target_dir: str,
     """
     import xml.etree.ElementTree as ET
     cp = CoverageProfile()
-    cp.set_type("file")
+    cp.set_type("function")
 
+    # Retrieve jacoco.xml coverage report
     coverage_reports = utils.get_all_files_in_tree_with_regex(
         target_dir, "jacoco.xml")
     logger.info(f"FOUND XML COVERAGE FILES: {str(coverage_reports)}")
@@ -688,6 +655,7 @@ def load_jvm_coverage(target_dir: str,
         logger.info("Found no coverage files")
         return cp
 
+    # Parse the jacoco.xml to element tree
     cp.coverage_files.append(xml_file)
     try:
         xml_tree = ET.parse(xml_file)
@@ -695,31 +663,137 @@ def load_jvm_coverage(target_dir: str,
     except Exception:
         raise exceptions.DataLoaderError("Error %s as xml file" % (xml_file))
 
+    # Handles package by package
     for package in root.findall('package'):
-        for cl in package.findall('sourcefile'):
-            cov_entry = cl.attrib['name']
-            if package.attrib['name']:
-                cov_entry = "%s/%s" % (package.attrib['name'], cov_entry)
-            cov_entry = cov_entry.replace("/", ".")
-            cov_entry = cov_entry.replace(".java", "")
-            executed_lines = []
-            missing_lines = []
-            d_executed_lines = []
-            d_missing_lines = []
-            for line in cl.findall('line'):
-                if line.attrib['ci'] > "0":
-                    executed_lines.append((int(line.attrib['nr']), 1000))
-                    d_executed_lines.append(int(line.attrib['nr']))
-                else:
-                    missing_lines.append((int(line.attrib['nr']), 0))
-                    d_missing_lines.append(int(line.attrib['nr']))
+        # Extract all source lines mapping
+        # In jacoco.xml, each packages contains a list of source files and classes.
+        # In each of the source file tag, it contains a list of line child elements
+        # for each valid line in that source file with the count of runtime coverage
+        # of that line. This information is separated with the methods and thus we
+        # are extracting them as a map for further reference when processing all
+        # the methods.
+        source_file_map = {}
+        for src in package.findall('sourcefile'):
+            line_list = []
+            for line in src.findall('line'):
+                # Process each line
+                line_list.append((int(line.attrib['nr']), int(line.attrib['ci'])))
+            source_file_map[src.attrib["name"]] = line_list
 
-            cp.file_map[cov_entry] = executed_lines
-            cp.dual_file_map[cov_entry] = dict()
-            cp.dual_file_map[cov_entry]['executed_lines'] = d_executed_lines
-            cp.dual_file_map[cov_entry]['missing_lines'] = d_missing_lines
+        # Process all methods in all classes within this package
+        for cl in package.findall('class'):
+            class_name = cl.attrib['name'].replace('/', '.')
+            line_list = source_file_map.get(cl.attrib['sourcefilename'], [])
+            if not line_list:
+                # Fail safe for malformed or invalid jacoco.xml report
+                continue
+
+            for method in cl.findall('method'):
+                # Determine method full signaturre
+                desc = method.attrib['desc'].split('(', 1)[1].split(')', 1)[0]
+                args = _interpret_jvm_arguments_type(desc)
+                name = '[{class_name}].{method.attrib["name"]}(",".join(args))'
+
+                start_line = int(method.attrib['line'])
+                total_line = 0
+
+                # Get total valid lines count of this method
+                for counter in method.findall('counter'):
+                    if counter.attrib('type') == 'LINE':
+                        missed_line = int(counter.attrib('missed'))
+                        covered_line = int(counter.attrib('covered'))
+                        total_line = missed_line + covered_line
+                        break
+
+                # Find the starting item in the line map
+                start_item = -1
+                for count, item in enumerate(line_list):
+                    if item[0] == start_line:
+                        start_item = count
+                        break
+
+                # if starting item not found, skip this method
+                if start_item < 0:
+                    continue
+
+                # Find the ending item in the line map
+                end_item = min(start_item + total_line, len(line_list))
+
+                # Store lines, hit_time into the covmap under the target method
+                cp.covmap[name] = []
+                # Add source code line and hitcount to coverage map of current function
+                logger.debug(f"reading coverage: {name} -- {line_list[count]}")
+                for count in range(start_item, end_item):
+                    cp.covmap[name].append(line_list[count])
 
     return cp
+
+
+def _interpret_jvm_arguments_type(desc: str) -> List[str]:
+    """
+      Interpret list of jvm arguments type for each method.
+      The desc tag for each jvm method in the jacoco.xml coverage
+      report is in basic Java class name specification following
+      the format of "({Arguments}){ReturnType}". The basic java
+      class name specification use single upper case letter for
+      primitive types (and void type) and L{full_class_name}; for
+      object arguments. The JVM_CLASS_MAPPING give the mapping of
+      the single upper case letter of each primitive types.
+      Arrays are specified with a [ character before the arugment
+      type. The number of [ character determine the dimention of
+      the array.
+      For example, for a method
+      "public void test(String,int,String[][],boolean[],int...)"
+      The desc value of the above method will be
+      "(Ljava.lang.String;I[[Ljava.lang.String;[Z[I)V".
+      This method is necessary to match the full method name with
+      the one given in the jacoco.xml report with full argument list.
+    """
+    JVM_CLASS_MAPPING = {
+        'Z': 'boolean', 'B': 'byte', 'C': 'char', 'D': 'double',
+        'F': 'float', 'I': 'int', 'J': 'long', 'S': 'short'
+    }
+
+    args = []
+    arg = ''
+    start = False
+    next_arg = ''
+    array_count = 0
+    for c in desc:
+      if c == '(':
+        continue
+      if c == ')':
+        break
+
+      if start:
+        if c == ';':
+          start = False
+          next_arg = arg.replace('/', '.')
+        else:
+          arg = arg + c
+      else:
+        if c == 'L':
+          start = True
+          if next_arg:
+            next_arg = f'{next_arg}{"[]" * array_count}'
+            array_count = 0
+            args.append(next_arg)
+          arg = ''
+          next_arg = ''
+        elif c == '[':
+          array_count += 1
+        else:
+          if c in JVM_CLASS_MAPPING:
+            if next_arg:
+              next_arg = f'{next_arg}{"[]" * array_count}'
+              array_count = 0
+              args.append(next_arg)
+            next_arg = JVM_CLASS_MAPPING[c]
+
+    if next_arg:
+      next_arg = f'{next_arg}{"[]" * array_count}'
+      args.append(next_arg)
+    return args
 
 
 if __name__ == "__main__":

--- a/src/fuzz_introspector/code_coverage.py
+++ b/src/fuzz_introspector/code_coverage.py
@@ -155,6 +155,8 @@ class CoverageProfile:
             fuzz_key = utils.demangle_cpp_func(funcname)
         elif utils.normalise_str(funcname) in self.covmap:
             fuzz_key = utils.normalise_str(funcname)
+        elif utils.remove_jvm_generics(funcname) in self.covmap:
+            fuzz_key = utils.remove_jvm_generics(funcname)
 
         if fuzz_key is None or fuzz_key not in self.covmap:
             return []
@@ -342,6 +344,8 @@ class CoverageProfile:
             fuzz_key = utils.demangle_cpp_func(funcname)
         elif utils.normalise_str(funcname) in self.covmap:
             fuzz_key = utils.normalise_str(funcname)
+        elif utils.remove_jvm_generics(funcname) in self.covmap:
+            fuzz_key = utils.remove_jvm_generics(funcname)
 
         if fuzz_key is None:
             return None, None

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -497,9 +497,6 @@ class FuzzerProfile:
         elif self.target_lang == "jvm":
             self.coverage = code_coverage.load_jvm_coverage(
                 target_folder, self.identifier)
-            if self.coverage is not None:
-                self.coverage.correlate_jvm_method_with_coverage(
-                    self.all_class_functions)
         else:
             raise DataLoaderError(
                 "The profile target has no coverage loading support")

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -161,6 +161,12 @@ def demangle_jvm_func(package: str, funcname: str) -> str:
         return "[%s].%s" % (package, funcname)
 
 
+def remove_jvm_generics(funcname: str) -> str:
+    """Remove generic arguments from the full jvm method name."""
+    pattern = r'<[\s.,a-zA-Z0-9]+>|\\u003C[\s.,a-zA-Z0-9]+\\u003E'
+    return re.sub(pattern, '', funcname)
+
+
 def scan_executables_for_fuzz_introspector_logs(
         exec_dir: str) -> List[Dict[str, str]]:
     """Finds all executables containing fuzzerLogFile string

--- a/src/test/test_code_coverage.py
+++ b/src/test/test_code_coverage.py
@@ -34,15 +34,15 @@ def sample_jvm_coverage_xml():
   <sessioninfo id="9253a4a5cb62-c5efb6cd" start="1669995723552" dump="1669995724729"/>
   <package name="">
     <class name="BASE64EncoderStreamFuzzer" sourcefilename="BASE64EncoderStreamFuzzer.java">
-      <method name="&lt;init&gt;" desc="()V" line="24">
+      <method name="&lt;init&gt;" desc="()V" line="23">
         <counter type="INSTRUCTION" missed="3" covered="0"/>
         <counter type="LINE" missed="1" covered="0"/>
         <counter type="COMPLEXITY" missed="1" covered="0"/>
         <counter type="METHOD" missed="1" covered="0"/>
       </method>
-      <method name="fuzzerTestOneInput" desc="(LFuzzedDataProvider;)V" line="26">
+      <method name="fuzzerTestOneInput" desc="(LFuzzedDataProvider;)V" line="25">
         <counter type="INSTRUCTION" missed="2" covered="16"/>
-        <counter type="LINE" missed="2" covered="5"/>
+        <counter type="LINE" missed="1" covered="1"/>
         <counter type="COMPLEXITY" missed="0" covered="1"/>
         <counter type="METHOD" missed="0" covered="1"/>
       </method>
@@ -137,54 +137,10 @@ def test_jvm_coverage(tmpdir, sample_jvm_coverage_xml):
     assert len(cp.coverage_files) == 1
     assert cp.coverage_files == [os.path.join(tmpdir, "jacoco.xml")]
 
-    # Ensure file map is correct
-    assert len(cp.file_map) == 1
-    assert "BASE64EncoderStreamFuzzer" in cp.file_map
-    assert cp.file_map["BASE64EncoderStreamFuzzer"] == [(25, 1000), (27, 1000)]
-
-    # Ensure dual file map is correct
-    assert len(cp.dual_file_map) == 1
-    assert "BASE64EncoderStreamFuzzer" in cp.dual_file_map
-    assert len(cp.dual_file_map["BASE64EncoderStreamFuzzer"]) == 2
-    assert "executed_lines" in cp.dual_file_map["BASE64EncoderStreamFuzzer"]
-    assert "missing_lines" in cp.dual_file_map["BASE64EncoderStreamFuzzer"]
-    assert len(cp.dual_file_map["BASE64EncoderStreamFuzzer"]["executed_lines"]) == 2
-    assert len(cp.dual_file_map["BASE64EncoderStreamFuzzer"]["missing_lines"]) == 1
-    assert cp.dual_file_map["BASE64EncoderStreamFuzzer"]["executed_lines"] == [25, 27]
-    assert cp.dual_file_map["BASE64EncoderStreamFuzzer"]["missing_lines"] == [23]
-
-
-def test_jvm_coverage_correlation(tmpdir, sample_jvm_coverage_xml):
-    """Test jvm coverage correlation"""
-    write_coverage_file(tmpdir, sample_jvm_coverage_xml)
-
-    # Generate Coverage Profile
-    cp = code_coverage.load_jvm_coverage(tmpdir)
-
-    # Assure coverage profile has been correctly retrieved
-    assert cp is not None
-
-    # Generate test function list
-    function_list = dict()
-    function_list["<init>"] = generate_temp_function_profile(
-        "<init>",
-        "BASE64EncoderStreamFuzzer"
-    )
-    function_list["fuzzerTestOneInput"] = generate_temp_function_profile(
-        "fuzzerTestOneInput",
-        "BASE64EncoderStreamFuzzer"
-    )
-    function_list["test"] = generate_temp_function_profile(
-        "test",
-        "test"
-    )
-
-    # Correlate jvm coverage map
-    cp.correlate_jvm_method_with_coverage(function_list)
-
     # Ensure the coverage map result is correct
     assert len(cp.covmap) == 2
-    assert "<init>" in cp.covmap
-    assert "fuzzerTestOneInput" in cp.covmap
-    assert cp.covmap["<init>"] == []
-    assert cp.covmap["fuzzerTestOneInput"] == [(25, 1000), (27, 1000), (23, 0)]
+    assert "[BASE64EncoderStreamFuzzer].<init>()" in cp.covmap
+    assert "[BASE64EncoderStreamFuzzer].fuzzerTestOneInput(FuzzedDataProvider)" in cp.covmap
+    assert cp.covmap["[BASE64EncoderStreamFuzzer].<init>()"] == [(23, 0)]
+    assert cp.covmap[
+        "[BASE64EncoderStreamFuzzer].fuzzerTestOneInput(FuzzedDataProvider)"] == [(25, 3), (27, 6)]


### PR DESCRIPTION
It is found that the code coverage report calculation for JVM does not reflect the real data correctly. After some analysis of the code, it is believed that the current coverage calculation and extraction from the jacoco.xml only consider items in terms of source files but not methods. This cause separate methods inherit a wrong coverage calculation. This PR proposes a revamp on the coverage calculation for JVM projects to consider cov_map on separate methods instead of the whole source files. This is necessary to retrieve correct coverage information for each methods and that information is needed for further post-processing and the candidate choosing process for oss-fuzz-gen.