### PR TITLE
Fix oss-fuzz patch

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -20,7 +20,7 @@ index 64d11095b..34bee0c13 100644
  # /ccache/bin will contain the compiler wrappers, and /ccache/cache will
  # contain the actual cache, which can be saved.
 diff --git a/infra/base-images/base-builder/compile b/infra/base-images/base-builder/compile
-index e05d0e6ea..eccd5c3b3 100755
+index e05d0e6ea..2554b9d3f 100755
 --- a/infra/base-images/base-builder/compile
 +++ b/infra/base-images/base-builder/compile
 @@ -235,6 +235,8 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
@@ -32,6 +32,52 @@ index e05d0e6ea..eccd5c3b3 100755
    elif [ "$FUZZING_LANGUAGE" = "jvm" ]; then
      python3 /fuzz-introspector/src/main.py light --language=jvm
      cp -rf $SRC/inspector/ /tmp/inspector-saved
+@@ -353,28 +355,7 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+   python3 -m pip install -e .
+   cd /src/
+
+-  if [ "$FUZZING_LANGUAGE" = "jvm" ]; then
+-    echo "GOING jvm route"
+-
+-    set -x
+-    # Output will be put in /out/
+-    python3 -m fuzz_introspector.frontends.oss_fuzz --language jvm --target-dir $SRC --entrypoint fuzzerTestOneInput
+-
+-    # Move files temporarily to fit workflow of other languages.
+-    mkdir -p $SRC/my-fi-data
+-    find ./ -name *.data -exec mv {} $SRC/my-fi-data/ \;
+-    find ./ -name *.data.yaml -exec mv {} $SRC/my-fi-data/ \;
+-  elif [ "$FUZZING_LANGUAGE" = "rust" ]; then
+-    echo "GOING rust route"
+-
+-    # Run the rust frontend
+-    python3 -m fuzz_introspector.frontends.oss_fuzz --language rust --target-dir $SRC
+-
+-    # Move files temporarily to fix workflow of other languages.
+-    mkdir -p $SRC/my-fi-data
+-    find ./ -name "*.data" -exec mv {} $SRC/my-fi-data/ \;
+-    find ./ -name "*.data.yaml" -exec mv {} $SRC/my-fi-data/ \;
+-
++  if [ "$FUZZING_LANGUAGE" = "rust" ]; then
+     # Restore the sanitizer flag for rust
+     export SANITIZER="introspector"
+   fi
+@@ -415,13 +396,13 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+     find $OUT/ -name "jacoco.xml" -exec cp {} $SRC/inspector/ \;
+     REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
+     REPORT_ARGS="$REPORT_ARGS --language=jvm"
+-    fuzz-introspector report $REPORT_ARGS
++    fuzz-introspector full $REPORT_ARGS
+     rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
+   elif [ "$FUZZING_LANGUAGE" = "rust" ]; then
+     echo "GOING rust route"
+     REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
+     REPORT_ARGS="$REPORT_ARGS --language=rust"
+-    fuzz-introspector report $REPORT_ARGS
++    fuzz-introspector full $REPORT_ARGS
+     rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
+   else
+     # C/C++
 diff --git a/infra/base-images/base-clang/Dockerfile b/infra/base-images/base-clang/Dockerfile
 index 296b1f7fb..9c6b1ff55 100644
 --- a/infra/base-images/base-clang/Dockerfile

--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -67,7 +67,7 @@ index e05d0e6ea..2554b9d3f 100755
      set -x
      find $OUT/ -name "jacoco.xml" -exec cp {} $SRC/inspector/ \;
 -    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
-+    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC --out-dir=$SRC/inspector"
      REPORT_ARGS="$REPORT_ARGS --language=jvm"
 -    fuzz-introspector report $REPORT_ARGS
 +    fuzz-introspector full $REPORT_ARGS
@@ -75,14 +75,14 @@ index e05d0e6ea..2554b9d3f 100755
    elif [ "$FUZZING_LANGUAGE" = "rust" ]; then
      echo "GOING rust route"
 -    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
-+    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC --out-dir=$SRC/inspector"
      REPORT_ARGS="$REPORT_ARGS --language=rust"
 -    fuzz-introspector report $REPORT_ARGS
 +    fuzz-introspector full $REPORT_ARGS
 +    rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
 +  elif [ "$FUZZING_LANGUAGE" = "go" ]; then
 +    echo "GOING go route"
-+    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC --out-dir=$SRC/inspector"
 +    REPORT_ARGS="$REPORT_ARGS --language=go"
 +    fuzz-introspector full $REPORT_ARGS
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"

--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -62,18 +62,28 @@ index e05d0e6ea..2554b9d3f 100755
      # Restore the sanitizer flag for rust
      export SANITIZER="introspector"
    fi
-@@ -415,13 +396,13 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+@@ -413,15 +394,21 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+     echo "GOING jvm route"
+     set -x
      find $OUT/ -name "jacoco.xml" -exec cp {} $SRC/inspector/ \;
-     REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
+-    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC"
      REPORT_ARGS="$REPORT_ARGS --language=jvm"
 -    fuzz-introspector report $REPORT_ARGS
 +    fuzz-introspector full $REPORT_ARGS
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
    elif [ "$FUZZING_LANGUAGE" = "rust" ]; then
      echo "GOING rust route"
-     REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
+-    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC/inspector"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC"
      REPORT_ARGS="$REPORT_ARGS --language=rust"
 -    fuzz-introspector report $REPORT_ARGS
++    fuzz-introspector full $REPORT_ARGS
++    rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
++  elif [ "$FUZZING_LANGUAGE" = "go" ]; then
++    echo "GOING go route"
++    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC"
++    REPORT_ARGS="$REPORT_ARGS --language=go"
 +    fuzz-introspector full $REPORT_ARGS
      rsync -avu --delete "$SRC/inspector/" "$OUT/inspector"
    else


### PR DESCRIPTION
In the latest FI operation, the main function in frontend/oss-fuzz has been removed and it required the CLI to activate the frontend. But the oss-fuzz patch does not reflect that correctly thus the patched compile script failed to execute the frontend for JVM/Rust correctly. This PR fixes the patch to allow a full run (instead of sole report running) for Rust and JVM projects.