### PR TITLE
[Rust] Fix missing expression in function/method discovery process

### DIFF
--- a/frontends/rust/rust_function_analyser/src/analyse.rs
+++ b/frontends/rust/rust_function_analyser/src/analyse.rs
@@ -552,6 +552,20 @@ impl FunctionAnalyser {
                 self.extract_from_expr(&await_expr.base, called_functions, callsites, file, arg_map);
             }
 
+            // Async block
+            Expr::Async(async_expr) => {
+                for stmt in &async_expr.block.stmts {
+                    self.extract_called_functions(stmt, called_functions, callsites, file, arg_map);
+                }
+            }
+
+            // Try block
+            Expr::TryBlock(try_block_expr) => {
+                for stmt in &try_block_expr.block.stmts {
+                    self.extract_called_functions(stmt, called_functions, callsites, file, arg_map);
+                }
+            }
+
             // Try statment
             Expr::Try(try_expr) => {
                 self.extract_from_expr(&try_expr.expr, called_functions, callsites, file, arg_map);
@@ -587,6 +601,13 @@ impl FunctionAnalyser {
                     file,
                     arg_map,
                 );
+            }
+
+            // Infinite loop
+            Expr::Loop(loop_expr) => {
+                for stmt in &loop_expr.body.stmts {
+                    self.extract_called_functions(stmt, called_functions, callsites, file, arg_map);
+                }
             }
 
             // Closures inline


### PR DESCRIPTION
This PR fixes the rust frontend function/method discovery logic by adding back some missing handling of certain expression type. including conditions in certain statement and block of codes.

The problem mentioned in #1826 where certain functions/methods in unsafe block are missing has been solved. Here is the new call tree in the generated data file for parse_response_multspaces with all the functions/methods call in the unsafe block being discovered.

