### PR TITLE
webapp: enable automated API documentation

### DIFF
--- a/tools/web-fuzzing-introspection/app/main.py
+++ b/tools/web-fuzzing-introspection/app/main.py
@@ -15,7 +15,7 @@
 import os
 
 from flask import Flask
-
+from flask_smorest import Api
 from typing import Optional, Tuple
 import webapp
 from webapp import routes
@@ -23,7 +23,17 @@ from webapp import routes
 
 def create_app():
     app = Flask(__name__)
+    app.config["API_TITLE"] = "Fuzz Introspector Web API"
+    app.config["API_VERSION"] = "v1"
+    app.config["OPENAPI_VERSION"] = "3.0.3"
+    app.config["OPENAPI_URL_PREFIX"] = "/"
+    app.config["OPENAPI_SWAGGER_UI_PATH"] = "/swagger-ui"
+    app.config[
+        "OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
     app.register_blueprint(routes.blueprint)
+
+    api = Api(app)
+    api.register_blueprint(routes.api_blueprint)
 
     try:
         routes.gtag = os.environ['G_ANALYTICS_TAG']

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -20,7 +20,10 @@ import signal
 from typing import Dict, List, Optional
 import requests
 
-from flask import Blueprint, render_template, request, redirect
+from flask import render_template, request, redirect
+from flask_smorest import Blueprint
+
+import marshmallow
 
 from . import models, data_storage, page_texts
 from .helper import function_helper
@@ -29,6 +32,10 @@ from .helper import function_helper
 #from app.site import test_data
 
 blueprint = Blueprint('site', __name__, template_folder='templates')
+
+api_blueprint = Blueprint('api',
+                          'Fuzz Introspector API',
+                          description='Fuzz Introspector Web app Api.')
 
 gtag = None
 is_local = False
@@ -45,6 +52,22 @@ MAX_TEST_SIZE = 6000
 
 # Max matches to show when searching for functions in functions view.
 MAX_MATCHES_TO_DISPLAY = 180
+
+
+class ProjectSchema(marshmallow.Schema):
+    """Schema for project names."""
+    project = marshmallow.fields.String(
+        description='Name of the OSS-Fuzz project.')
+
+
+class ProjectFunctionSchema(marshmallow.Schema):
+    """Generic response with function dictionaries"""
+    extended_msgs = marshmallow.fields.List(
+        marshmallow.fields.String(),
+        description='List of informative messages')
+    result = marshmallow.fields.String(
+        description='Indication of success or not.')
+    functions = marshmallow.fields.List(marshmallow.fields.Dict())
 
 
 def get_introspector_report_url_base(project_name, datestr):
@@ -1876,15 +1899,25 @@ def api_oracle_2():
     }
 
 
-@blueprint.route('/api/far-reach-low-cov-fuzz-keyword')
-def api_oracle_1():
-    err_msgs = list()
-    project_name = request.args.get('project', None)
+@api_blueprint.route('/api/far-reach-low-cov-fuzz-keyword')
+@api_blueprint.arguments(ProjectSchema, location='query')
+@api_blueprint.response(200, ProjectFunctionSchema)
+def api_oracle_1(args):
+    """Returns functions with far reach, low coverage and function names
+    that are often relevant for fuzzing.
+    
+    
+    This API is used to extract interesting targets to fuzz. The filtering
+    on naming is meant to increase the likelihood of the function being
+    a good target."""
+    returner = ProjectFunctionSchema()
+
+    project_name = args.get('project', None)
     if project_name is None:
-        return {
-            'result': 'error',
-            'extended_msgs': ['Please provide project name']
-        }
+        returner.result = 'error'
+        returner.extended_msgs = ['Please provide project name']
+        returner.functions = []
+        return returner
 
     no_static_funcs_arg = request.args.get('exclude-static-functions',
                                            'false').lower()
@@ -1903,7 +1936,10 @@ def api_oracle_1():
 
     target_project = get_project_with_name(project_name)
     if not target_project:
