### PR TITLE
webapp: Fix ordering bug for far-reach-but-low-coverage oracle API

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -181,7 +181,7 @@ def get_functions_of_interest(project_name):
     sorted_functions_of_interest = sorted(
         project_functions,
         key=lambda x:
-        (-x.accummulated_cyclomatic_complexity, -x.runtime_code_coverage))
+        (-x.accummulated_cyclomatic_complexity, x.runtime_code_coverage))
 
     return sorted_functions_of_interest
 


### PR DESCRIPTION
The `get_functions_of_interest` function is supposed to return a list of functions that are ordered by high cyclomatic complexity in descending order and runtime coverage in ascending order. This ordering ensures that the functions with high cyclomatic complexity and low coverage always come first in the list. It is found that the ordering is wrong by sorting both parameters in descending order. Although it does not affect the content of the resulting list, the order in the list is wrong and possibly affects OSS-Fuzz-gen's process if limitation is applied. This PR fixes that by making sure the runtime coverage is ordered in ascending order.