### PR TITLE
core: find where functions are declared in header files

### DIFF
--- a/src/fuzz_introspector/debug_info.py
+++ b/src/fuzz_introspector/debug_info.py
@@ -305,6 +305,7 @@ def load_debug_report(debug_files):
         'all_global_variables': list(all_global_variables.values()),
         'all_types': list(all_types.values())
     }
+
     return report_dict
 
 

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -763,7 +763,7 @@ def create_html_report(introspection_proj: analysis.IntrospectionProject,
     # Correlate debug info to introspector functions
     analysis.correlate_introspection_functions_to_debug_info(
         all_functions_json_report, introspection_proj.debug_all_functions,
-        proj_profile.target_lang)
+        proj_profile.target_lang, introspection_proj.debug_report)
 
     # Write various stats and all-functions data to summary.json
     proj_profile.write_stats_to_summary_file()


### PR DESCRIPTION
In https://github.com/google/oss-fuzz-gen/pull/370 some harnesses were found to have a lot of unnecessary header files included in the prompts. This is an effort to fix this by identifying where functions are declared in header files, such that we can narrow it down further which files to include.