### PR TITLE
webapp: Fix wrong src_end return bug

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1236,7 +1236,7 @@ def api_function_source_code():
         'source': source_code,
         'filepath': src_file,
         'src_begin': src_begin,
-        'src_end': src_begin
+        'src_end': src_end
     }
 
 


### PR DESCRIPTION
This PR fixes the wrong `src_end` value returned by the `/api/function-source-code` api in the webapp.