### PR TITLE
webapp: fix bug in src_end handling

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1196,7 +1196,8 @@ def api_function_source_code():
     # Transform java class name to java source file path with package directories
     if project.language == 'java':
         src_file = f'/{src_file.split("$", 1)[0].replace(".", "/")}.java'
-        src_end = src_begin + 10
+        if src_end <= src_begin:
+            src_end = src_begin + 10
 
     # Check if we have accompanying debug info
     debug_source_dict = target_function.debug_data.get('source', None)


### PR DESCRIPTION
This PR fixes a bug in src_end handling. The src_end variable should only add 10 when it is less than or equal to the src begin, which indicates that the src_end is not provided correctly.