### PR TITLE
webapp: delay static checking for performance reasons

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -593,7 +593,6 @@ def oracle_1(all_functions,
             if not to_continue:
                 continue
 
-
             if no_static_functions:
                 # Exclude function if it's static
                 if is_static(function):

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -579,11 +579,6 @@ def oracle_1(all_functions,
         if not is_interesting_func:
             continue
 
-        if no_static_functions:
-            # Exclude function if it's static
-            if is_static(function):
-                continue
-
         if (function.runtime_code_coverage < 60.0
                 and project_count.get(function.project, 0) < max_project_count
                 and function.accummulated_cyclomatic_complexity > 30):
@@ -597,6 +592,12 @@ def oracle_1(all_functions,
                     to_continue = True
             if not to_continue:
                 continue
+
+
+            if no_static_functions:
+                # Exclude function if it's static
+                if is_static(function):
+                    continue
             tmp_list.append(function)
             current_count = project_count.get(function.project, 0)
             current_count += 1


### PR DESCRIPTION
The static checks is expensive (we should probably push this into the frontends), and having it before e.g. checking if function's project is the same as the target project caused a significant slowdown. This delays the check to the very end for performance reasons.