### PR TITLE
Analyser: Fix unexpected exit from coverage extraction

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -295,8 +295,7 @@ def get_node_coverage_hitcount(demangled_name: str, callstack: Dict[int, str],
         # The difference is this node has node "parent" or prior nodes.
 
         if not profile.func_is_entrypoint(demangled_name):
-            logger.warning(
-                "First node in calltree is non-fuzzer function")
+            logger.warning("First node in calltree is non-fuzzer function")
             return 0
         if profile.coverage.get_type() == 'kernel':
             # For now, assume EP is hit. TODO(David) adjust this.

--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -295,8 +295,9 @@ def get_node_coverage_hitcount(demangled_name: str, callstack: Dict[int, str],
         # The difference is this node has node "parent" or prior nodes.
 
         if not profile.func_is_entrypoint(demangled_name):
-            raise AnalysisError(
+            logger.warning(
                 "First node in calltree is non-fuzzer function")
+            return 0
         if profile.coverage.get_type() == 'kernel':
             # For now, assume EP is hit. TODO(David) adjust this.
             return 100

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -196,8 +196,13 @@ def analyse(args) -> int:
                             entrypoint=entrypoint,
                             out=out_dir)
 
+    if 'c' in args.language:
+        language = 'c-cpp'
+    else:
+        language = args.language
+
     # Perform the FI backend project analysis from the frontend
-    introspection_proj = analysis.IntrospectionProject(args.language, out_dir,
+    introspection_proj = analysis.IntrospectionProject(language, out_dir,
                                                        '')
     introspection_proj.load_data_files(True, '', out_dir)
 

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -202,8 +202,7 @@ def analyse(args) -> int:
         language = args.language
 
     # Perform the FI backend project analysis from the frontend
-    introspection_proj = analysis.IntrospectionProject(language, out_dir,
-                                                       '')
+    introspection_proj = analysis.IntrospectionProject(language, out_dir, '')
     introspection_proj.load_data_files(True, '', out_dir)
 
     # Perform the chosen standalone analysis


### PR DESCRIPTION
This PR fixes a bug in the SourceCodeLineAnalyser which does not handles the case of exceptions thrown from missing fuzzing entrypoints.