### PR TITLE
oss-fuzz: fix patches

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -1,16 +1,7 @@
 diff --git a/infra/base-images/base-builder/Dockerfile b/infra/base-images/base-builder/Dockerfile
-index 64d11095b..ec8ad457c 100644
+index 64d11095b..34bee0c13 100644
 --- a/infra/base-images/base-builder/Dockerfile
 +++ b/infra/base-images/base-builder/Dockerfile
-@@ -82,7 +82,7 @@ ENV SANITIZER_FLAGS_memory "-fsanitize=memory -fsanitize-memory-track-origins"
- 
- ENV SANITIZER_FLAGS_thread "-fsanitize=thread"
- 
--ENV SANITIZER_FLAGS_introspector "-O0 -flto -fno-inline-functions -fuse-ld=gold -Wno-unused-command-line-argument"
-+ENV SANITIZER_FLAGS_introspector "-O0 -fno-inline-functions -Wno-unused-command-line-argument"
- 
- # Do not use any sanitizers in the coverage build.
- ENV SANITIZER_FLAGS_coverage ""
 @@ -193,6 +193,16 @@ COPY llvmsymbol.diff $SRC
  COPY detect_repo.py /opt/cifuzz/
  COPY bazel.bazelrc /root/.bazelrc
@@ -29,22 +20,9 @@ index 64d11095b..ec8ad457c 100644
  # /ccache/bin will contain the compiler wrappers, and /ccache/cache will
  # contain the actual cache, which can be saved.
 diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
-index 1c10d9e23..5e10ccc14 100755
+index 1c10d9e23..f48a3e2d8 100755
 --- a/infra/base-images/base-builder/compile
 +++ b/infra/base-images/base-builder/compile
-@@ -209,9 +209,9 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
- 
-   export CFLAGS="$CFLAGS -g"
-   export CXXFLAGS="$CXXFLAGS -g"
--  export FI_BRANCH_PROFILE=1
--  export FUZZ_INTROSPECTOR=1
--  export FUZZ_INTROSPECTOR_AUTO_FUZZ=1
-+  export FI_BRANCH_PROFILE=0
-+  export FUZZ_INTROSPECTOR=0
-+  export FUZZ_INTROSPECTOR_AUTO_FUZZ=0
- 
-   # Move ar and ranlib
-   mv /usr/bin/ar /usr/bin/old-ar
 @@ -223,13 +223,13 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
    ln -sf /usr/local/bin/llvm-ranlib /usr/bin/ranlib
  
@@ -63,27 +41,56 @@ index 1c10d9e23..5e10ccc14 100755
    popd
  
    if [ "$FUZZING_LANGUAGE" = "python" ]; then
-@@ -238,11 +238,14 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+@@ -238,10 +238,38 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
      python3 /fuzz-introspector/src/main.py light --language=jvm
    elif [ "$FUZZING_LANGUAGE" = "rust" ]; then
      python3 /fuzz-introspector/src/main.py light --language=rust
 +  elif [ "$FUZZING_LANGUAGE" = "go" ]; then
 +    python3 /fuzz-introspector/src/main.py light --language=go
    else
--    python3 /fuzz-introspector/src/main.py light
-+  #  python3 /fuzz-introspector/src/main.py light
-+    echo "hello"
+     python3 /fuzz-introspector/src/main.py light
    fi
  
--  rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
-+  #rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
++  # Make a copy of the light. This is needed because we run two versions of
++  # introspector: one based on pure statis analysis and one based on
++  # regular LTO.
++  cp -rf $SRC/inspector/ /tmp/inspector-saved
++
++
++  # Move coverage report.
++  if [ -d "$OUT/textcov_reports" ]
++  then
++    find $OUT/textcov_reports/ -name "*.covreport" -exec cp {} $SRC/inspector/ \;
++    find $OUT/textcov_reports/ -name "*.json" -exec cp {} $SRC/inspector/ \;
++  fi
++
++  # Make fuzz-introspector HTML report using light approach.
++  REPORT_ARGS="--name=$PROJECT_NAME"
++
++  # Only pass coverage_url when COVERAGE_URL is set (in cloud builds)
++  if [[ ! -z "${COVERAGE_URL+x}" ]]; then
++    REPORT_ARGS="$REPORT_ARGS --coverage-url=${COVERAGE_URL}"
++  fi
++
++  # Run pure static analysis fuzz introspector
++  fuzz-introspector full --target-dir=$SRC \
++      --language=${FUZZING_LANGUAGE} \
++      --out-dir=$SRC/inspector \
++      ${REPORT_ARGS}
+   rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
  fi
  
- echo "---------------------------------------------------------------"
-@@ -313,38 +316,52 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+@@ -313,31 +341,52 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
    unset CFLAGS
    export G_ANALYTICS_TAG="G-8WTFM1Y62J"
  
++
++  # If we get to here, it means the e.g. LTO had no problems and succeeded.
++  # TO this end, we wlil restore the original light analysis and used the
++  # LTO processing itself.
++  rm -rf $SRC/inspector
++  cp -rf /tmp/inspector-saved $SRC/inspector
++
 +  cd /fuzz-introspector/src
 +  python3 -m pip install -e .
 +  cd /src/
@@ -132,22 +139,7 @@ index 1c10d9e23..5e10ccc14 100755
    fi
  
    mkdir -p $SRC/inspector
