### PR TITLE
frontend: Fix bug on missing fuzzer name/path

### DIFF
--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -131,7 +131,8 @@ class FuzzerProfile:
 
         elif self._target_lang == "jvm":
             # Class name is used for jvm identifier for old frontend
-            return os.path.basename(self.fuzzer_source_file).replace(".java", "")
+            return os.path.basename(self.fuzzer_source_file).replace(
+                ".java", "")
 
         elif self._target_lang == "rust":
             return os.path.basename(self.fuzzer_source_file).replace(".rs", "")

--- a/src/fuzz_introspector/datatypes/fuzzer_profile.py
+++ b/src/fuzz_introspector/datatypes/fuzzer_profile.py
@@ -130,8 +130,8 @@ class FuzzerProfile:
             return os.path.basename(self.fuzzer_source_file).replace(".py", "")
 
         elif self._target_lang == "jvm":
-            # Class name is used for jvm identifier
-            return os.path.basename(self.fuzzer_source_file)
+            # Class name is used for jvm identifier for old frontend
+            return os.path.basename(self.fuzzer_source_file).replace(".java", "")
 
         elif self._target_lang == "rust":
             return os.path.basename(self.fuzzer_source_file).replace(".rs", "")

--- a/src/fuzz_introspector/frontends/frontend_go.py
+++ b/src/fuzz_introspector/frontends/frontend_go.py
@@ -177,11 +177,15 @@ class Project():
             for item in src.functions + src.methods
         ]
 
-    def dump_module_logic(self, report_name: str, entry_function: str = ''):
+    def dump_module_logic(self,
+                          report_name: str,
+                          entry_function: str = '',
+                          harness_source: str = ''):
         """Dumps the data for the module in full."""
         logger.info('Dumping project-wide logic.')
         report: dict[str, Any] = {'report': 'name'}
         report['sources'] = []
+        report['Fuzzer filename'] = harness_source
 
         # Log entry function if provided
         if entry_function:

--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -900,11 +900,13 @@ class Project():
 
     def dump_module_logic(self,
                           report_name: str,
-                          harness_name: Optional[str] = None):
+                          harness_name: Optional[str] = None,
+                          harness_source: str = ''):
         """Dumps the data for the module in full."""
         logger.info('Dumping project-wide logic.')
         report: dict[str, Any] = {'report': 'name'}
         report['sources'] = []
+        report['Fuzzer filename'] = harness_source
 
         all_classes = {}
         project_methods: list[JavaMethod] = []

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -546,11 +546,13 @@ class Project():
 
     def dump_module_logic(self,
                           report_name: str,
-                          harness_name: Optional[str] = None):
+                          harness_name: Optional[str] = None,
+                          harness_source: str = ''):
         """Dumps the data for the module in full."""
         logger.info('Dumping project-wide logic.')
         report: dict[str, Any] = {'report': 'name'}
         report['sources'] = []
+        report['Fuzzer filename'] = harness_source
 
         self.all_functions = {}
         for source_code in self.source_code_files:

--- a/src/fuzz_introspector/frontends/oss_fuzz.py
+++ b/src/fuzz_introspector/frontends/oss_fuzz.py
@@ -148,9 +148,8 @@ def process_go_project(target_dir, out):
         harness_name = harness.source_file.split('/')[-1].split('.')[0]
         logger.info(f'Dump functions/methods for {harness_name}')
         target = os.path.join(out, f'fuzzerLogFile-{harness_name}.data.yaml')
-        project.dump_module_logic(
-            target, harness.get_entry_function_name(), harness.source_file
-        )
+        project.dump_module_logic(target, harness.get_entry_function_name(),
+                                  harness.source_file)
 
         logger.info(f'Extracting calltree for {harness_name}')
         calltree = project.extract_calltree(harness.source_file, harness)

--- a/src/fuzz_introspector/frontends/oss_fuzz.py
+++ b/src/fuzz_introspector/frontends/oss_fuzz.py
@@ -148,7 +148,9 @@ def process_go_project(target_dir, out):
         harness_name = harness.source_file.split('/')[-1].split('.')[0]
         logger.info(f'Dump functions/methods for {harness_name}')
         target = os.path.join(out, f'fuzzerLogFile-{harness_name}.data.yaml')
-        project.dump_module_logic(target, harness.get_entry_function_name())
+        project.dump_module_logic(
+            target, harness.get_entry_function_name(), harness.source_file
+        )
 
         logger.info(f'Extracting calltree for {harness_name}')
         calltree = project.extract_calltree(harness.source_file, harness)
@@ -180,7 +182,7 @@ def process_jvm_project(target_dir, entrypoint, out):
         # Method data
         logger.info(f'Dump methods for {harness_name}')
         target = os.path.join(out, f'fuzzerLogFile-{harness_name}.data.yaml')
-        project.dump_module_logic(target, harness_name)
+        project.dump_module_logic(target, harness_name, harness.source_file)
 
         # Calltree
         logger.info(f'Extracting calltree for {harness_name}')
@@ -213,7 +215,7 @@ def process_rust_project(target_dir, out):
         # Method data
         logger.info(f'Dump methods for {harness_name}')
         target = os.path.join(out, f'fuzzerLogFile-{harness_name}.data.yaml')
-        project.dump_module_logic(target, harness_name)
+        project.dump_module_logic(target, harness_name, harness.source_file)
 
         # Calltree
         logger.info(f'Extracting calltree for {harness_name}')


### PR DESCRIPTION
This PR fixes a bug for missing fuzzer name/path in the tree-sitter frontend for go/rust/jvm.