-        return {'result': 'error', 'extended_msgs': ['Could not find project']}
+        returner.result = 'error'
+        returner.extended_msgs = ['Could not find project']
+        returner.functions = []
+        return returner
 
     all_functions = data_storage.get_functions_by_project(project_name)
     all_projects = [target_project]
@@ -1919,12 +1955,10 @@ def api_oracle_1():
     if ALLOWED_ORACLE_RETURNS:
         functions_to_return = sort_funtions_to_return(functions_to_return)
 
-    result_status = 'success'
-    return {
-        'result': result_status,
-        'extended_msgs': err_msgs,
-        'functions': functions_to_return
-    }
+    returner.result = 'success'
+    returner.extended_msgs = []
+    returner.functions = functions_to_return
+    return returner
 
 
 @blueprint.route('/api/project-repository')

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1914,7 +1914,7 @@ def api_oracle_1(args):
 
     project_name = args.get('project', None)
     if project_name is None:
-        return ProjectFunctionSchema.dump({
+        return returner.dump({
             'result': 'error',
             'extended_msgs': ['Please provide project name'],
             'functions': []

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1914,10 +1914,11 @@ def api_oracle_1(args):
 
     project_name = args.get('project', None)
     if project_name is None:
-        returner.result = 'error'
-        returner.extended_msgs = ['Please provide project name']
-        returner.functions = []
-        return returner
+        return ProjectFunctionSchema.dump({
+            'result': 'error',
+            'extended_msgs': ['Please provide project name'],
+            'functions': []
+        })
 
     no_static_funcs_arg = request.args.get('exclude-static-functions',
                                            'false').lower()

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1937,10 +1937,11 @@ def api_oracle_1(args):
 
     target_project = get_project_with_name(project_name)
     if not target_project:
-        returner.result = 'error'
-        returner.extended_msgs = ['Could not find project']
-        returner.functions = []
-        return returner
+        return returner.dump({
+            'result': 'error',
+            'extended_msgs': ['Could not find project'],
+            'functions': []
+        })
 
     all_functions = data_storage.get_functions_by_project(project_name)
     all_projects = [target_project]
@@ -1956,10 +1957,11 @@ def api_oracle_1(args):
     if ALLOWED_ORACLE_RETURNS:
         functions_to_return = sort_funtions_to_return(functions_to_return)
 
-    returner.result = 'success'
-    returner.extended_msgs = []
-    returner.functions = functions_to_return
-    return returner
+    return returner.dump({
+        'result': 'success',
+        'extended_msgs': [],
+        'functions': functions_to_return
+    })
 
 
 @blueprint.route('/api/project-repository')

--- a/tools/web-fuzzing-introspection/requirements.txt
+++ b/tools/web-fuzzing-introspection/requirements.txt
@@ -8,4 +8,4 @@ requests==2.32.3
 pyyaml==6.0
 orjson==3.10.0
 flask_smorest==0.44.0
-marshmallow==3.23.0
+marshmallow==3.21.0

--- a/tools/web-fuzzing-introspection/requirements.txt
+++ b/tools/web-fuzzing-introspection/requirements.txt
@@ -7,5 +7,5 @@ Werkzeug==3.0.3
 requests==2.32.3
 pyyaml==6.0
 orjson==3.10.0
-flask_smorest==0.45.0
+flask_smorest==0.44.0
 marshmallow==3.23.0

--- a/tools/web-fuzzing-introspection/requirements.txt
+++ b/tools/web-fuzzing-introspection/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.3
-Flask==2.2.5
+Flask==3.0.2
 itsdangerous==2.1.2
 Jinja2==3.1.4
 MarkupSafe==2.1.2
@@ -7,3 +7,5 @@ Werkzeug==3.0.3
 requests==2.32.3
 pyyaml==6.0
 orjson==3.10.0
+flask_smorest==0.45.0
+marshmallow==3.23.0


### PR DESCRIPTION
Introduces API documentation with flask smorest. This has been applied to a single API for now to introduce the concept. Follow-up PR will happen with all APIs.