### PR TITLE
webapp: Fix bug for wrong java path and empty coverage report

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -210,7 +210,7 @@ def extract_lines_from_source_code(
         return None
 
     # Transform java class name to java source file path with package directories
-    if project.language == 'java':
+    if project.language == 'java' and not target_file.endswith('.java'):
         target_file = f'/{target_file.split("$", 1)[0].replace(".", "/")}.java'
 
     # Light source code
@@ -2660,6 +2660,8 @@ def database_language_stats():
     }
     for project_info in latest_coverage_profiles.values():
         if project_info.language == 'N/A':
+            continue
+        if not project_info.coverage_data:
             continue
         language_counts[
             project_info.language]['covered'] += project_info.coverage_data[


### PR DESCRIPTION
This PR fixes two bugs.
1) For the source path, it could be class name or java source file path. The transformation only needed when it is a java class name. This PR fixes it to only do the replacement when it is not a file path ends with .java.

2) When project_info retrieve an empty coverage_data (for failed coverage build), the direct map retrieval will result in error. This PR fixes that by adding an empty check before the use of the map data.