### PR TITLE
webapp: Add API for retrieving JVM properties of methods

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
+++ b/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
@@ -151,11 +151,5 @@ def convert_functions_to_list_of_dict(
             function.debug_data,
             'is_enum_class':
             function.is_enum_class,
-            'is_static':
-            function.is_static,
-            'need_close':
-            function.need_close,
-            'exceptions':
-            function.exceptions
         })
     return sorted_function_dict_list_by_fuzz_worthiness

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1468,8 +1468,10 @@ def api_jvm_method_properties():
 
     if target_function is None:
         return {
-            'result': 'error',
-            'msg': f'Function signature could not be found in project {project_name}'
+            'result':
+            'error',
+            'msg':
+            f'Function signature could not be found in project {project_name}'
         }
 
     return {

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1453,6 +1453,33 @@ def api_function_with_matching_type():
     }
 
 
+@blueprint.route('/api/jvm-method-properties')
+def api_jvm_method_properties():
+    """Returns some properties for the jvm method"""
+    project_name = request.args.get('project', None)
+    if project_name is None:
+        return {'result': 'error', 'msg': 'Please provide a project name'}
+    function_signature = request.args.get('function_signature', None)
+    if function_signature is None:
+        return {'result': 'error', 'msg': 'No function signature provided'}
+
+    target_function = get_function_from_func_signature(function_signature,
+                                                       project_name)
+
+    if target_function is None:
+        return {
+            'result': 'error',
+            'msg': f'Function signature could not be found in project {project_name}'
+        }
+
+    return {
+        'result': 'success',
+        'is-jvm-static': target_function.is_static,
+        'need-close': target_function.need_close,
+        'exceptions': target_function.exceptions
+    }
+
+
 def get_build_status_of_project(project_name):
     build_status = data_storage.get_build_status()
 


### PR DESCRIPTION
This PR adds a new API endpoint for retrieving JVM-method-specific properties. It also removes the returning of these properties from the original API calls to reduce the size of the response for other APIs.