### PR TITLE
frontend: Add missing helper function for go and rust

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_go.py
+++ b/src/fuzz_introspector/frontends/frontend_go.py
@@ -392,6 +392,13 @@ class FunctionMethod():
         # Process icount
         self._process_icount()
 
+    def function_source_code_as_text(self) -> str:
+        """Returns the source code the function."""
+        if self.root and self.root.text:
+            return self.root.text.decode()
+
+        return ''
+
     def get_function_uses(self,
                           all_funcs_meths: list['FunctionMethod']) -> int:
         """Calculate how many function called this function."""

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -273,6 +273,13 @@ class RustFunction():
         # Process instr count
         self._process_icount()
 
+    def function_source_code_as_text(self) -> str:
+        """Returns the source code the function."""
+        if self.root and self.root.text:
+            return self.root.text.decode()
+
+        return ''
+
     def _process_declaration(self):
         """Internal helper to process the function/method declaration."""
         # Process name


### PR DESCRIPTION
Add missing helper function function_source_code_as_text to frontend_go and frontend_rust.