### PR TITLE
frontend: Fix bug on wrong additional argument

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -1277,8 +1277,7 @@ def load_treesitter_trees(source_files: list[str],
     return JvmProject(results)
 
 
-def analyse_source_code(source_content: str,
-                        entrypoint: str) -> JvmSourceCodeFile:
+def analyse_source_code(source_content: str) -> JvmSourceCodeFile:
     """Returns a source abstraction based on a single source string."""
     source_code = JvmSourceCodeFile('jvm',
                                     source_file='in-memory string',

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -866,10 +866,8 @@ def load_treesitter_trees(source_files: list[str],
     return RustProject(results)
 
 
-def analyse_source_code(source_content: str,
-                        entrypoint: str) -> RustSourceCodeFile:
+def analyse_source_code(source_content: str) -> RustSourceCodeFile:
     """Returns a source abstraction based on a single source string."""
-    # pylint: disable=unused-argument
     source_code = RustSourceCodeFile('rust',
                                      source_file='in-memory string',
                                      source_content=source_content.encode())


### PR DESCRIPTION
This PR fixes a bug in frontend_jvm and frontend_rust where an additional unused argument is required for the analyse_source_file function which has been removed from other frontend.