### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cxxfilt==0.3.0
 lxml==4.9.1
 matplotlib==3.10.0
 numpy==2.1.0
-PyYAML==6.0
+PyYAML==6.0.2
 soupsieve==2.2.1
 yapf==0.32.0
 pylint==3.0.0

--- a/tools/web-fuzzing-introspection/requirements.txt
+++ b/tools/web-fuzzing-introspection/requirements.txt
@@ -5,7 +5,13 @@ Jinja2==3.1.5
 MarkupSafe==2.1.2
 Werkzeug==3.0.6
 requests==2.32.3
-pyyaml==6.0
+pyyaml==6.0.2
 orjson==3.10.0
 flask_smorest==0.44.0
 marshmallow==3.21.0
+apispec==6.8
+webargs==8.6
+blinker==1.9
+certifi==2025.1.31
+idna==3.10
+urllib3==2.3


### PR DESCRIPTION
update PyYAML to add support for Cython 3.x and Python 3.13
and add missing requirements for the webapp (needed for launch_minor_oss_fuzz.sh and main.py)
