### PR TITLE
webapp: Fix bug in wrong empty checking

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -14,7 +14,7 @@
 
 import json
 import datetime
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Optional, Any
 
 
 def get_date_at_offset_as_str(day_offset: int = -1) -> str:
@@ -26,10 +26,9 @@ def get_date_at_offset_as_str(day_offset: int = -1) -> str:
 class Project:
 
     def __init__(self, name: str, language: str, date: str,
-                 coverage_data: Dict[str,
-                                     Tuple], introspector_data: Dict[str,
-                                                                     Tuple],
-                 fuzzer_count: int, project_repository: str):
+                 coverage_data: Optional[Dict[str, Any]],
+                 introspector_data: Optional[Dict[str, Any]],
+                 fuzzer_count: int, project_repository: Optional[str]):
         self.name = name
         self.language = language
         self.date = date
@@ -72,8 +71,9 @@ class DBSummary:
 class ProjectTimestamp:
 
     def __init__(self, project_name: str, date: str, language: str,
-                 coverage_data: Dict[str, Tuple],
-                 introspector_data: Dict[str, Tuple], fuzzer_count: int):
+                 coverage_data: Optional[Dict[str, Any]],
+                 introspector_data: Optional[Dict[str,
+                                                  Any]], fuzzer_count: int):
         self.project_name = project_name
         # date in the format Y-m-d
         self.date = date

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -818,6 +818,9 @@ def api_annotated_cfg():
     if target_project is None:
         return {'result': 'error', 'msg': 'Project not in the database'}
 
+    if target_project.introspector_data is None:
+        return {'result': 'error', 'msg': 'Found no introspector data.'}
+
     try:
         return {
             'result': 'success',

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -370,9 +370,9 @@ def project_profile():
                                      language=build_status.language,
                                      date="",
                                      fuzzer_count=0,
-                                     coverage_data={},
-                                     introspector_data={},
-                                     project_repository='')
+                                     coverage_data=None,
+                                     introspector_data=None,
+                                     project_repository=None)
 
             # Get statistics of the project
             project_statistics = data_storage.PROJECT_TIMESTAMPS


### PR DESCRIPTION
In #1584, the 3 default values in routes.py for initialize an empty models.Project object has been changed from None to empty Dict and string for fulfilling later type checking by mypy. But this change accidentally break some of the projects. Some projects (Either a wrong project or we only have a build status for it) will call this code to generate an empty project for further process. And the rendering template in template/project_profile.html actually consider if these arguments are None in order to determine if data should be retrieved from it (a Dict). Thus changing them to an empty Dict and trying accessing its content with an non-exist key cause the rendering to throw an exception. This PR fixes that by reverting them to default None value. To fulfil the mypy check, this PR also change the specific arguments type to Optional in order to indicate it could be None.