### PR TITLE
frontend: Make get_cross_references globally for all language frontend

### DIFF
--- a/src/fuzz_introspector/frontends/datatypes.py
+++ b/src/fuzz_introspector/frontends/datatypes.py
@@ -132,3 +132,17 @@ class Project(Generic[T]):
                 harnesses.append(source_code)
 
         return harnesses
+
+    def get_cross_references(self, src_func: Any) -> list[Any]:
+        """Gets list of functions that reference src_func"""
+        # TODO specify type after generalisation of FunctionDefinition
+        xrefs = []
+        for func in self.all_functions:
+            if func.sig == src_func:
+                continue
+
+            for callsite in func.base_callsites:
+                if callsite[0] == src_func.name:
+                    xrefs.append(func)
+
+        return xrefs

--- a/src/fuzz_introspector/frontends/frontend_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_cpp.py
@@ -704,17 +704,6 @@ class CppProject(datatypes.Project[CppSourceCodeFile]):
 
         return None
 
-    def get_cross_references(self, src_func) -> list[FunctionDefinition]:
-        """Gets list of functions that reference src_func"""
-        xrefs = []
-        for func in self.all_functions:
-            if func.sig == src_func:
-                continue
-            for callsite in func.base_callsites:
-                if callsite[0] == src_func.name:
-                    xrefs.append(func)
-        return xrefs
-
     def extract_calltree(self,
                          source_file: str = '',
                          source_code: Optional[CppSourceCodeFile] = None,


### PR DESCRIPTION
Cross reference retrieval logic originally from frontend_cpp is required by all languages in OFG from scratch approach. This PR makes that function globally available for all language frontends.