### PR TITLE
frontend: Unify function name property for golang

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_go.py
+++ b/src/fuzz_introspector/frontends/frontend_go.py
@@ -124,9 +124,7 @@ class GoSourceCodeFile(SourceCodeFile):
 
     def has_libfuzzer_harness(self) -> bool:
         """Returns whether the source code holds a libfuzzer harness"""
-        if any(
-                func.name.startswith('Fuzz')
-                for func in self.functions):
+        if any(func.name.startswith('Fuzz') for func in self.functions):
             return True
 
         if any(meth.name.startswith('Fuzz') for meth in self.methods):
@@ -137,12 +135,10 @@ class GoSourceCodeFile(SourceCodeFile):
     def has_function_definition(self, target_function_name: str) -> bool:
         """Returns if the source file holds a given function definition."""
 
-        if any(func.name == target_function_name
-               for func in self.functions):
+        if any(func.name == target_function_name for func in self.functions):
             return True
 
-        if any(meth.name == target_function_name
-               for meth in self.methods):
+        if any(meth.name == target_function_name for meth in self.methods):
             return True
 
         return False


### PR DESCRIPTION
This PR fixes the function_name property for golang in the frontend to unify with other languages.