### PR TITLE
Analyser: Add handling of far-reach-low-coverage-with-fuzz-keyword

### DIFF
--- a/src/fuzz_introspector/cli.py
+++ b/src/fuzz_introspector/cli.py
@@ -198,6 +198,11 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         help=('Excluding functions without header declaration in the '
               'analysing result.'))
     far_reach_low_coverage_analyser_parser.add_argument(
+        '--only-interesting-functions',
+        action='store_true',
+        help=('Excluding functions without interesting fuzz keywords, like'
+              'parse or deserialise'))
+    far_reach_low_coverage_analyser_parser.add_argument(
         '--max-functions',
         default=30,
         type=int,

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -219,13 +219,15 @@ def analyse(args) -> int:
         exclude_static_functions = args.exclude_static_functions
         only_referenced_functions = args.only_referenced_functions
         only_header_functions = args.only_header_functions
+        only_interesting_functions = args.only_interesting_functions
         max_functions = args.max_functions
 
         introspection_proj.load_debug_report(out_dir)
 
         target_analyser.set_flags(exclude_static_functions,
                                   only_referenced_functions,
-                                  only_header_functions)
+                                  only_header_functions,
+                                  only_interesting_functions)
         target_analyser.set_max_functions(max_functions)
         target_analyser.set_introspection_project(introspection_proj)
 


### PR DESCRIPTION
This PR adds the handling of the interesting function checking from far-reach-low-cov-fuzz-keyword into the FarReachLowCoverage analyser because they have similar logic.