### PR TITLE
oss-fuzz: Fix patch for golang

### DIFF
--- a/oss_fuzz_integration/oss-fuzz-patches.diff
+++ b/oss_fuzz_integration/oss-fuzz-patches.diff
@@ -63,7 +63,7 @@ index e05d0e6ea..2554b9d3f 100755
      # Restore the sanitizer flag for rust
      export SANITIZER="introspector"
    fi
-@@ -413,15 +394,22 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
+@@ -413,15 +394,23 @@ if [ "$SANITIZER" = "introspector" ] || [ "$RUST_SANITIZER" = "introspector" ];
      echo "GOING jvm route"
      set -x
      find $OUT/ -name "jacoco.xml" -exec cp {} $SRC/inspector/ \;
@@ -84,6 +84,7 @@ index e05d0e6ea..2554b9d3f 100755
 +  elif [ "$FUZZING_LANGUAGE" = "go" ]; then
 +    echo "GOING go route"
 +    find $OUT/ -name "fuzz.cov" -exec cp {} $SRC/inspector/ \;
++    find $OUT/ -name "fuzz.cov" -exec cp {} $OUT/textcov_reports/ \;
 +    REPORT_ARGS="$REPORT_ARGS --target-dir=$SRC --out-dir=$SRC/inspector"
 +    REPORT_ARGS="$REPORT_ARGS --language=go"
 +    fuzz-introspector full $REPORT_ARGS


### PR DESCRIPTION
This PR fixes the patch for copying fuzz.cov of golang projects to unify with coverage report handling in OFG.