### PR TITLE
webapp: Fix wrong empty raw_source checking

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -149,6 +149,7 @@ def extract_introspector_raw_source_code(project_name, date_str,
         src_location = os.path.join(local_oss_fuzz, 'build', 'out',
                                     project_name, 'inspector', 'source-code',
                                     target_file)
+
         if not os.path.isfile(src_location):
             return ''
         with open(src_location, 'r') as f:

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -149,7 +149,6 @@ def extract_introspector_raw_source_code(project_name, date_str,
         src_location = os.path.join(local_oss_fuzz, 'build', 'out',
                                     project_name, 'inspector', 'source-code',
                                     target_file)
-
         if not os.path.isfile(src_location):
             return ''
         with open(src_location, 'r') as f:
@@ -229,9 +228,9 @@ def extract_lines_from_source_code(
         raw_source = light_raw_source
 
     # Return None if source is not found.
-    if raw_source is None:
+    if not raw_source:
         print("Did not found source")
-        return raw_source
+        return None
 
     return_source = ""
     source_lines = raw_source.split("\n")


### PR DESCRIPTION
A bug has been identified in the `extract_lines_from_source_code` function. The `raw_source` is retrieved using either the `extract_introspector_raw_source_code` or `_light_extract_introspector_raw_source_code` function. A check is performed after the source code extraction to ensure that subsequent processing occurs only if the source code has been successfully extracted.

However, the check only verifies for a `NoneType` value and does not account for an empty string. This oversight constitutes a bug because, unlike `_light_extract_introspector_raw_source_code`, the `extract_introspector_raw_source_code` function returns an empty string rather than `None` when it fails to extract the source code.

As a result, an empty source code returned by `extract_introspector_raw_source_code` is mistakenly processed, producing a false positive success result that includes only a single `'\n'` character. This behaviour adversely affects APIs that depend on this function.

This PR resolves the issue by correcting the check to handle both `NoneType` and empty string values appropriately.