### PR TITLE
webapp: Fix type error bug

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -94,7 +94,7 @@ class Function:
                  is_reached: bool = False,
                  runtime_code_coverage: float = 0.0,
                  function_filename: str = "",
-                 reached_by_fuzzers: int = 0,
+                 reached_by_fuzzers: List[str] = [],
                  code_coverage_url: str = "",
                  accummulated_cyclomatic_complexity: int = 0,
                  llvm_instruction_count: int = 0,


### PR DESCRIPTION
It is found that the default value for reached_by_fuzzers of the Function object is wrong at the beginning and that cause the typing added in #1600 also wrong. This PR fixes both the typing and default value of the reached_by_fuzzers in the Function object.