### PR TITLE
webapp: Fix and unify source file path

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -71,8 +71,8 @@ def extract_introspector_raw_source_code(project_name, date_str, target_file):
 
     if is_local:
         src_location = os.path.join(local_oss_fuzz, 'build', 'out',
-                                    project_name, 'inspector',
-                                    'source-code',  target_file)
+                                    project_name, 'inspector', 'source-code',
+                                    target_file)
 
         if not os.path.isfile(src_location):
             return None
@@ -80,8 +80,9 @@ def extract_introspector_raw_source_code(project_name, date_str, target_file):
             return f.read()
 
     introspector_summary_url = os.path.join(
-        get_introspector_report_url_source_base(
-            project_name, date_str.replace("-", "")), target_file)
+        get_introspector_report_url_source_base(project_name,
+                                                date_str.replace("-", "")),
+        target_file)
 
     print("URL: %s" % (introspector_summary_url))
     # Read the introspector atifact

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -66,7 +66,8 @@ def get_coverage_report_url(project_name, datestr, language):
 
 
 def extract_introspector_raw_source_code(project_name, date_str, target_file):
-    if target_file.startswith('/'):
+    # Remove leading slash to avoid errors
+    while target_file.startswith('/'):
         target_file = target_file[1:]
 
     if is_local:

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -66,18 +66,22 @@ def get_coverage_report_url(project_name, datestr, language):
 
 
 def extract_introspector_raw_source_code(project_name, date_str, target_file):
+    if target_file.startswith('/'):
+        target_file = target_file[1:]
 
     if is_local:
         src_location = os.path.join(local_oss_fuzz, 'build', 'out',
                                     project_name, 'inspector',
-                                    'source-code') + target_file
+                                    'source-code',  target_file)
+
         if not os.path.isfile(src_location):
             return None
         with open(src_location, 'r') as f:
             return f.read()
 
-    introspector_summary_url = get_introspector_report_url_source_base(
-        project_name, date_str.replace("-", "")) + target_file
+    introspector_summary_url = os.path.join(
+        get_introspector_report_url_source_base(
+            project_name, date_str.replace("-", "")), target_file)
 
     print("URL: %s" % (introspector_summary_url))
     # Read the introspector atifact


### PR DESCRIPTION
This PR fixes an issue with non-unified target file strings. For JVM projects, the target file string is a path of the source file within the package directory, which does not start with a '/'. This behaviour differs from other project languages like C/C++, where the path always starts with a '/'. This PR unifies the behaviour to allow the logic to handle both cases successfully.