### PR TITLE
FI: Remove unnecessary package

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
 "tree-sitter",
 "tree-sitter-python",
 "networkx",
-"pygraphviz",
 "tree-sitter-languages",
 "tree-sitter-c",
 "tree-sitter-cpp",


### PR DESCRIPTION
This PR removes unnecessary package which requires libgraphviz-dev.