### PR TITLE
[Frontend-Rust] Add test for unreached functions and match path splitting

### DIFF
--- a/src/test/data/source-code/rust/test-project-4/fuzzer.rs
+++ b/src/test/data/source-code/rust/test-project-4/fuzzer.rs
@@ -1,0 +1,33 @@
+// Copyright 2025 Fuzz Introspector Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+#[macro_use]
+extern crate libfuzzer_sys;
+
+fn unused_function() {
+    let _ = unsafe { 42 };
+}
+
+fn reachable_function(data: &[u8]) -> Option<usize> {
+    match data {
+        [] => None,
+        [_, ..] => Some(data.len()),
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = reachable_function(data);
+});

--- a/src/test/test_frontends_rust.py
+++ b/src/test/test_frontends_rust.py
@@ -58,3 +58,23 @@ def test_tree_sitter_rust_sample2():
     # Callsite check
     assert 'double_add' in functions_reached
     assert 'add' in functions_reached
+
+
+def test_tree_sitter_rust_sample4():
+    project = oss_fuzz.analyse_folder(
+        'rust',
+        'src/test/data/source-code/rust/test-project-4',
+        dump_output=False,
+    )
+
+    # Project check
+    harness = project.get_source_codes_with_harnesses()
+    assert len(harness) == 1
+
+    functions_reached = project.get_reachable_functions(harness[0].source_file, harness[0])
+
+    # Callsite check
+    assert 'Some' in functions_reached
+    assert '&[u8]::len' in functions_reached
+    assert 'reachable_function' in functions_reached
+    assert 'unused_function' not in functions_reached


### PR DESCRIPTION
This PR adds a new test project for frontend rust on unreachable functions and path splitting from match statements.