### PR TITLE
web: avoid excessive logging

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -535,7 +535,6 @@ def extract_project_data(project_name, date_str, should_include_details,
             amount_of_fuzzers = len(introspector_report) - 2
             number_of_functions = len(all_function_list)
         else:
-            print('Using new style of function storage')
             amount_of_fuzzers = project_stats['harness-count']
             number_of_functions = project_stats['total-functions']
             all_function_list = None


### PR DESCRIPTION
The new format is used by almost al projects now, so it's spamming unnecessarily at this point. Removing to make logs clearer