### PR TITLE
[Go] Fix link for coverage report

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -169,3 +169,35 @@ index d0f45bb73..388563180 100755
    else
      # C/C++
  
+diff --git a/infra/base-images/base-runner/coverage b/infra/base-images/base-runner/coverage
+index 585b4d457..014bdbce6 100755
+--- a/infra/base-images/base-runner/coverage
++++ b/infra/base-images/base-runner/coverage
+@@ -382,6 +382,26 @@ if [[ $FUZZING_LANGUAGE == "go" ]]; then
+   echo $DUMPS_DIR
+   $SYSGOPATH/bin/gocovmerge $DUMPS_DIR/*.profdata > fuzz.cov
+   gotoolcover -html=fuzz.cov -o $REPORT_ROOT_DIR/index.html
++
++  # Patch the html with additional javascript to allow direct url
++  # selection of target source file.
++  SCRIPT='<script>
++    function handleHashChange() {
++        const hash = location.hash.substr(1);
++        const files = document.getElementById("files");
++        if (files && hash) {
++            files.value = hash;
++            files.dispatchEvent(new Event("change"));
++        }
++    }
++    window.addEventListener("hashchange", handleHashChange);
++    window.addEventListener("DOMContentLoaded", handleHashChange);
++    </script>
++    </html>'
++  sed -i "/<\/html>/d" $REPORT_ROOT_DIR/index.html
++  echo $SCRIPT >> $REPORT_ROOT_DIR/index.html
++  echo "</html>" >> $REPORT_ROOT_DIR/index.html
++
+   $SYSGOPATH/bin/gocovsum fuzz.cov > $SUMMARY_FILE
+   cp $REPORT_ROOT_DIR/index.html $REPORT_PLATFORM_DIR/index.html
+   $SYSGOPATH/bin/pprof-merge $DUMPS_DIR/*.perf.cpu.prof
+

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -366,7 +366,8 @@ def resolve_coverage_link(cov_url: str, source_file: str, lineno: int,
 
         # Read the single coverage report html for processing
         report_html = ''
-        report_path = os.path.join(os.environ.get('OUT', ''), 'report', 'linux', 'index.html')
+        report_path = os.path.join(os.environ.get('OUT', ''), 'report',
+                                   'linux', 'index.html')
         if os.path.isfile(report_path):
             with open(report_path, 'r') as f:
                 report_html = f.read()

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -22,6 +22,8 @@ import re
 import shutil
 import yaml
 
+from bs4 import BeautifulSoup
+
 from typing import (
     Any,
     List,
@@ -361,6 +363,24 @@ def resolve_coverage_link(cov_url: str, source_file: str, lineno: int,
     elif (target_lang == "go"):
         # Go coverage report only have a single page with no line index
         result = "index.html"
+
+        # Read the single coverage report html for processing
+        report_html = ''
+        report_path = os.path.join(os.environ.get('OUT', ''), 'report', 'linux', 'index.html')
+        if os.path.isfile(report_path):
+            with open(report_path, 'r') as f:
+                report_html = f.read()
+
+        # Obtain the correct file value for the needed source code file
+        if report_html:
+            soup = BeautifulSoup(report_html, 'html.parser')
+            select_element = soup.find('select', id='files')
+            for option in select_element.find_all('option'):
+                key = option['value']
+                file = option.text.strip().split(' ')[0]
+                if file.endswith(source_file):
+                    result = f'{result}#{key}'
+                    break
     else:
         logger.info("Unsupported language for coverage link resolve")
 


### PR DESCRIPTION
For go coverage report, it only contains a single page and use an existing javascript to change and display the chosen source file coverage. 
This PR fixes the coverage report by adding additional java script logic to accept file tag from the url and automatically change to show the correct source file.
This PR also change the logic for FI to determine the correct file tag for a specific function call site in the call tree to allow displaying the correct source code coverage from the coverage report.