--  find $SRC/ -name "fuzzerLogFile-*.data" -exec cp {} $SRC/inspector/ \;
--  find $SRC/ -name "fuzzerLogFile-*.data.yaml" -exec cp {} $SRC/inspector/ \;
--  find $SRC/ -name "fuzzerLogFile-*.data.debug_*" -exec cp {} $SRC/inspector/ \;
--  find $SRC/ -name "allFunctionsWithMain-*.yaml" -exec cp {} $SRC/inspector/ \;
-+  #find $SRC/ -name "fuzzerLogFile-*.data" -exec cp {} $SRC/inspector/ \;
-+  #find $SRC/ -name "fuzzerLogFile-*.data.yaml" -exec cp {} $SRC/inspector/ \;
-+  #find $SRC/ -name "fuzzerLogFile-*.data.debug_*" -exec cp {} $SRC/inspector/ \;
-+  #find $SRC/ -name "allFunctionsWithMain-*.yaml" -exec cp {} $SRC/inspector/ \;
- 
-   # Move coverage report.
-   if [ -d "$OUT/textcov_reports" ]
-@@ -356,17 +373,18 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
-   cd $SRC/inspector
- 
-   # Make fuzz-introspector HTML report.
-+  export PROJECT_NAME="123"
+@@ -359,43 +408,46 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
    REPORT_ARGS="--name=$PROJECT_NAME"
    # Only pass coverage_url when COVERAGE_URL is set (in cloud builds)
    if [[ ! -z "${COVERAGE_URL+x}" ]]; then
@@ -162,43 +154,46 @@ index 1c10d9e23..5e10ccc14 100755
 -    REPORT_ARGS="$REPORT_ARGS --target_dir=$SRC/inspector"
 +    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
      REPORT_ARGS="$REPORT_ARGS --language=python"
-     python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
+-    python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
++    fuzz-introspector report $REPORT_ARGS
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
-@@ -374,28 +392,31 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+   elif [ "$FUZZING_LANGUAGE" = "jvm" ]; then
      echo "GOING jvm route"
      set -x
      find $OUT/ -name "jacoco.xml" -exec cp {} $SRC/inspector/ \;
 -    REPORT_ARGS="$REPORT_ARGS --target_dir=$SRC/inspector"
 +    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
      REPORT_ARGS="$REPORT_ARGS --language=jvm"
-     python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
+-    python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
++    fuzz-introspector report $REPORT_ARGS
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
    elif [ "$FUZZING_LANGUAGE" = "rust" ]; then
      echo "GOING rust route"
 -    REPORT_ARGS="$REPORT_ARGS --target_dir=$SRC/inspector"
 +    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
      REPORT_ARGS="$REPORT_ARGS --language=rust"
-     python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
+-    python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
++    fuzz-introspector report $REPORT_ARGS
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
    else
      # C/C++
 +    mkdir -p $SRC/inspector
-+    fuzz-introspector full --target-dir=$SRC --language=${FUZZING_LANGUAGE} --out-dir=$SRC/inspector ${REPORT_ARGS}
++    #fuzz-introspector full --target-dir=$SRC --language=${FUZZING_LANGUAGE} --out-dir=$SRC/inspector ${REPORT_ARGS}
 +    #fuzz-introspector full --target_dir $SRC --language=${FUZZING_LANGUAGE}
  
      # Correlate fuzzer binaries to fuzz-introspector's raw data
 -    python3 /fuzz-introspector/src/main.py correlate --binaries_dir=$OUT/
-+    #python3 /fuzz-introspector/src/main.py correlate --binaries_dir=$OUT/
++    fuzz-introspector correlate --binaries-dir=$OUT/
  
      # Generate fuzz-introspector HTML report, this generates
      # the file exe_to_fuzz_introspector_logs.yaml
 -    REPORT_ARGS="$REPORT_ARGS --target_dir=$SRC/inspector"
-+    #REPORT_ARGS="$REPORT_ARGS --target_dir=$SRC/inspector"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
      # Use the just-generated correlation file
 -    REPORT_ARGS="$REPORT_ARGS --correlation_file=exe_to_fuzz_introspector_logs.yaml"
 -    python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
-+    #REPORT_ARGS="$REPORT_ARGS --correlation_file=exe_to_fuzz_introspector_logs.yaml"
-+    #python3 /fuzz-introspector/src/main.py report $REPORT_ARGS
++    REPORT_ARGS="$REPORT_ARGS --correlation-file=exe_to_fuzz_introspector_logs.yaml"
++    fuzz-introspector report $REPORT_ARGS
  
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
    fi
@@ -247,3 +242,35 @@ index 585b4d457..014bdbce6 100755
    $SYSGOPATH/bin/gocovsum fuzz.cov > $SUMMARY_FILE
    cp $REPORT_ROOT_DIR/index.html $REPORT_PLATFORM_DIR/index.html
    $SYSGOPATH/bin/pprof-merge $DUMPS_DIR/*.perf.cpu.prof
+diff --git a/projects/cjson/build.sh b/projects/cjson/build.sh
+index 7d6cea020..fd92b97c5 100644
+--- a/projects/cjson/build.sh
++++ b/projects/cjson/build.sh
+@@ -14,5 +14,10 @@
+ # limitations under the License.
+ #
+ ################################################################################
++
++if [[ "$SANITIZER" == introspector ]]; then
++        exit 1
++fi
++
+ # Run the OSS-Fuzz script in the project
+-$SRC/cjson/fuzzing/ossfuzz.sh
+\ No newline at end of file
++$SRC/cjson/fuzzing/ossfuzz.sh
+diff --git a/projects/htslib/build.sh b/projects/htslib/build.sh
+index a0bbdfd69..8580e7895 100755
+--- a/projects/htslib/build.sh
++++ b/projects/htslib/build.sh
+@@ -14,7 +14,9 @@
+ # limitations under the License.
+ #
+ ################################################################################
+-
++if [[ "$SANITIZER" == introspector ]]; then
++	exit 1
++fi
+ # build project
+ autoconf
+ autoheader


### PR DESCRIPTION
We can now run both light and regular introspector. Light will only be used if main introspector fails.