### PR TITLE
webapp: force caching of functions

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -53,6 +53,10 @@ def load_db() -> None:
                 introspector_url=project_timestamp.get('introspector_url',
                                                        None),
                 project_url=project_timestamp.get('project_url', None)))
+    # If we're caching, then remove the timestamp file.
+    force_cache = True
+    if 'G_ANALYTICS_TAG' in os.environ or force_cache:
+        os.remove(project_timestamps_file)
 
     # Load all profiles
     with open(project_currents, 'r') as f:
@@ -122,5 +126,8 @@ def load_db() -> None:
         with open(all_header_files_file, 'r') as f:
             all_header_files = json.load(f)
         data_storage.ALL_HEADER_FILES = all_header_files
+
+    # Load all functions into a cache
+    data_storage.load_cache()
 
     return

--- a/tools/web-fuzzing-introspection/app/webapp/data_storage.py
+++ b/tools/web-fuzzing-introspection/app/webapp/data_storage.py
@@ -32,9 +32,16 @@ ALL_HEADER_FILES: List[Dict[str, Any]] = []
 
 TOTAL_FUNCTION_COUNT = -1
 
+JSON_TO_FUNCTION_CACHE = dict()
+
 
 def get_projects() -> List[Project]:
     return PROJECTS
+
+
+def load_cache():
+    for project in PROJECTS:
+        get_functions_by_project(project.name)
 
 
 def get_functions_by_project(proj: str) -> List[Function]:
@@ -112,6 +119,9 @@ def retrieve_functions(proj: str, is_constructor: bool) -> List[Function]:
     else:
         json_path = all_functions_file.replace('{PROJ}', proj)
 
+    if json_path in JSON_TO_FUNCTION_CACHE:
+        return JSON_TO_FUNCTION_CACHE[json_path]
+
     if os.path.isfile(json_path):
         with open(json_path, 'r') as file:
             function_list = orjson.loads(file.read())
@@ -157,5 +167,13 @@ def retrieve_functions(proj: str, is_constructor: bool) -> List[Function]:
                      is_static=func.get('static', False),
                      need_close=func.get('need_close', False),
                      exceptions=func.get('exc', [])))
+    JSON_TO_FUNCTION_CACHE[json_path] = result_list
 
+    # At this point if google analytics tag is set it means we are in production, and we should
+    # delete the .json file then to save storage.
+    force_cache = True
+    if 'G_ANALYTICS_TAG' in os.environ or force_cache:
+        os.remove(json_path)
+
+    print("Converted list")
     return result_list

--- a/tools/web-fuzzing-introspection/app/webapp/data_storage.py
+++ b/tools/web-fuzzing-introspection/app/webapp/data_storage.py
@@ -32,7 +32,7 @@ ALL_HEADER_FILES: List[Dict[str, Any]] = []
 
 TOTAL_FUNCTION_COUNT = -1
 
-JSON_TO_FUNCTION_CACHE = dict()
+JSON_TO_FUNCTION_CACHE: Dict[str, List[Function]] = dict()
 
 
 def get_projects() -> List[Project]:

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -236,6 +236,7 @@ def get_project_with_name(project_name):
 
 
 def get_fuction_with_name(function_name, project_name):
+
     all_functions = data_storage.get_functions_by_project(project_name)
     for function in all_functions:
         if function.name == function_name:
@@ -841,7 +842,6 @@ def target_oracle():
                     continue
                 total_funcs.add(func)
                 functions_to_display.append((func, heuristic_name))
-
     func_to_lang = dict()
     for func, heuristic in functions_to_display:
         language = 'c'


### PR DESCRIPTION
This is to avoid having both file stored on the filesystem as well as in dictionaries during production. The current file-system only approach is causing significant delays making introspector.oss-fuzz.com unresponsive