### PR TITLE
Frontend: Fix bug on exclude directories

### DIFF
--- a/src/fuzz_introspector/frontends/oss_fuzz.py
+++ b/src/fuzz_introspector/frontends/oss_fuzz.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(name=__name__)
 
 EXCLUDE_DIRECTORIES = [
     'node_modules', 'aflplusplus', 'honggfuzz', 'inspector', 'libfuzzer',
-    'fuzztest', 'target', 'build'
+    'fuzztest', 'build'
 ]
 
 


### PR DESCRIPTION
When generalising the excluded directories into oss-fuzz, there is a missed consideration that fuzzing harnesses of Rust projects are normally located within the fuzz_target directory which are accidentally excluded by the generalised setting. This PR fixes that.