### PR TITLE
core: frontend: force pkg inclusion

### DIFF
--- a/src/fuzz_introspector/frontends/src/frontend_c.py
+++ b/src/fuzz_introspector/frontends/src/frontend_c.py
@@ -436,6 +436,8 @@ class SourceCodeFile():
                 # Go through each of the field declarations
                 fields = []
                 for child in struct.child_by_field_name('body').children:
+                    if not child.child_by_field_name('declarator'):
+                        continue
                     if child.type == 'field_declaration':
                         fields.append({
                             'type':

--- a/src/fuzz_introspector/frontends/src/oss_fuzz.py
+++ b/src/fuzz_introspector/frontends/src/oss_fuzz.py
@@ -17,9 +17,9 @@
 import argparse
 import logging
 
-import frontend_c
-import frontend_cpp
-import frontend_go
+from fuzz_introspector.frontends.src import frontend_c
+from fuzz_introspector.frontends.src import frontend_cpp
+from fuzz_introspector.frontends.src import frontend_go
 
 logger = logging.getLogger(name=__name__)
 LOG_FMT = '%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s'


### PR DESCRIPTION
Force  the use of the fuzz introspector library as a package. This should be done forcing `python3 -m pip install .` in the fuzz introspector `src` dir.