### PR TITLE
webapp: Add project property to function details return

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
+++ b/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
@@ -126,6 +126,8 @@ def convert_functions_to_list_of_dict(
     sorted_function_dict_list_by_fuzz_worthiness = []
     for function in functions:
         sorted_function_dict_list_by_fuzz_worthiness.append({
+            'project':
+            function.project,
             'function_name':
             function.name,
             'function_filename':


### PR DESCRIPTION
It was found that some OFG logic for Python requires the project name where a function belongs to determine if the function should be included in a fuzzer. This PR adds the necessary information to the function dictionary, returning it for APIs that require function information.