### PR TITLE
mypy: Fix mypy CI

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Install Dependencies
       run: |
         pip install mypy types-PyYAML
+    - name: Install FI as modules
+      run: |
+        cd src && pip install .
     - name: mypy
       run: |
         cd src && mypy --ignore-missing-imports -m main

--- a/src/fuzz_introspector/frontends/frontend_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_cpp.py
@@ -152,7 +152,10 @@ class FunctionDefinition():
 
     def function_source_code_as_text(self) -> str:
         """Returns the source code the function."""
-        return self.root.text.decode()
+        if self.root and self.root.text:
+            return self.root.text.decode()
+
+        return ''
 
     def _extract_pointer_array_from_type(
             self, param_name: Node) -> tuple[int, int, Node]:
@@ -364,9 +367,9 @@ class FunctionDefinition():
     def _process_invoke(self, expr: Node,
                         project) -> list[tuple[str, int, int]]:
         """Internal helper for processing the function invocation statement."""
-        # logger.debug('Handling invoke statmenet: %s', expr.text.decode())
         # logger.debug('Current namespace: %s', self.namespace_or_class)
-        logger.debug('Processing invoke: %s', expr.text.decode())
+        logger.debug('Processing invoke: %s',
+                     expr.text.decode() if expr.text else '')
         callsites = []
         target_name: str = ''
 
@@ -480,7 +483,8 @@ class FunctionDefinition():
     def _process_callsites(self, stmt: Node,
                            project) -> list[tuple[str, int, int]]:
         """Process and store the callsites of the function."""
-        logger.debug('Processing callsite: %s', stmt.text.decode())
+        logger.debug('Processing callsite: %s',
+                     stmt.text.decode() if stmt.text else '')
         callsites = []
 
         # Call statement
@@ -536,7 +540,7 @@ class FunctionDefinition():
             except AttributeError:
                 var_name = None
 
-            if not var_name:
+            if not var_name or not var_name.text:
                 logger.debug('Could not extract necessary attributes')
                 return []
 


### PR DESCRIPTION
After changing FI to module based operation, the mypy CI fails to check on the module because the module is not installed. This PR fixes the mypy CI to install the FI modules before the checking to ensure the mypy CI picks up typing errors in the FI modules, including the tree-sitter frontend. This PR also fixes the mypy errors in frontend_cpp to pass the mypy check.