### PR TITLE
[webapp] Match java result to jvm for OFG

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -2667,6 +2667,9 @@ def database_language_stats():
         language_counts[project_info.language][
             'total'] += project_info.coverage_data['line_coverage']['count']
 
+    # Match java result to OSS-Fuzz jvm setting
+    language_counts['jvm'] = language_counts['java']
+
     return {'result': 'success', 'stats': language_counts}
 
 


### PR DESCRIPTION
OSS-Fuzz and OSS-Fuzz-Gen use "JVM" instead of "Java" for all types of JVM projects. This PR updates the database-language-stats API to duplicate the "Java" result with the "JVM" tag, ensuring consistency with the language settings used by OSS-Fuzz and OSS-Fuzz-Gen.
The result in "Java" tag is kept for supporting future use.