### PR TITLE
webapp: limit size of sample references

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1814,6 +1814,9 @@ def sample_cross_references():
         src_end = target_function.source_line_end
         src_file = target_function.function_filename
 
+        # Don't show enormous functions
+        if (src_end - src_begin) > 70:
+            continue
         # Check if we have accompanying debug info
         debug_source_dict = target_function.debug_data.get('source', None)
         if debug_source_dict:


### PR DESCRIPTION
The experiment in https://github.com/google/oss-fuzz-gen/pull/370 showed some large sample references in some of the targets. Setting a limit here to avoid this.