### PR TITLE
[Rust] Fix wrong rust flag for introspector

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -59,12 +59,14 @@ index d9077510f..5baa138a6 100755
  if [ -z "${SANITIZER_FLAGS-}" ]; then
    FLAGS_VAR="SANITIZER_FLAGS_${SANITIZER}"
    export SANITIZER_FLAGS=${!FLAGS_VAR-}
-@@ -111,7 +119,7 @@ fi
+@@ -111,7 +119,9 @@ fi
  # use RUSTFLAGS.
  # FIXME: Support code coverage once support is in.
  # See https://github.com/rust-lang/rust/issues/34701.
 -if [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "none" ] && [ "$ARCHITECTURE" != 'i386' ]; then
-+if [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "none" ] && [ "$RUST_SANITIZER" != "introspector" ] && [ "$ARCHITECTURE" != 'i386' ]; then
++if [ "$RUST_SANITIZER" == "introspector" ]; then
++  export RUSTFLAGS="-Cdebuginfo=2 -Cforce-frame-pointers"
++elif [ "$SANITIZER" != "undefined" ] && [ "$SANITIZER" != "coverage" ] && [ "$SANITIZER" != "none" ] && [ "$ARCHITECTURE" != 'i386' ]; then
    export RUSTFLAGS="--cfg fuzzing -Zsanitizer=${SANITIZER} -Cdebuginfo=1 -Cforce-frame-pointers"
  else
    export RUSTFLAGS="--cfg fuzzing -Cdebuginfo=1 -Cforce-frame-pointers"


### PR DESCRIPTION
This PR fixes a wrong rustflag used for rust frontend build making all the debug span information missing. After the update the calltree generated in FI report contains correct linkage of functions and line number.