### PR TITLE
cli: Fix default coverage url for end-to-end run

### DIFF
--- a/src/fuzz_introspector/cli.py
+++ b/src/fuzz_introspector/cli.py
@@ -61,7 +61,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
                              type=str,
                              help='Name of the report.')
     full_parser.add_argument('--coverage-url',
-                             default='',
+                             default='/covreport/linux',
                              type=str,
                              help='Base coverage URL.')
     full_parser.add_argument(


### PR DESCRIPTION
This PR fixes a bug in wrong default coverage url for end-to-end run in the cli.