### PR TITLE
webapp: local: enable loading in context of light introspector

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -125,6 +125,8 @@ def extract_local_introspector_function_list(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector',
                                 'all-fuzz-introspector-functions.json')
+    if not os.path.isfile(summary_json):
+        return []
 
     with open(summary_json, 'r') as f:
         function_list = json.load(f)
@@ -278,6 +280,8 @@ def extract_introspector_report(project_name, date_str):
 def extract_local_introspector_all_files(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector', 'all-files.json')
+    if not os.path.isfile(summary_json):
+        return []
     with open(summary_json, 'r') as f:
         json_list = json.load(f)
     return json_list
@@ -286,6 +290,8 @@ def extract_local_introspector_all_files(project_name, oss_fuzz_folder):
 def extract_local_introspector_test_files(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector', 'test-files.json')
+    if not os.path.isfile(summary_json):
+        return {}
     with open(summary_json, 'r') as f:
         json_list = json.load(f)
     return json_list
@@ -294,6 +300,8 @@ def extract_local_introspector_test_files(project_name, oss_fuzz_folder):
 def extract_local_introspector_debug_info(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector', 'all_debug_info.json')
+    if not os.path.isfile(summary_json):
+        return {}
     with open(summary_json, 'r') as f:
         json_dict = json.load(f)
     return json_dict
@@ -302,6 +310,8 @@ def extract_local_introspector_debug_info(project_name, oss_fuzz_folder):
 def get_local_introspector_type_map(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector', 'all-friendly-debug-types.json')
+    if not os.path.isfile(summary_json):
+        return {}
     with open(summary_json, 'r') as f:
         json_dict = json.load(f)
     return json_dict

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -327,9 +327,6 @@ def extract_local_project_data(project_name, oss_fuzz_path,
         project_name, oss_fuzz_path)
     introspector_report = oss_fuzz.extract_local_introspector_report(
         project_name, oss_fuzz_path)
-    if not introspector_report:
-        return
-
     introspector_type_map = oss_fuzz.get_local_introspector_type_map(
         project_name, oss_fuzz_path)
     debug_report = oss_fuzz.extract_local_introspector_debug_info(
@@ -375,11 +372,15 @@ def extract_local_project_data(project_name, oss_fuzz_path,
         project_name, oss_fuzz_path)
     all_constructor_list = oss_fuzz.extract_local_introspector_constructor_list(
         project_name, oss_fuzz_path)
-    project_stats = introspector_report['MergedProjectProfile']['stats']
-    amount_of_fuzzers = project_stats['harness-count']
-    number_of_functions = project_stats['total-functions']
-    functions_covered_estimate = project_stats[
-        'code-coverage-function-percentage']
+
+    try:
+        project_stats = introspector_report['MergedProjectProfile']['stats']
+    except KeyError:
+        project_stats = {}
+    amount_of_fuzzers = project_stats.get('harness-count', 0)
+    number_of_functions = project_stats.get('total-functions', 0)
+    functions_covered_estimate = project_stats.get(
+        'code-coverage-function-percentage', 0.0)
 
     # Get details if needed and otherwise leave empty
     refined_proj_list = list()
@@ -402,16 +403,26 @@ def extract_local_project_data(project_name, oss_fuzz_path,
         project_repository = 'N/A'
 
     introspector_data_dict = {
-        "introspector_report_url": 'introspector_url',
-        "coverage_lines": project_stats['code-coverage-function-percentage'],
-        "static_reachability": project_stats['reached-complexity-percentage'],
-        "fuzzer_count": amount_of_fuzzers,
-        "function_count": len(all_function_list),
-        "functions_covered_estimate": functions_covered_estimate,
-        'refined_proj_list': refined_proj_list,
-        'refined_constructor_list': refined_constructor_list,
-        'annotated_cfg': annotated_cfg,
-        'project_name': project_name
+        "introspector_report_url":
+        'introspector_url',
+        "coverage_lines":
+        project_stats.get('code-coverage-function-percentage', 0.0),
+        "static_reachability":
+        project_stats.get('reached-complexity-percentage', 0.0),
+        "fuzzer_count":
+        amount_of_fuzzers,
+        "function_count":
+        len(all_function_list),
+        "functions_covered_estimate":
+        functions_covered_estimate,
+        'refined_proj_list':
+        refined_proj_list,
+        'refined_constructor_list':
+        refined_constructor_list,
+        'annotated_cfg':
+        annotated_cfg,
+        'project_name':
+        project_name
     }
 
     code_coverage_data_dict = extract_code_coverage_data(


### PR DESCRIPTION
Enables loading using the current logic in case some projects only succeeded with light introspector. The next step is to load in the light introspector data to the webapp as well.