### PR TITLE
frontend: Allow returning frontend yaml directly

### DIFF
--- a/src/fuzz_introspector/frontends/datatypes.py
+++ b/src/fuzz_introspector/frontends/datatypes.py
@@ -107,7 +107,7 @@ class Project(Generic[T]):
                           dump_output: bool = True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
         # Dummy function for subclasses
-        pass
+        return {}
 
     def extract_calltree(self,
                          source_file: str = '',

--- a/src/fuzz_introspector/frontends/datatypes.py
+++ b/src/fuzz_introspector/frontends/datatypes.py
@@ -94,12 +94,17 @@ class Project(Generic[T]):
         self.source_code_files = source_code_files
         self.all_functions: list[Any] = []
 
+    def get_report(self, harness_source: str = '') -> dict[str, Any]:
+        """Runs analysis if needed and gets a report yaml"""
+        return self.dump_module_logic(harness_source=harness_source,
+                                      dump_output=False)
+
     def dump_module_logic(self,
-                          report_name: str,
+                          report_name: str = '',
                           entry_function: str = '',
                           harness_name: str = '',
                           harness_source: str = '',
-                          dump_output: bool = True):
+                          dump_output: bool = True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
         # Dummy function for subclasses
         pass
@@ -148,7 +153,3 @@ class Project(Generic[T]):
                     xrefs.append(func)
 
         return xrefs
-
-    def get_report(self, harness_source: str = ''):
-        """Runs analysis if needed and gets a report wrt a given harness"""
-        return {}

--- a/src/fuzz_introspector/frontends/frontend_c.py
+++ b/src/fuzz_introspector/frontends/frontend_c.py
@@ -33,11 +33,11 @@ class CProject(Project['CSourceCodeFile']):
         super().__init__(source_code_files)
 
     def dump_module_logic(self,
-                          report_name,
+                          report_name: str = '',
                           entry_function: str = '',
                           harness_name: str = '',
                           harness_source: str = '',
-                          dump_output: bool = True):
+                          dump_output: bool = True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
         logger.info('Dumping project-wide logic.')
         report: dict[str, Any] = {'report': 'name'}
@@ -116,6 +116,8 @@ class CProject(Project['CSourceCodeFile']):
         if dump_output:
             with open(report_name, 'w', encoding='utf-8') as f:
                 f.write(yaml.dump(report))
+
+        return report
 
     def get_source_code_with_target(self, target_func_name):
         for source_code in self.source_code_files:

--- a/src/fuzz_introspector/frontends/frontend_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_cpp.py
@@ -685,7 +685,7 @@ class CppProject(datatypes.Project[CppSourceCodeFile]):
             self.report['All functions'] = {}
             self.report['All functions']['Elements'] = func_list
 
-    def get_report(self, harness_source: str) -> dict[str, Any]:
+    def get_report(self, harness_source: str = '') -> dict[str, Any]:
         """Runs analysis if needed and gets a report wrt a given harness"""
         if not self.report:
             self.generate_report()

--- a/src/fuzz_introspector/frontends/frontend_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_cpp.py
@@ -685,7 +685,7 @@ class CppProject(datatypes.Project[CppSourceCodeFile]):
             self.report['All functions'] = {}
             self.report['All functions']['Elements'] = func_list
 
-    def get_report(self, harness_source):
+    def get_report(self, harness_source: str) -> dict[str, Any]:
         """Runs analysis if needed and gets a report wrt a given harness"""
         if not self.report:
             self.generate_report()
@@ -695,11 +695,11 @@ class CppProject(datatypes.Project[CppSourceCodeFile]):
         return new_report
 
     def dump_module_logic(self,
-                          report_name: str,
+                          report_name: str = '',
                           entry_function: str = '',
                           harness_name: str = '',
                           harness_source: str = '',
-                          dump_output=True):
+                          dump_output=True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
 
         if not self.report:
@@ -715,6 +715,8 @@ class CppProject(datatypes.Project[CppSourceCodeFile]):
         if dump_output:
             with open(report_name, 'w', encoding='utf-8') as f:
                 f.write(yaml.dump(new_report))
+
+        return new_report
 
     def get_function_from_name(self, function_name):
         for func in self.all_functions:

--- a/src/fuzz_introspector/frontends/frontend_go.py
+++ b/src/fuzz_introspector/frontends/frontend_go.py
@@ -173,11 +173,11 @@ class GoProject(Project[GoSourceCodeFile]):
         }
 
     def dump_module_logic(self,
-                          report_name: str,
+                          report_name: str = '',
                           entry_function: str = '',
                           harness_name: str = '',
                           harness_source: str = '',
-                          dump_output: bool = True):
+                          dump_output: bool = True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
         # pylint: disable=unused-argument
         logger.info('Dumping project-wide logic.')
@@ -251,6 +251,8 @@ class GoProject(Project[GoSourceCodeFile]):
         if dump_output:
             with open(report_name, 'w', encoding='utf-8') as f:
                 f.write(yaml.dump(report))
+
+        return report
 
     def extract_calltree(self,
                          source_file: str = '',

--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -1042,11 +1042,11 @@ class JvmProject(Project[JvmSourceCodeFile]):
             self.all_classes.extend(source_code.classes)
 
     def dump_module_logic(self,
-                          report_name: str,
+                          report_name: str = '',
                           entry_function: str = '',
                           harness_name: str = '',
                           harness_source: str = '',
-                          dump_output: bool = True):
+                          dump_output: bool = True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
         logger.info('Dumping project-wide logic.')
         report: dict[str, Any] = {'report': 'name'}
@@ -1160,6 +1160,8 @@ class JvmProject(Project[JvmSourceCodeFile]):
 
         # Store method list to all_functions for the project
         self.all_functions = project_methods[:]
+
+        return report
 
     def find_source_with_method(self,
                                 name: str) -> Optional[JvmSourceCodeFile]:

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -597,11 +597,11 @@ class RustProject(datatypes.Project[RustSourceCodeFile]):
         self.source_code_files = source_code_files
 
     def dump_module_logic(self,
-                          report_name: str,
+                          report_name: str = '',
                           entry_function: str = '',
                           harness_name: str = '',
                           harness_source: str = '',
-                          dump_output: bool = True):
+                          dump_output: bool = True) -> dict[str, Any]:
         """Dumps the data for the module in full."""
         # pylint: disable=unused-argument
         logger.info('Dumping project-wide logic.')
@@ -683,6 +683,8 @@ class RustProject(datatypes.Project[RustSourceCodeFile]):
         if dump_output:
             with open(report_name, 'w', encoding='utf-8') as f:
                 f.write(yaml.dump(report))
+
+        return report
 
     def _find_source_with_function(self,
                                    name: str) -> Optional[RustSourceCodeFile]:


### PR DESCRIPTION
This PR fixes the frontend for other language, following the C++ approach to allow retrieving in-memory report yaml directly without the need to dump it to intermediate location if the full process is executed. It only generalises those functions to allow better reuse and refactoring later.