### PR TITLE
Add reset for each introspector run

### DIFF
--- a/scripts/oss-fuzz-gen-e2e/run_all.sh
+++ b/scripts/oss-fuzz-gen-e2e/run_all.sh
@@ -36,6 +36,10 @@ echo "[+] Creating introspector reports"
 cd $ROOT_FI/oss_fuzz_integration/oss-fuzz                                        
 for project in ${PROJECT}; do
   python3 ../runner.py introspector $project 10 --disable-webserver
+  # Reset is necessary because some project exeuction
+  # could break the display encoding which affect
+  # the later oss-fuzz-gen execution.
+  reset
 done
                                                                                
 # Create webserver DB


### PR DESCRIPTION
The building and executing of fuzzers in the target projects may break the display encoding because of random character use in some of the fuzzers. The broken text encoding could affect the later oss-fuzz-gen execution. This PR fixes that by adding a reset command after each project introspector run to recover from possible display text encoding breaking problem.