### PR TITLE
[Frontend-go] Add unit test for object type detect and fix logic

### DIFF
--- a/src/test/data/source-code/go/test-project-3/fuzzer.go
+++ b/src/test/data/source-code/go/test-project-3/fuzzer.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package structs
+
+import (
+	"testing"
+	"fmt"
+	"strconv"
+)
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+func (p Person) Greet() string {
+	return fmt.Sprintf("Hello, my name is %s and I am %d years old.", p.Name, p.Age)
+}
+
+func (p Person) Introduce() string {
+	return fmt.Sprintf("I am %s, a person of age %d.", p.Name, p.Age)
+}
+
+func (p Person) Describe() string {
+	return fmt.Sprintf("Person: %s, Age: %d", p.Name, p.Age)
+}
+
+type Dog struct {
+	Name string
+}
+
+func (d Dog) Greet() string {
+	return fmt.Sprintf("Hello, my dog's name is %s.", d.Name)
+}
+
+func (d Dog) Introduce() string {
+	return fmt.Sprintf("This is my dog, %s.", d.Name)
+}
+
+func (d Dog) Describe() string {
+	return fmt.Sprintf("Dog: %s", d.Name)
+}
+
+func NewDog(name string) Dog {
+	return Dog{Name: name}
+}
+
+type Robot struct {
+	Model string
+}
+
+func (r Robot) Greet() string {
+	return fmt.Sprintf("Hello, I am a robot of model %s.", r.Model)
+}
+
+func (r Robot) Introduce() string {
+	return fmt.Sprintf("I am %s, a highly advanced robot.", r.Model)
+}
+
+func (r Robot) Describe() string {
+	return fmt.Sprintf("Robot Model: %s", r.Model)
+}
+
+func FuzzStructs(f *testing.F) {
+	f.Fuzz(func(t *testing.T, name string, ageString string, model string) {
+		age, err := strconv.Atoi(ageString)
+		if err != nil {
+			return
+		}
+
+		p := Person{Name: name, Age: age}
+		d := NewDog(name)
+		r := new(Robot)
+		r.Model = model
+
+		_ = p.Greet()
+		_ = d.Introduce()
+		_ = r.Describe()
+	})
+}

--- a/src/test/test_frontends_go.py
+++ b/src/test/test_frontends_go.py
@@ -64,7 +64,22 @@ def test_tree_sitter_go_sample3():
 
     # Project check
     harness = project.get_source_codes_with_harnesses()
-    assert len(harness) == 0
+    assert len(harness) == 1
+
+    functions_reached = project.get_reachable_functions(harness[0].source_file, harness[0])
+
+    # Callsite check
+    assert 'strconv.Atoi' in functions_reached
+    assert 'NewDog' in functions_reached
+    assert 'Person.Greet' in functions_reached
+    assert 'Dog.Introduce' in functions_reached
+    assert 'Robot.Describe' in functions_reached
+    assert 'Person.Introduce' not in functions_reached
+    assert 'Person.Describe' not in functions_reached
+    assert 'Dog.Greet' not in functions_reached
+    assert 'Dog.Describe' not in functions_reached
+    assert 'Robot.Greet' not in functions_reached
+    assert 'Robot.Introduce' not in functions_reached
 
 
 def test_tree_sitter_go_sample4():


### PR DESCRIPTION
This PR fixes the logic to allow detection of type for short variable declaration. This is necessary to allow tracing the correct function callsites. A unit testing contains 3 methods with the same name declared in different structs helps to test the correctness of type detection.

Additional detection of other object declaration approach will be added in later PR.