### PR TITLE
[Rust] Fix calltree for rust

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -330,6 +330,14 @@ def get_node_coverage_hitcount(demangled_name: str, callstack: Dict[int, str],
                              hit_count_cov)
                 if n_line_number == node.src_linenumber and hit_count_cov > 0:
                     node_hitcount = hit_count_cov
+        elif profile.target_lang == "rust":
+            coverage_data = profile.coverage.get_hit_details(
+                callstack_get_parent(node, callstack))
+            for (n_line_number, hit_count_cov) in coverage_data:
+                logger.debug("  - iterating %d : %d", n_line_number,
+                             hit_count_cov)
+                if n_line_number == node.src_linenumber and hit_count_cov > 0:
+                    node_hitcount = hit_count_cov
         node.cov_parent = callstack_get_parent(node, callstack)
     else:
         logger.error(
@@ -1008,6 +1016,8 @@ def extract_all_sources(language):
         test_extensions = ['.java', '.scala', '.sc', '.groovy', '.kt', '.kts']
     elif language == 'python':
         test_extensions = ['.py']
+    elif language == 'rust':
+        test_extensions = ['.rs']
     else:
         test_extensions = ['.cc', '.cpp', '.cxx', '.c++', '.c', '.h', '.hpp']
 


### PR DESCRIPTION
This PR fixes the missing branches for rust to process hitcount. After the fix, the calltree for runtime coverage is correctly interpreted. Sample for one of the harness for httparse project is shown below.

![Screenshot 2024-11-25 at 7 12 13 PM](https://github.com/user-attachments/assets/336ea043-c275-4a62-8e37-d145e9a94d0c)
