### PR TITLE
Fix bug in wrong detailed callsites

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_cpp.py
@@ -584,7 +584,7 @@ class FunctionDefinition():
 
         if not self.detailed_callsites:
             for dst, src_line in self.base_callsites:
-                src_loc = self.parent_source.source_file + f':{src_line},1'
+                src_loc = f'{self.parent_source.source_file}:{src_line},1'
                 self.detailed_callsites.append({'Src': src_loc, 'Dst': dst})
 
 

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -579,7 +579,7 @@ class RustFunction():
 
         if not self.detailed_callsites:
             for dst, src_line in self.base_callsites:
-                src_loc = f'self.parent_source.source_file :{src_line},1'
+                src_loc = f'{self.parent_source.source_file}:{src_line},1'
                 self.detailed_callsites.append({'Src': src_loc, 'Dst': dst})
 
 


### PR DESCRIPTION
This PR unifies the src_line string formatting and fix a bug in wrong interpretation of detailed callsites source for frontend rust.