### PR TITLE
[JVM] Fix jvm function source file

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -1045,7 +1045,8 @@ class JvmProject(Project[JvmSourceCodeFile]):
             method_dict: dict[str, Any] = {}
 
             if method.parent_source:
-                method_dict['functionSourceFile'] = method.parent_source.source_file
+                method_dict[
+                    'functionSourceFile'] = method.parent_source.source_file
             else:
                 method_dict['functionSourceFile'] = method.class_interface.name
 

--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -1043,8 +1043,13 @@ class JvmProject(Project[JvmSourceCodeFile]):
         method_list = []
         for method in project_methods:
             method_dict: dict[str, Any] = {}
+
+            if method.parent_source:
+                method_dict['functionSourceFile'] = method.parent_source.source_file
+            else:
+                method_dict['functionSourceFile'] = method.class_interface.name
+
             method_dict['functionName'] = method.name
-            method_dict['functionSourceFile'] = method.class_interface.name
             method_dict['functionLinenumber'] = method.start_line
             method_dict['functionLinenumberEnd'] = method.end_line
             method_dict['linkageType'] = ''

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -354,7 +354,7 @@ def resolve_coverage_link(cov_url: str, source_file: str, lineno: int,
         source_file = match.group(1) if match else source_file
 
         # Handle source class for jvm
-        if '.' in source_file):
+        if '.' in source_file:
             # Source file has package, change package.class to package/class
             source_file = os.sep.join(source_file.rsplit(".", 1))
         else:

--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -347,10 +347,14 @@ def resolve_coverage_link(cov_url: str, source_file: str, lineno: int,
                 result = found_target + ".html" + "#t" + str(lineno)
         else:
             logger.info("Could not find any html_status.json file")
-    elif (target_lang == "jvm"):
+    elif (target_lang == 'jvm'):
         """Resolves link to HTML coverage report for JVM targets"""
+        # Retrieve class name for jvm function
+        match = re.search(r'\[(.*?)\]\.', function_name)
+        source_file = match.group(1) if match else source_file
+
         # Handle source class for jvm
-        if ("." in source_file):
+        if '.' in source_file):
             # Source file has package, change package.class to package/class
             source_file = os.sep.join(source_file.rsplit(".", 1))
         else:

--- a/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
+++ b/tools/web-fuzzing-introspection/app/webapp/helper/function_helper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 import sys
 from typing import Dict, List, Set, Any
 
@@ -65,8 +66,10 @@ def get_public_class_list(target_list: List[models.Function]) -> Set[str]:
     class_set = set()
     for function in target_list:
         if function.is_accessible and not function.is_jvm_library:
-            if '/' not in function.function_filename:
-                class_set.add(function.function_filename.split('$')[0])
+            # Extract class name from function
+            match = re.search(f'\[(.*?)\]\.', function.name)
+            if match:
+                class_set.add(match.group(1))
 
     return class_set
 


### PR DESCRIPTION
This PR fixes the function_source_file properties in FunctionProfile class for JVM project. The original frontend for JVM use the function source file to store the class name of the function. this is because we does not have ways to locate the original source file name and path from class files as each class file only contains a single class.  Multiple classes defined in the same source file are compiled as separate class files. Thus the original logic for JVM have specific handling for function source file properties since it contains different information comparing to other language. The new tree-sitter frontend for JVM can now correctly obtained the source file name and path for a function, thus this PR fixes the logic to make JVM use the properties to correctly store the source file name of functions, while retriving the class name from the enclosed function name. 