### PR TITLE
core: frontends: always generate report

### DIFF
--- a/src/fuzz_introspector/frontends/datatypes.py
+++ b/src/fuzz_introspector/frontends/datatypes.py
@@ -108,8 +108,7 @@ class Project(Generic[T]):
                    harness_name: str = '',
                    harness_source: str = '') -> dict[str, Any]:
         """Runs analysis if needed and gets a report yaml"""
-        if not self.report:
-            self.generate_report(entry_function, harness_name, harness_source)
+        self.generate_report(entry_function, harness_name, harness_source)
 
         new_report = copy.deepcopy(self.report)
         new_report['Fuzzer filename'] = harness_source
@@ -122,9 +121,8 @@ class Project(Generic[T]):
                           harness_name: str = '',
                           harness_source: str = '',
                           dump_output: bool = True) -> None:
-        """Dumps the data for the module in full."""
-        if not self.report:
-            self.generate_report(entry_function, harness_name, harness_source)
+        """Dumps the data    for the module in full."""
+        self.generate_report(entry_function, harness_name, harness_source)
 
         new_report = copy.deepcopy(self.report)
         new_report['Fuzzer filename'] = harness_source

--- a/src/fuzz_introspector/frontends/datatypes.py
+++ b/src/fuzz_introspector/frontends/datatypes.py
@@ -121,7 +121,7 @@ class Project(Generic[T]):
                           harness_name: str = '',
                           harness_source: str = '',
                           dump_output: bool = True) -> None:
-        """Dumps the data    for the module in full."""
+        """Dumps the data for the module in full."""
         self.generate_report(entry_function, harness_name, harness_source)
 
         new_report = copy.deepcopy(self.report)

--- a/src/fuzz_introspector/frontends/frontend_c.py
+++ b/src/fuzz_introspector/frontends/frontend_c.py
@@ -68,6 +68,9 @@ class CProject(Project['CSourceCodeFile']):
                 if harness_source:
                     if func_def.name(
                     ) == 'LLVMFuzzerTestOneInput' and source_code.source_file != harness_source:
+                        logger.debug('Skipping harness: %s -- %s -- %s',
+                                     func_def.name(), source_code.source_file,
+                                     harness_source)
                         continue
                 func_dict = {}
                 func_dict['functionName'] = func_def.name()


### PR DESCRIPTION
This is causing issues in particular in C frontend because we avoid dumping data that is related to harness files. We need this data for the post processing to work.

We should refactor things though, so we don't have so much duplicate data.