### PR TITLE
[Frontend-jvm] Fix bug in incomplete entrypoint confusion

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -1170,6 +1170,9 @@ class JvmProject(Project[JvmSourceCodeFile]):
         if not visited_functions:
             visited_functions = set()
 
+        if function and '].' not in function:
+            function = None
+
         if not source_code and function:
             source_code = self.find_source_with_method(function)
 


### PR DESCRIPTION
This PR fixes a bug in the generalisation of the Project class. The default fuzzer entry point is used and create confusion on calltree extraction because it does not contains the necessary class information. This PR fixes that by forcing it to retrieve the needed JavaMethod instance for entry methods.