### PR TITLE
Fix: Missing command in the installation section of sphinx-doc

### DIFF
--- a/doc/sphinx/source/installation-instructions/installation.rst
+++ b/doc/sphinx/source/installation-instructions/installation.rst
@@ -60,6 +60,7 @@ Build a test case
 
     # Build the target using Fuzz Introspector instrumentation
     ./build_all.sh
+    cd work
 
     # Run post-processing to analyse data files and generate HTML report
     python3 ../../../src/main.py correlate --binaries-dir=.


### PR DESCRIPTION
This PR fix is to address the issue #1841. @DavidKorczynski has updated the installation section of Sphinx documentation. However, the shell does not remain in the `work` directory after executing the script `build_all.sh`. Hence, I have added the command `cd work` to ensure the subsequent processes can be executed correctly. This approach maintains consistency with the command style in Option 2.