### PR TITLE
[Frontend-jvm] Add parameters invocation test

### DIFF
--- a/src/test/data/source-code/jvm/test-project-8/variable/B.java
+++ b/src/test/data/source-code/jvm/test-project-8/variable/B.java
@@ -1,0 +1,25 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package variable;
+
+import variable.test.*;
+
+public class B {
+    public static void callInstanceMethod(A obj) {
+        obj.instanceMethod();
+    }
+}

--- a/src/test/data/source-code/jvm/test-project-8/variable/Fuzzer.java
+++ b/src/test/data/source-code/jvm/test-project-8/variable/Fuzzer.java
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package variable;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import variable.test.A;
+
+public class Fuzzer {
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        B.callInstanceMethod(new A());
+    }
+}

--- a/src/test/data/source-code/jvm/test-project-8/variable/test/A.java
+++ b/src/test/data/source-code/jvm/test-project-8/variable/test/A.java
@@ -1,0 +1,23 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package variable.test;
+
+public class A {
+    public void instanceMethod() {
+        System.out.println("Instance method in Class A called");
+    }
+}

--- a/src/test/test_frontends_jvm.py
+++ b/src/test/test_frontends_jvm.py
@@ -191,3 +191,23 @@ def test_tree_sitter_jvm_sample7():
         '[combined.NestedClass.InnerClass]'
         '.unreachableInnerClassMethod()') not in functions_reached
     assert '[combined.AbstractBase].unreachableAbstractBaseMethod()' not in functions_reached
+
+
+def test_tree_sitter_jvm_sample8():
+    project = oss_fuzz.analyse_folder(
+        'jvm',
+        'src/test/data/source-code/jvm/test-project-8',
+        'fuzzerTestOneInput',
+        dump_output=False,
+    )
+
+    # Project check
+    harness = project.get_source_codes_with_harnesses()
+    assert len(harness) == 1
+
+    functions_reached = project.get_reachable_methods(harness[0].source_file, harness[0])
+
+    # Callsite check
+    assert '[variable.B].callInstanceMethod(variable.test.A)' in functions_reached
+    assert '[variable.test.A].instanceMethod()' in functions_reached
+    assert 'System.out.println(String)' in functions_reached


### PR DESCRIPTION
This PR adds another test for invocation from parameter instance, aiming to test the ability to determine variable object type from parameters and general import statements.