### PR TITLE
frontend-jvm: Fix bug on missing entrypoint in oss-fuzz patch

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -52,7 +52,7 @@ index 1c10d9e23..6a97bc287 100755
      # Output will be put in /out/
 -    python3 /fuzz-introspector/frontends/java/oss-fuzz-main.py
 +    # Using new approach
-+    python3 -m fuzz_introspector.frontends.oss_fuzz --language jvm --target-dir $SRC
++    python3 -m fuzz_introspector.frontends.oss_fuzz --language jvm --target-dir $SRC --entrypoint fuzzerTestOneInput
 +    # python3 /fuzz-introspector/frontends/java/oss-fuzz-main.py
      # Move files temporarily to fit workflow of other languages.
      mkdir -p $SRC/my-fi-data


### PR DESCRIPTION
This PR fixes a bug in the oss-fuzz patch for jvm-tree-sitter frontend that the entrypoint is missing from the command.