### PR TITLE
[webapp] Fix possible index error for oracles

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -93,12 +93,6 @@ def extract_lines_from_source_code(project_name,
                                    line_end,
                                    print_line_numbers=False,
                                    sanity_check_function_end=False):
-    # Skip the process and return None if src_begin is < 0. This is because
-    # JVM constructors do not have valid source line information and thus
-    # cannot be located in the source file.
-    if line_begin <= 0:
-        return None
-
     raw_source = extract_introspector_raw_source_code(project_name, date_str,
                                                       target_file)
 
@@ -116,7 +110,8 @@ def extract_lines_from_source_code(project_name,
     max_length = len(str(line_end))
     function_lines = []
     for line_num in range(line_begin, line_end):
-        if line_num >= len(source_lines):
+        # To avoid list out of index from invalid line_num
+        if line_num >= len(source_lines) or line_num < 0:
             continue
 
         if print_line_numbers:

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -93,8 +93,15 @@ def extract_lines_from_source_code(project_name,
                                    line_end,
                                    print_line_numbers=False,
                                    sanity_check_function_end=False):
+    # Skip the process and return None if src_begin is < 0. This is because
+    # JVM constructors do not have valid source line information and thus
+    # cannot be located in the source file.
+    if line_begin < 0:
+        return None
+
     raw_source = extract_introspector_raw_source_code(project_name, date_str,
                                                       target_file)
+
     if raw_source is None:
         print("Did not found source")
         return raw_source
@@ -652,11 +659,6 @@ def is_static(target_function) -> bool:
     src_begin = target_function.source_line_begin
     src_end = target_function.source_line_end
     src_file = target_function.function_filename
-
-    # Skip the check and return False if src_begin is -1. This is because
-    # JVM constructors do not have valid source line information
-    if src_begin < 0:
-        return False
 
     # Check if we have accompanying debug info
     debug_source_dict = target_function.debug_data.get('source', None)

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -96,7 +96,7 @@ def extract_lines_from_source_code(project_name,
     # Skip the process and return None if src_begin is < 0. This is because
     # JVM constructors do not have valid source line information and thus
     # cannot be located in the source file.
-    if line_begin < 0:
+    if line_begin <= 0:
         return None
 
     raw_source = extract_introspector_raw_source_code(project_name, date_str,

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -111,7 +111,6 @@ def extract_lines_from_source_code(project_name,
     for line_num in range(line_begin, line_end):
         if line_num >= len(source_lines):
             continue
-
         if print_line_numbers:
             line_num_str = " " * (max_length - len(str(line_num)))
             return_source += "%s%d " % (line_num_str, line_num)
@@ -652,6 +651,11 @@ def is_static(target_function) -> bool:
     src_begin = target_function.source_line_begin
     src_end = target_function.source_line_end
     src_file = target_function.function_filename
+
+    # Skip the check and return False if src_begin is -1. This is because
+    # JVM constructors do not have valid source line information
+    if src_begin < 0:
+      return False
 
     # Check if we have accompanying debug info
     debug_source_dict = target_function.debug_data.get('source', None)

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -111,6 +111,7 @@ def extract_lines_from_source_code(project_name,
     for line_num in range(line_begin, line_end):
         if line_num >= len(source_lines):
             continue
+
         if print_line_numbers:
             line_num_str = " " * (max_length - len(str(line_num)))
             return_source += "%s%d " % (line_num_str, line_num)
@@ -655,7 +656,7 @@ def is_static(target_function) -> bool:
     # Skip the check and return False if src_begin is -1. This is because
     # JVM constructors do not have valid source line information
     if src_begin < 0:
-      return False
+        return False
 
     # Check if we have accompanying debug info
     debug_source_dict = target_function.debug_data.get('source', None)


### PR DESCRIPTION
In #1610, the support for excluding static functions in oracles has been added. The static function checking is supported by the is_static function. The is_static function takes in a source's begin and end line information and invokes the extract_lines_from_source_code function to extract the source for the target function to determine if it is a static function or not. Although the logic has checked if the begin src line is larger than the total source line to avoid index overflow, there is a missing check for a negative begin src line which causes a possible index underflow and results in an Internal Server Error when querying the oracle with `exclude-static-functions=True`
This will happen because in #1555, the webapp has introduced JVM constructors as part of the function candidates, and the source line start information for JVM constructors is always -1 because that information does not exist. Thus it breaks the current logic. 
This PR fixes that by adding a negative checking and returning immediately when a negative src_begin is found to avoid the later index underflow problem.

**Remark: Although the support for JVM constructors has been introduced in #1555, it still does not affect the latest production webapp. The reason is that the JVM constructor information needed for the webapp depends on a JSON file generated by the fuzz-introspector introduced in #1523. This version of the fuzz-introspector has not yet bumped in oss-fuzz. So the constructor list on the webapp production is still empty and hence the bug is not yet appearing on production.**