### PR TITLE
webapp: Handles missing function signature

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -153,6 +153,11 @@ class Function:
         self.need_close = need_close
         self.exceptions = exceptions
 
+        # Handles the case when function signature is not available
+        # Majorly used for python project
+        if self.func_signature == 'N/A':
+            self.func_signature = self.name
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             'function_name': self.name,


### PR DESCRIPTION
The frontend of FI failed to extract signatures for functions in a Python project. This results in N/A for the function signature field of all functions in the project, affecting the further processing of the web app and OFG. This PR fixes the issue by setting the function signature to the function name by default whenever the signature is missing.