```
Call tree
fuzz_target /src/httparse/fuzz/fuzz_targets/parse_request_multspaces.rs linenumber=-1
  Request::new /src/httparse/fuzz/fuzz_targets/parse_request_multspaces.rs linenumber=7
  httparse::ParserConfig::default /src/httparse/fuzz/fuzz_targets/parse_request_multspaces.rs linenumber=8
  ParserConfig::allow_multiple_spaces_in_request_line_delimiters /src/httparse/fuzz/fuzz_targets/parse_request_multspaces.rs linenumber=9
  ParserConfig::parse_request /src/httparse/fuzz/fuzz_targets/parse_request_multspaces.rs linenumber=10
    Request::parse_with_config /src/httparse/src/lib.rs linenumber=403
      core::mem::replace /src/httparse/src/lib.rs linenumber=583
      Request::parse_with_config_and_uninit_headers /src/httparse/src/lib.rs linenumber=589
        b[u8]::len /src/httparse/src/lib.rs linenumber=538
        Bytes::new /src/httparse/src/lib.rs linenumber=539
          a[u8]::as_ptr /src/httparse/src/iter.rs linenumber=17
          add /src/httparse/src/iter.rs linenumber=19
          a[u8]::len /src/httparse/src/iter.rs linenumber=19
        skip_empty_lines /src/httparse/src/lib.rs linenumber=540
          Bytes::peek /src/httparse/src/lib.rs linenumber=611
            Some /src/httparse/src/iter.rs linenumber=38
          Bytes::bump /src/httparse/src/lib.rs linenumber=615
            Bytes::advance /src/httparse/src/iter.rs linenumber=72
              add /src/httparse/src/iter.rs linenumber=82
          Bytes::slice /src/httparse/src/lib.rs linenumber=625
            slice_from_ptr_range /src/httparse/src/iter.rs linenumber=99
              core::slice::from_raw_parts /src/httparse/src/iter.rs linenumber=172
            Bytes::commit /src/httparse/src/iter.rs linenumber=100
          Ok /src/httparse/src/lib.rs linenumber=626
          Status::Complete /src/httparse/src/lib.rs linenumber=626
          Ok /src/httparse/src/lib.rs linenumber=628
        parse_method /src/httparse/src/lib.rs linenumber=541
          Bytes::peek_n /src/httparse/src/lib.rs linenumber=850
            Bytes::as_ref /src/httparse/src/iter.rs linenumber=62
            get /src/httparse/src/iter.rs linenumber=62
            try_into /src/httparse/src/iter.rs linenumber=62
            ok /src/httparse/src/iter.rs linenumber=62
          Bytes::slice_skip /src/httparse/src/lib.rs linenumber=855
            sub /src/httparse/src/iter.rs linenumber=112
            sub /src/httparse/src/iter.rs linenumber=113
          str::from_utf8_unchecked /src/httparse/src/lib.rs linenumber=856
          Ok /src/httparse/src/lib.rs linenumber=858
          Status::Complete /src/httparse/src/lib.rs linenumber=858
          str::from_utf8_unchecked /src/httparse/src/lib.rs linenumber=865
          Ok /src/httparse/src/lib.rs linenumber=867
          Status::Complete /src/httparse/src/lib.rs linenumber=867
          parse_token /src/httparse/src/lib.rs linenumber=869
            is_method_token /src/httparse/src/lib.rs linenumber=937
            Err /src/httparse/src/lib.rs linenumber=939
            Ok /src/httparse/src/lib.rs linenumber=945
              Status::Complete /src/httparse/src/lib.rs linenumber=945
            str::from_utf8_unchecked /src/httparse/src/lib.rs linenumber=947
            Err /src/httparse/src/lib.rs linenumber=950
        Some /src/httparse/src/lib.rs linenumber=542
        Some /src/httparse/src/lib.rs linenumber=546
        parse_uri /src/httparse/src/lib.rs linenumber=546
          Bytes::pos /src/httparse/src/lib.rs linenumber=960
          match_uri_vectored /src/httparse/src/lib.rs linenumber=961
            Bytes::len /src/httparse/src/simd/sse42.rs linenumber=5
            match_url_char_16_sse /src/httparse/src/simd/sse42.rs linenumber=6
              [u8]::len /src/httparse/src/simd/sse42.rs linenumber=19
              [u8]::as_ptr /src/httparse/src/simd/sse42.rs linenumber=26
              _mm_set1_epi8 /src/httparse/src/simd/sse42.rs linenumber=28
              _mm_setr_epi8 /src/httparse/src/simd/sse42.rs linenumber=44
              _mm_setr_epi8 /src/httparse/src/simd/sse42.rs linenumber=48
              _mm_lddqu_si128 /src/httparse/src/simd/sse42.rs linenumber=53
              _mm_shuffle_epi8 /src/httparse/src/simd/sse42.rs linenumber=54
              _mm_and_si128 /src/httparse/src/simd/sse42.rs linenumber=55
              _mm_srli_epi16 /src/httparse/src/simd/sse42.rs linenumber=55
              _mm_and_si128 /src/httparse/src/simd/sse42.rs linenumber=56
              _mm_shuffle_epi8 /src/httparse/src/simd/sse42.rs linenumber=56
              _mm_cmpeq_epi8 /src/httparse/src/simd/sse42.rs linenumber=58
              _mm_setzero_si128 /src/httparse/src/simd/sse42.rs linenumber=58
          Err /src/httparse/src/lib.rs linenumber=967
          Ok /src/httparse/src/lib.rs linenumber=970
          Status::Complete /src/httparse/src/lib.rs linenumber=970
          str::from_utf8_unchecked /src/httparse/src/lib.rs linenumber=972
          Err /src/httparse/src/lib.rs linenumber=975
        Some /src/httparse/src/lib.rs linenumber=550
        parse_version /src/httparse/src/lib.rs linenumber=550
          u64::from_ne_bytes /src/httparse/src/lib.rs linenumber=812
          u64::from_ne_bytes /src/httparse/src/lib.rs linenumber=813
          u64::from_ne_bytes /src/httparse/src/lib.rs linenumber=818
          Ok /src/httparse/src/lib.rs linenumber=821
          Status::Complete /src/httparse/src/lib.rs linenumber=821
          Ok /src/httparse/src/lib.rs linenumber=823
          Status::Complete /src/httparse/src/lib.rs linenumber=823
          Err /src/httparse/src/lib.rs linenumber=825
          Ok /src/httparse/src/lib.rs linenumber=840
        parse_headers_iter_uninit /src/httparse/src/lib.rs linenumber=554
          Err /src/httparse/src/lib.rs linenumber=1091
          iter_mut /src/httparse/src/lib.rs linenumber=1093
          Ok /src/httparse/src/lib.rs linenumber=1157
          Status::Complete /src/httparse/src/lib.rs linenumber=1157
          Ok /src/httparse/src/lib.rs linenumber=1162
          Status::Complete /src/httparse/src/lib.rs linenumber=1162
          is_header_name_token /src/httparse/src/lib.rs linenumber=1165
          match_header_name_vectored /src/httparse/src/lib.rs linenumber=1188
            match_header_name_char_16_neon /src/httparse/src/simd/neon.rs linenumber=9
              vld1q_u8 /src/httparse/src/simd/neon.rs linenumber=88
              Bytes::as_ptr /src/httparse/src/simd/neon.rs linenumber=88
              vld1q_u8 /src/httparse/src/simd/neon.rs linenumber=94
              vld1q_u8 /src/httparse/src/simd/neon.rs linenumber=97
              vandq_u8 /src/httparse/src/simd/neon.rs linenumber=100
              vdupq_n_u8 /src/httparse/src/simd/neon.rs linenumber=100
              vqtbl1q_u8 /src/httparse/src/simd/neon.rs linenumber=107
              vqtbl1q_u8 /src/httparse/src/simd/neon.rs linenumber=111
              vshrq_n_u8 /src/httparse/src/simd/neon.rs linenumber=111
              vandq_u8 /src/httparse/src/simd/neon.rs linenumber=118
              vceqq_u8 /src/httparse/src/simd/neon.rs linenumber=119
          str::from_utf8_unchecked /src/httparse/src/lib.rs linenumber=1195
          is_header_value_token /src/httparse/src/lib.rs linenumber=1226
          match_header_value_vectored /src/httparse/src/lib.rs linenumber=1248
            match_header_value_char_16_sse /src/httparse/src/simd/sse42.rs linenumber=67
              [u8]::len /src/httparse/src/simd/sse42.rs linenumber=80
              [u8]::as_ptr /src/httparse/src/simd/sse42.rs linenumber=87
              _mm_set1_epi8 /src/httparse/src/simd/sse42.rs linenumber=90
              _mm_set1_epi8 /src/httparse/src/simd/sse42.rs linenumber=91
              _mm_set1_epi8 /src/httparse/src/simd/sse42.rs linenumber=92
              _mm_lddqu_si128 /src/httparse/src/simd/sse42.rs linenumber=94
              _mm_cmpeq_epi8 /src/httparse/src/simd/sse42.rs linenumber=96
              _mm_max_epu8 /src/httparse/src/simd/sse42.rs linenumber=96
              _mm_cmpeq_epi8 /src/httparse/src/simd/sse42.rs linenumber=97
              _mm_cmpeq_epi8 /src/httparse/src/simd/sse42.rs linenumber=98
              _mm_andnot_si128 /src/httparse/src/simd/sse42.rs linenumber=99
              _mm_or_si128 /src/httparse/src/simd/sse42.rs linenumber=99
          Bytes::next /src/httparse/src/lib.rs linenumber=1270
            Some /src/httparse/src/iter.rs linenumber=185
          MaybeUninit::new /src/httparse/src/lib.rs linenumber=1288
        assume_init_slice /src/httparse/src/lib.rs linenumber=565
        Ok /src/httparse/src/lib.rs linenumber=567
        Status::Complete /src/httparse/src/lib.rs linenumber=567
      Ok /src/httparse/src/lib.rs linenumber=590
      Status::Complete /src/httparse/src/lib.rs linenumber=590
```