### PR TITLE
frontend: Fix typo bug in node type checking

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -742,7 +742,7 @@ class JavaMethod():
             type, invoke_callsites = self._process_callsites(right, classes)
             self.var_map[var_name] = type
             callsites.extend(invoke_callsites)
-        elif stmt.type.endswith('local_variable_declarattion'):
+        elif stmt.type.endswith('local_variable_declaration'):
             for vars in stmt.children:
                 if vars.type == 'variable_declarator':
                     var_name = vars.child_by_field_name('name').text.decode()


### PR DESCRIPTION
This PR fixes a bug in frontend_jvm where a node type checking contains a typo and cause the checking skipped unexpectedly.