### PR TITLE
script: Add installation of dependencies to oss-fuzz-gen script

### DIFF
--- a/scripts/oss-fuzz-gen-e2e/run_all.sh
+++ b/scripts/oss-fuzz-gen-e2e/run_all.sh
@@ -34,6 +34,10 @@ comma_separated=${comma_separated::-1}
 cd ${BASE_DIR}
 . .venv/bin/activate
 
+# Install dependencies
+pip3 install -r $ROOT_FI/tools/web-fuzzing-introspection/requirements.txt
+pip3 install -r $BASE_DIR/oss-fuzz-gen/requirements.txt
+
 echo "[+] Creating introspector reports"
 cd $ROOT_FI/oss_fuzz_integration/oss-fuzz                                        
 for project in ${PROJECT}; do

--- a/scripts/oss-fuzz-gen-e2e/web_run_all.sh
+++ b/scripts/oss-fuzz-gen-e2e/web_run_all.sh
@@ -38,6 +38,10 @@ comma_separated=${comma_separated::-1}
 cd ${BASE_DIR}
 . .venv/bin/activate
 
+# Install dependencies
+pip3 install -r $ROOT_FI/tools/web-fuzzing-introspection/requirements.txt
+pip3 install -r $BASE_DIR/oss-fuzz-gen/requirements.txt
+
 # Create webserver DB
 echo "[+] Creating the webapp DB"
 cd $ROOT_FI/tools/web-fuzzing-introspection/app/static/assets/db/


### PR DESCRIPTION
It is found that both the webapp and the oss-fuzz-gen require some dependencies that need to be installed. This PR fixes both the run_all.sh and web_run_all.sh by adding dependencies installation in the python venv before starting the webapp or calling oss-fuzz-gen.