### PR TITLE
JVM: Fix bug when no source file is copied

### DIFF
--- a/src/fuzz_introspector/utils.py
+++ b/src/fuzz_introspector/utils.py
@@ -479,6 +479,10 @@ def _copy_java_source_files(required_class_list: list[str], out_dir):
                 copied_source_path_list.append(required_file)
                 break
 
+    if not count:
+        logger.info('No java source files copied.')
+        return
+
     # Store a list of existing source file paths for reference
     with open(
             os.path.join(out_dir, constants.SAVED_SOURCE_FOLDER, 'index.json'),


### PR DESCRIPTION
This PR fixes a bugs for jvm source code copying. When the full execution is done without the need of source file copying, the source copying logic will copied 0 files and the dumping of index.json will be failed since the path is unaccessible. This PR fixes that by only activating the dumping of index.json if file coping are done.