### PR TITLE
webapp: Fix function to consider constructor signature

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -913,7 +913,8 @@ def branch_blockers():
 
 def get_function_from_func_signature(func_signature, project_name):
     all_functions = data_storage.get_functions()
-    for function in all_functions:
+    all_constructors = data_storage.get_constructors()
+    for function in (all_functions + all_constructors):
         if function.project == project_name and function.func_signature == func_signature:
             return function
     return None


### PR DESCRIPTION
The PR fixes the logic for get_function_from_func_signature function to also consider possible jvm constructors.