### PR TITLE
JVM-webapp: Add close property

### DIFF
--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/FunctionElement.java
@@ -289,6 +289,14 @@ public class FunctionElement {
       methodInfo.addException(exception.getFilePath());
     }
 
+    // Determine if the method's class need closing after use
+    for (SootMethod temp : c.getMethods()) {
+      if (temp.getName().equals("close")) {
+        methodInfo.setNeedClose(true);
+        break;
+      }
+    }
+
     // Additional information for auto-fuzz process
     if (isAutoFuzz) {
       // Extra class information for constructors

--- a/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
+++ b/frontends/java/src/main/java/ossf/fuzz/introspector/soot/yaml/JavaMethodInfo.java
@@ -33,6 +33,7 @@ public class JavaMethodInfo {
   private Boolean isClassConcrete;
   private Boolean isClassEnum;
   private Boolean isClassPublic;
+  private Boolean needClose;
 
   public JavaMethodInfo() {
     this.exceptions = new ArrayList<String>();
@@ -48,6 +49,7 @@ public class JavaMethodInfo {
     this.isClassConcrete = true;
     this.isClassEnum = false;
     this.isClassPublic = true;
+    this.needClose = false;
   }
 
   public List<String> getExceptions() {
@@ -164,5 +166,13 @@ public class JavaMethodInfo {
 
   public void setIsClassPublic(Boolean isClassPublic) {
     this.isClassPublic = isClassPublic;
+  }
+
+  public Boolean isNeedClose() {
+    return this.needClose;
+  }
+
+  public void setNeedClose(Boolean needClose) {
+    this.needClose = needClose;
   }
 }

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -70,6 +70,7 @@ class FunctionProfile:
         self.is_enum = self._is_enum_class(elem)
         self.is_static = self._is_static(elem)
         self.exceptions = self._get_exceptions(elem)
+        self.need_close = self._need_close(elem)
 
         # Temporary handle for unreadable library method (JVM)
         # (jar missing or purposely ignored)
@@ -151,6 +152,12 @@ class FunctionProfile:
     def _is_static(self, elem: Dict[Any, Any]) -> bool:
         if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
             return bool(elem['JavaMethodInfo']['static'])
+
+        return False
+
+    def _need_close(self, elem: Dict[Any, Any]) -> bool:
+        if "JavaMethodInfo" in elem and elem['JavaMethodInfo']:
+            return bool(elem['JavaMethodInfo']['needClose'])
 
         return False
 

--- a/src/fuzz_introspector/html_report.py
+++ b/src/fuzz_introspector/html_report.py
@@ -147,6 +147,7 @@ def create_all_function_table(
         json_copy['is_jvm_library'] = fd.is_jvm_library
         json_copy['is_enum_class'] = fd.is_enum
         json_copy['is_static'] = fd.is_static
+        json_copy['need_close'] = fd.need_close
         json_copy['exceptions'] = fd.exceptions
         table_rows_json_report.append(json_copy)
 
@@ -836,6 +837,7 @@ def create_html_report(introspection_proj: analysis.IntrospectionProject,
             json_copy['is_jvm_library'] = fd.is_jvm_library
             json_copy['is_enum_class'] = fd.is_enum
             json_copy['is_static'] = fd.is_static
+            json_copy['need_close'] = fd.need_close
             json_copy['exceptions'] = fd.exceptions
             json_copy['Fuzzers runtime hit'] = 'no'
             json_copy['Func lines hit %'] = '0.0%'

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -241,6 +241,7 @@ def extract_and_refine_functions(all_function_list, project_name, date_str):
         introspector_func['jvm_lib'] = func.get('is_jvm_library', False)
         introspector_func['enum'] = func.get('is_enum_class', False)
         introspector_func['static'] = func.get('is_static', False)
+        introspector_func['need_close'] = func.get('need_close', False)
         introspector_func['exc'] = func.get('exceptions', [])
 
         # For JVM projects, the function name, function signature and function raw

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -189,6 +189,7 @@ def load_functions(function_list: List[Dict[str, Any]],
                             is_jvm_library=func.get('jvm_lib', False),
                             is_enum_class=func.get('enum', False),
                             is_static=func.get('static', False),
+                            need_close=func.get('need_close', False),
                             exceptions=func.get('exc', [])))
 
     return idx

--- a/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
+++ b/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
@@ -153,6 +153,8 @@ def convert_functions_to_list_of_dict(
             function.is_enum_class,
             'is_static':
             function.is_static,
+            'need_close':
+            function.need_close,
             'exceptions':
             function.exceptions
         })

--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -115,6 +115,7 @@ class Function:
                  is_jvm_library: bool = False,
                  is_enum_class: bool = False,
                  is_static: bool = False,
+                 need_close: bool = False,
                  exceptions: List[str] = []):
         self.name = name
         self.function_filename = function_filename
@@ -142,6 +143,7 @@ class Function:
         self.is_jvm_library = is_jvm_library
         self.is_enum_class = is_enum_class
         self.is_static = is_static
+        self.need_close = need_close
         self.exceptions = exceptions
 
     def to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
This PR adds a new "need_close" property to the functions for supporting the oss-fuzz-gen prompt generation of JVM projects. This could avoid false positive OOM happening on fuzzers generated by LLM.