### PR TITLE
[Frontend-JVM] Add unit test for multiple entry points

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -303,7 +303,8 @@ class JavaMethod():
         # Refine name
         class_name = self.parent_source.get_full_qualified_name(
             self.class_interface.name)
-        self.name = f'[{class_name}].{self.name}({",".join(self.arg_types)})'
+        if '[' not in self.name and '].' not in self.name:
+            self.name = f'[{class_name}].{self.name}({",".join(self.arg_types)})'
 
         # Refine variable map
         for key in self.var_map:

--- a/src/test/data/source-code/jvm/test-project-9/multiple/FuzzerOne.java
+++ b/src/test/data/source-code/jvm/test-project-9/multiple/FuzzerOne.java
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package multiple;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class FuzzerOne {
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        SimpleClass sc = new SimpleClass(data.consumeRemainingAsString());
+        sc.simpleMethodOne();
+    }
+}

--- a/src/test/data/source-code/jvm/test-project-9/multiple/FuzzerTwo.java
+++ b/src/test/data/source-code/jvm/test-project-9/multiple/FuzzerTwo.java
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package multiple;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class FuzzerTwo {
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        SimpleClass sc = new SimpleClass();
+        sc.simpleMethodTwo();
+    }
+}

--- a/src/test/data/source-code/jvm/test-project-9/multiple/SimpleClass.java
+++ b/src/test/data/source-code/jvm/test-project-9/multiple/SimpleClass.java
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package multiple
+
+public class SimpleClass {
+    public SimpleClass() {
+        System.out.println("Default Constructor Called");
+    }
+
+    public SimpleClass(String param) {
+        System.out.println("Constructor with parameter called: " + param.toUpperCase());
+    }
+
+    public void simpleMethodOne() {
+        System.out.println("Simple Method One Called");
+    }
+
+    public void simpleMethodTwo() {
+        System.out.println("Simple Method Two Called");
+    }
+
+    public void unreachableMethod() {
+        System.out.println("Unreachable Method in SimpleClass");
+    }
+}

--- a/src/test/test_frontends_jvm.py
+++ b/src/test/test_frontends_jvm.py
@@ -211,3 +211,39 @@ def test_tree_sitter_jvm_sample8():
     assert '[variable.B].callInstanceMethod(variable.test.A)' in functions_reached
     assert '[variable.test.A].instanceMethod()' in functions_reached
     assert 'System.out.println(String)' in functions_reached
+
+
+def test_tree_sitter_jvm_sample9():
+    project = oss_fuzz.analyse_folder(
+        'jvm',
+        'src/test/data/source-code/jvm/test-project-9',
+        'fuzzerTestOneInput',
+        dump_output=False,
+    )
+
+    # Project check
+    harness = project.get_source_codes_with_harnesses()
+    assert len(harness) == 2
+
+    result_one = project.get_reachable_methods(harness[0].source_file, harness[0])
+    result_two = project.get_reachable_methods(harness[1].source_file, harness[1])
+
+    # Callsite check
+    if 'FuzzerOne' in harness[0].source_file:
+        functions_reached_one = result_one
+        functions_reached_two = result_two
+    else:
+        functions_reached_one = result_two
+        functions_reached_two = result_one
+
+    assert '[multiple.SimpleClass].<init>(String)' in functions_reached_one
+    assert '[multiple.SimpleClass].simpleMethodOne()' in functions_reached_one
+    assert '[multiple.SimpleClass].<init>()' not in functions_reached_one
+    assert '[multiple.SimpleClass].simpleMethodTwo()' not in functions_reached_one
+    assert '[multiple.SimpleClass].unreachableMethod()' not in functions_reached_one
+
+    assert '[multiple.SimpleClass].<init>()' in functions_reached_two
+    assert '[multiple.SimpleClass].simpleMethodTwo()' in functions_reached_two
+    assert '[multiple.SimpleClass].<init>(String)' not in functions_reached_two
+    assert '[multiple.SimpleClass].simpleMethodOne()' not in functions_reached_two
+    assert '[multiple.SimpleClass].unreachableMethod()' not in functions_reached_two


### PR DESCRIPTION
This PR add a new unit testing for jvm frontend with multiple fuzzing entry points. This PR also fixes a bug on class name duplication on some methods.