### PR TITLE
webapp: Fix bug for handling jvm source file path

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -96,6 +96,19 @@ def extract_lines_from_source_code(project_name,
                                    line_end,
                                    print_line_numbers=False,
                                    sanity_check_function_end=False):
+    # Retrieve project from project_name
+    project = get_project_with_name(project_name)
+    if project is None:
+        # Failed to locate the project with project_name
+        return None
+
+    # Transform java class name to java source file path with package directories
+    if project.language == 'java':
+        target_file = f'/{target_file.split("$", 1)[0].replace(".", "/")}.java'
+        if line_end <= line_begin:
+            line_end = line_begin + 10
+
+    # Extract the source code from the target file
     raw_source = extract_introspector_raw_source_code(project_name, date_str,
                                                       target_file)
 
@@ -1322,10 +1335,6 @@ def api_function_source_code():
     if project_name is None:
         return {'result': 'error', 'msg': 'Please provide a project name'}
 
-    project = get_project_with_name(project_name)
-    if project is None:
-        return {'result': 'error', 'msg': 'Could not find project'}
-
     function_signature = request.args.get('function_signature', None)
     if function_signature is None:
         return {'result': 'error', 'msg': 'No function signature provided'}
@@ -1357,12 +1366,6 @@ def api_function_source_code():
     src_begin = target_function.source_line_begin
     src_end = target_function.source_line_end
     src_file = target_function.function_filename
-
-    # Transform java class name to java source file path with package directories
-    if project.language == 'java':
-        src_file = f'/{src_file.split("$", 1)[0].replace(".", "/")}.java'
-        if src_end <= src_begin:
-            src_end = src_begin + 10
 
     # Check if we have accompanying debug info
     debug_source_dict = target_function.debug_data.get('source', None)


### PR DESCRIPTION
In #1623, changes have been made for source code querying API to accommodate Java projects. The changes are only done in a single API but all other APIs required source code querying is not changed. This causes the logic can only accommodate Java projects in a single API. This PR moves the Java-specific logic for source code querying into the underlying source code querying function to accommodate all APIs for Java project source code querying.