### PR TITLE
[Java-frontend] Add functionLinenumberEnd to methods

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
@@ -23,12 +23,14 @@ import soot.SootClass;
 import soot.SootField;
 import soot.SootMethod;
 import soot.Type;
+import soot.Unit;
 
 public class FunctionElement {
   private String functionName;
   private String functionSourceFile;
   private String linkageType;
   private Integer functionLinenumber;
+  private Integer functionLinenumberEnd;
   private Integer functionDepth;
   private String returnType;
   private Integer argCount;
@@ -59,6 +61,7 @@ public class FunctionElement {
     this.returnType = "";
 
     this.functionLinenumber = -1;
+    this.functionLinenumberEnd = -1;
     this.functionDepth = 0;
     this.argCount = 0;
     this.BBCount = 0;
@@ -100,6 +103,14 @@ public class FunctionElement {
 
   public void setFunctionLinenumber(Integer functionLinenumber) {
     this.functionLinenumber = functionLinenumber;
+  }
+
+  public Integer getFunctionLinenumberEnd() {
+    return functionLinenumberEnd;
+  }
+
+  public void setFunctionLinenumberEnd(Integer functionLinenumberEnd) {
+    this.functionLinenumberEnd = functionLinenumberEnd;
   }
 
   public Integer getFunctionDepth() {
@@ -314,13 +325,29 @@ public class FunctionElement {
     SootClass c = m.getDeclaringClass();
 
     this.setFunctionSourceFile(c.getFilePath());
-    this.setFunctionLinenumber(m.getJavaSourceStartLineNumber());
     this.setReturnType(m.getReturnType().toString());
     this.setFunctionDepth(0);
     this.setArgCount(m.getParameterCount());
     for (Type type : m.getParameterTypes()) {
       this.addArgType(type.toString());
     }
+
+    Integer startLine = m.getJavaSourceStartLineNumber();
+    Integer endLine = -1;
+    if ((startLine > 0) && (m.hasActiveBody())) {
+      for (Unit u : m.getActiveBody().getUnits()) {
+        Integer line = u.getJavaSourceStartLineNumber();
+        if (line > endLine) {
+          endLine = line;
+        }
+      }
+      if (endLine > 0) {
+        endLine++;
+      }
+    }
+
+    this.setFunctionLinenumber(startLine);
+    this.setFunctionLinenumberEnd(endLine);
   }
 
   public void setCountInformation(Integer bbCount, Integer iCount, Integer complexity) {


### PR DESCRIPTION
In #1396, a new variable functionLinenumberEnd is added to indicate the possible ending line number of specific functions/methods in the source file. The Java frontend does not comply with this new element and always has the functionLinenumberEnd equal to -1. 
To accommodate additional API to retrieve the real method source location for oss-fuzz-gen cross reference, it is necessary to know both the starting line number and ending line number of a method to retrieve the source code for reference. 
This PR fixes the Java frontend logic to calculate the ending line number using the data contained in the active body of the SootMethod. Then the ending line number is added to the function elements and output in the data.yaml file for fuzz-introspector to process. If the logic fails to retrieve the active body, it will use the default -1 as the ending line number.