### PR TITLE
cfg_load: return empty list instead of throwing exception

### DIFF
--- a/src/fuzz_introspector/cfg_load.py
+++ b/src/fuzz_introspector/cfg_load.py
@@ -68,7 +68,7 @@ def extract_all_callsites(
         calltree: Optional[CalltreeCallsite]) -> List[CalltreeCallsite]:
     if calltree is None:
         logger.error("Trying to extract from a None calltree")
-        raise CalltreeError("Calltree is None")
+        return []
 
     cs_list: List[CalltreeCallsite] = []
     extract_all_callsites_recursive(calltree, cs_list)


### PR DESCRIPTION
This helps kernel driver analysis where we may not always have a calltree, since we don't have an entrypoint at first.