### PR TITLE
per fuzzer coverage information in project overview

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -153,10 +153,12 @@ def get_code_coverage_summary_url(project_name, datestr):
     project_url = base_url.format(project_name, datestr)
     return project_url
 
+
 def get_fuzzer_code_coverage_summary_url(project_name, datestr, fuzzer):
     base_url = 'https://storage.googleapis.com/oss-fuzz-coverage/{0}/reports-by-target/{1}/{2}/linux/summary.json'
     project_url = base_url.format(project_name, datestr, fuzzer)
     return project_url
+
 
 def get_coverage_report_url(project_name, datestr, language):
     if language == 'java' or language == 'python' or language == 'go':
@@ -259,8 +261,10 @@ def get_code_coverage_summary(project_name, datestr):
     except:
         return None
 
+
 def get_fuzzer_code_coverage_summary(project_name, datestr, fuzzer):
-    cov_summary_url = get_fuzzer_code_coverage_summary_url(project_name, datestr, fuzzer)
+    cov_summary_url = get_fuzzer_code_coverage_summary_url(
+        project_name, datestr, fuzzer)
     try:
         coverage_summary_raw = requests.get(cov_summary_url, timeout=20).text
     except:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -153,6 +153,10 @@ def get_code_coverage_summary_url(project_name, datestr):
     project_url = base_url.format(project_name, datestr)
     return project_url
 
+def get_fuzzer_code_coverage_summary_url(project_name, datestr, fuzzer):
+    base_url = 'https://storage.googleapis.com/oss-fuzz-coverage/{0}/reports-by-target/{1}/{2}/linux/summary.json'
+    project_url = base_url.format(project_name, datestr, fuzzer)
+    return project_url
 
 def get_coverage_report_url(project_name, datestr, language):
     if language == 'java' or language == 'python' or language == 'go':
@@ -245,6 +249,18 @@ def get_local_code_coverage_stats(project_name, oss_fuzz_folder):
 
 def get_code_coverage_summary(project_name, datestr):
     cov_summary_url = get_code_coverage_summary_url(project_name, datestr)
+    try:
+        coverage_summary_raw = requests.get(cov_summary_url, timeout=20).text
+    except:
+        return None
+    try:
+        json_dict = json.loads(coverage_summary_raw)
+        return json_dict
+    except:
+        return None
+
+def get_fuzzer_code_coverage_summary(project_name, datestr, fuzzer):
+    cov_summary_url = get_fuzzer_code_coverage_summary_url(project_name, datestr, fuzzer)
     try:
         coverage_summary_raw = requests.get(cov_summary_url, timeout=20).text
     except:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -309,13 +309,14 @@ def extract_code_coverage_data(code_coverage_summary):
     return line_total_summary
 
 
-def prepare_code_coverage_dict(code_coverage_summary, project_name: str, date_str: str,
-                               project_language: str) -> Optional[Dict[str, Any]]:
+def prepare_code_coverage_dict(
+        code_coverage_summary, project_name: str, date_str: str,
+        project_language: str) -> Optional[Dict[str, Any]]:
     """Gets coverage URL and line coverage total of a project"""
     line_total_summary = extract_code_coverage_data(code_coverage_summary)
 
     coverage_url = oss_fuzz.get_coverage_report_url(project_name,
-                                                    date_str.replace("-", ""),
+                                                    date_str.replace('-', ''),
                                                     project_language)
     code_coverage_data_dict = {
         'coverage_url': coverage_url,
@@ -472,8 +473,8 @@ def extract_local_project_data(project_name, oss_fuzz_path,
     dictionary_key = '%s###%s' % (project_name, '')
     manager_return_dict[dictionary_key] = {
         'project_timestamp': project_timestamp,
-        "introspector-data-dict": introspector_data_dict,
-        "coverage-data-dict": code_coverage_data_dict,
+        'introspector-data-dict': introspector_data_dict,
+        'coverage-data-dict': code_coverage_data_dict,
         'all-header-files': all_header_files,
     }
 
@@ -722,7 +723,8 @@ def extract_project_data(project_name, date_str, should_include_details,
         amount_of_fuzzers = len(all_fuzzers)
         for ff in all_fuzzers:
             try:
-                fuzzer_cov = oss_fuzz.get_fuzzer_code_coverage_summary(project_name, date_str.replace("-", ""), ff)
+                fuzzer_cov = oss_fuzz.get_fuzzer_code_coverage_summary(
+                    project_name, date_str.replace("-", ""), ff)
                 fuzzer_cov_data = extract_code_coverage_data(fuzzer_cov)
                 per_fuzzer_cov[ff] = fuzzer_cov_data
             except:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -319,6 +319,8 @@ def prepare_code_coverage_dict(
         project_language: str) -> Optional[Dict[str, Any]]:
     """Gets coverage URL and line coverage total of a project"""
     line_total_summary = extract_code_coverage_data(code_coverage_summary)
+    if line_total_summary is None:
+        return None
 
     coverage_url = oss_fuzz.get_coverage_report_url(project_name,
                                                     date_str.replace('-', ''),

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -24,8 +24,10 @@ import requests
 import subprocess
 import zipfile
 import tarfile
+import statistics
+from pathlib import Path
 from threading import Thread
-from typing import List, Any, Optional, Dict
+from typing import List, Any, Optional, Dict, Tuple, Set
 
 import constants
 import oss_fuzz
@@ -34,7 +36,7 @@ DB_JSON_DB_TIMESTAMP = 'db-timestamps.json'
 DB_JSON_ALL_PROJECT_TIMESTAMP = 'all-project-timestamps.json'
 DB_JSON_ALL_FUNCTIONS = 'all-functions-db-{PROJ}.json'
 DB_JSON_ALL_CONSTRUCTORS = 'all-constructors-db-{PROJ}.json'
-DB_JSON_ALL_CURRENT_FUNCS = 'all-project-current.json'
+DB_JSON_ALL_CURRENT = 'all-project-current.json'
 DB_JSON_ALL_BRANCH_BLOCKERS = 'all-branch-blockers.json'
 DB_BUILD_STATUS_JSON = 'build-status.json'
 #DB_RAW_INTROSPECTOR_REPORTS = 'raw-introspector-reports'
@@ -44,7 +46,7 @@ ALL_JSON_FILES = [
     DB_JSON_ALL_PROJECT_TIMESTAMP,
     DB_JSON_ALL_FUNCTIONS,
     DB_JSON_ALL_CONSTRUCTORS,
-    DB_JSON_ALL_CURRENT_FUNCS,
+    DB_JSON_ALL_CURRENT,
 ]
 
 INTROSPECTOR_WEBAPP_ZIP = (
@@ -52,6 +54,9 @@ INTROSPECTOR_WEBAPP_ZIP = (
 
 FI_EXCLUDE_ALL_NON_MUSTS = bool(int(os.getenv('FI_EXCLUDE_ALL_NON_MUSTS',
                                               '0')))
+
+NUM_RECENT_DAYS = 30
+FUZZER_COVERAGE_IS_DEGRADED = 5  # 5% or more is a degradation
 
 MUST_INCLUDES = set()
 MUST_INCLUDE_WITH_LANG: List[Any] = []
@@ -896,11 +901,105 @@ def extend_db_timestamps(db_timestamp, output_directory):
             json.dump(existing_timestamps, f)
 
 
-def extend_db_json_files(project_timestamps, output_directory):
+def per_fuzzer_coverage_analysis(project_name: str,
+                                 coverages: Dict[str, List[Tuple[int, str]]],
+                                 lost_fuzzers):
+    """Go through the recent coverage results and combine them into a short summary.
+    Including an assessment if the fuzzer got worse over time.
+    """
+
+    # TODO This might not be a good metric when coverage is not meaningful,
+    # for example for very small projects or projects that have low coverage
+    # already. Though, this might not be super bad as we are taking a look
+    # at per fuzzer coverage, which is should already be normalized to what
+    # can be reached.
+    # TODO What would be a good percentage to mark as coverage degradation,
+    # taking 5% for now but should be observed, maybe per it should be
+    # configurable per project as well.
+    results = {}
+    for ff, data in coverages.items():
+        if len(data) > 0:
+            values = [dd[0] for dd in data]
+            dates = [dd[1] for dd in data]
+            latest_date_with_value = next(dd[1] for dd in reversed(data)
+                                          if dd[0] is not None)
+            if latest_date_with_value is not None:
+                report_url = oss_fuzz.get_fuzzer_code_coverage_summary_url(
+                    project_name, latest_date_with_value.replace('-', ''), ff)
+                report_url = report_url[:-len('summary.json')] + 'index.html'
+            else:
+                report_url = None
+            max_cov = max(values[:-1], default=0)
+            avg_cov = round(statistics.fmean(values), 2)
+            current = values[-1]
+            results[ff] = {
+                'report_url': report_url,
+                'report_date': latest_date_with_value,
+                'coverages_values': values,
+                'coverages_dates': dates,
+                'max': max_cov,
+                'avg': avg_cov,
+                'current': current,
+                'has_degraded':
+                (max_cov - current) > FUZZER_COVERAGE_IS_DEGRADED,
+                'got_lost': ff in lost_fuzzers,
+            }
+    return results
+
+
+def calculate_recent_results(projects_with_new_results, timestamps,
+                             num_days: int):
+    """Analyse recent project data to detect possible degradations of fuzzer efficiency."""
+    from collections import defaultdict
+
+    data: Dict[str, Dict[str, Dict[str, Any]]] = defaultdict(dict)
+    for pt in timestamps:
+        project_name = pt['project_name']
+        if project_name in projects_with_new_results:
+            data[project_name][pt['date']] = pt
+
+    results = {}
+    for project_name, project_data in data.items():
+        fuzzers_past = set()
+        fuzzers_current: Set[str] = set()
+        per_fuzzer_coverages = defaultdict(list)
+
+        for do in (get_date_at_offset_as_str(ii)
+                   for ii in range(-num_days, 0, 1)):
+            try:
+                date_data = project_data[do]
+                per_fuzzer_coverage_data = date_data[
+                    'per-fuzzer-coverage-data']
+
+                fuzzers_past |= fuzzers_current
+                fuzzers_current = set(per_fuzzer_coverage_data.keys())
+
+                for ff, cov_data in per_fuzzer_coverage_data.items():
+                    try:
+                        perc = round(
+                            100 * cov_data['covered'] / cov_data['count'], 2)
+                    except:
+                        perc = 0
+
+                    per_fuzzer_coverages[ff].append((perc, do))
+            except:
+                continue
+
+        fuzzer_diff = fuzzers_past - fuzzers_current
+        per_fuzzer_coverages = per_fuzzer_coverage_analysis(
+            project_name, per_fuzzer_coverages, fuzzer_diff)
+
+        results[project_name] = per_fuzzer_coverages
+
+    return results
+
+
+def extend_db_json_files(project_timestamps, output_directory,
+                         should_include_details):
     """Extends a set of DB .json files."""
 
     existing_timestamps = []
-    logging.info('Loading existing timestamps 1')
+    logging.info('Loading existing timestamps')
     if os.path.isfile(
             os.path.join(output_directory, DB_JSON_ALL_PROJECT_TIMESTAMP)):
         with open(
@@ -919,10 +1018,11 @@ def extend_db_json_files(project_timestamps, output_directory):
     existing_timestamp_mapping = dict()
 
     for es in existing_timestamps:
-        if not es['project_name'] in existing_timestamp_mapping:
+        if es['project_name'] not in existing_timestamp_mapping:
             existing_timestamp_mapping[es['project_name']] = set()
         existing_timestamp_mapping[es['project_name']].add(es['date'])
 
+    projects_with_new_results = set()
     for new_ts in project_timestamps:
         to_add = True
 
@@ -932,24 +1032,44 @@ def extend_db_json_files(project_timestamps, output_directory):
                 to_add = False
         if to_add:
             existing_timestamps.append(new_ts)
+            projects_with_new_results.add(new_ts['project_name'])
             have_added = True
 
     if FI_EXCLUDE_ALL_NON_MUSTS:
-        new_timestamps = []
+        # Filter existing timstamps to to only those in MUST_INCLUDES.
+        kept_timestamps = []
         for ts in existing_timestamps:
             if ts['project_name'] in MUST_INCLUDES:
-                new_timestamps.append(ts)
-        existing_timestamps = new_timestamps
+                kept_timestamps.append(ts)
+        existing_timestamps = kept_timestamps
 
-        new_project_stamps = []
+        # Also filter the current project results.
+        kept_project_stamps = []
         for project_stamp in project_timestamps:
             if project_stamp['project_name'] in MUST_INCLUDES:
-                new_project_stamps.append(project_stamp)
-        project_timestamps = new_project_stamps
+                kept_project_stamps.append(project_stamp)
+        project_timestamps = kept_project_stamps
 
-    logging.info('Dumping all current projects')
-    with open(os.path.join(output_directory, DB_JSON_ALL_CURRENT_FUNCS),
-              'w') as f:
+    if should_include_details:
+        recent_results = calculate_recent_results(projects_with_new_results,
+                                                  existing_timestamps,
+                                                  NUM_RECENT_DAYS)
+        # TODO these results might detect issues that should be communicated with
+        # project maintainers. The best approach might be to load the
+        # project_timestamps file (all-project-current.json)
+        # separately and load recent results there and maybe issue warnings.
+        for pt in project_timestamps:
+            try:
+                pt['recent_results'] = recent_results.get(pt['project_name'])
+            except Exception as exc:
+                logger.warning(
+                    f'Could not get recent results for {pt["project_name"]}: {exc}'
+                )
+    else:
+        recent_results = None
+
+    logging.info('Dumping current project data')
+    with open(os.path.join(output_directory, DB_JSON_ALL_CURRENT), 'w') as f:
         json.dump(project_timestamps, f)
 
     # Remove any light-introspector files because they should not be saved in the
@@ -1017,7 +1137,8 @@ def update_db_files(db_timestamp,
         f.write(json.dumps(all_header_files))
 
     logging.info('Extending DB json files')
-    extend_db_json_files(project_timestamps, output_directory)
+    extend_db_json_files(project_timestamps, output_directory,
+                         should_include_details)
 
     logging.info('Extending DB time stamps')
     extend_db_timestamps(db_timestamp, output_directory)

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -60,8 +60,6 @@ def load_db() -> None:
                 project_name=project_timestamp['project_name'],
                 language=project_timestamp['language'],
                 coverage_data=project_timestamp['coverage-data'],
-                per_fuzzer_coverage_data=project_timestamp.get(
-                    'per-fuzzer-coverage-data', None),
                 introspector_data=project_timestamp['introspector-data'],
                 fuzzer_count=project_timestamp['fuzzer-count'],
                 introspector_url=project_timestamp.get('introspector_url',
@@ -87,8 +85,9 @@ def load_db() -> None:
                 introspector_data=project_timestamp['introspector-data'],
                 fuzzer_count=project_timestamp['fuzzer-count'],
                 project_repository=project_timestamp['project_repository'],
-                light_analysis=project_timestamp.get('light-introspector',
-                                                     {})))
+                light_analysis=project_timestamp.get('light-introspector', {}),
+                recent_results=project_timestamp.get('recent_results'),
+            ))
 
         introspector_data = project_timestamp.get('introspector-data', None)
         if introspector_data is None:

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -60,6 +60,7 @@ def load_db() -> None:
                 project_name=project_timestamp['project_name'],
                 language=project_timestamp['language'],
                 coverage_data=project_timestamp['coverage-data'],
+                per_fuzzer_coverage_data=project_timestamp.get('per-fuzzer-coverage-data', None),
                 introspector_data=project_timestamp['introspector-data'],
                 fuzzer_count=project_timestamp['fuzzer-count'],
                 introspector_url=project_timestamp.get('introspector_url',

--- a/tools/web-fuzzing-introspection/app/webapp/__init__.py
+++ b/tools/web-fuzzing-introspection/app/webapp/__init__.py
@@ -60,7 +60,8 @@ def load_db() -> None:
                 project_name=project_timestamp['project_name'],
                 language=project_timestamp['language'],
                 coverage_data=project_timestamp['coverage-data'],
-                per_fuzzer_coverage_data=project_timestamp.get('per-fuzzer-coverage-data', None),
+                per_fuzzer_coverage_data=project_timestamp.get(
+                    'per-fuzzer-coverage-data', None),
                 introspector_data=project_timestamp['introspector-data'],
                 fuzzer_count=project_timestamp['fuzzer-count'],
                 introspector_url=project_timestamp.get('introspector_url',

--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -30,7 +30,8 @@ class Project:
                  introspector_data: Optional[Dict[str,
                                                   Any]], fuzzer_count: int,
                  project_repository: Optional[str], light_analysis: Dict[Any,
-                                                                         Any]):
+                                                                         Any],
+                 recent_results: Optional[Dict[str, Any]]):
         self.name = name
         self.language = language
         self.date = date
@@ -39,9 +40,13 @@ class Project:
         self.fuzzer_count = fuzzer_count
         self.project_repository = project_repository
         self.light_analysis = light_analysis
+        self.recent_results = recent_results
 
     def has_introspector(self) -> bool:
-        return self.introspector_data != None
+        return self.introspector_data is not None
+
+    def has_recent_results(self) -> bool:
+        return self.recent_results is not None
 
 
 class DBTimestamp:
@@ -78,7 +83,6 @@ class ProjectTimestamp:
                  date: str,
                  language: str,
                  coverage_data: Optional[Dict[str, Any]],
-                 per_fuzzer_coverage_data: Optional[Dict[str, Dict[str, Any]]],
                  introspector_data: Optional[Dict[str, Any]],
                  fuzzer_count: int,
                  introspector_url: Optional[str] = None,
@@ -89,7 +93,6 @@ class ProjectTimestamp:
         self.date = date
         self.language = language
         self.coverage_data = coverage_data
-        self.per_fuzzer_coverage_data = per_fuzzer_coverage_data
         self.introspector_data = introspector_data
         self.fuzzer_count = fuzzer_count
         self.introspector_url = introspector_url

--- a/tools/web-fuzzing-introspection/app/webapp/models.py
+++ b/tools/web-fuzzing-introspection/app/webapp/models.py
@@ -78,6 +78,7 @@ class ProjectTimestamp:
                  date: str,
                  language: str,
                  coverage_data: Optional[Dict[str, Any]],
+                 per_fuzzer_coverage_data: Optional[Dict[str, Dict[str, Any]]],
                  introspector_data: Optional[Dict[str, Any]],
                  fuzzer_count: int,
                  introspector_url: Optional[str] = None,
@@ -88,6 +89,7 @@ class ProjectTimestamp:
         self.date = date
         self.language = language
         self.coverage_data = coverage_data
+        self.per_fuzzer_coverage_data = per_fuzzer_coverage_data
         self.introspector_data = introspector_data
         self.fuzzer_count = fuzzer_count
         self.introspector_url = introspector_url

--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -574,7 +574,8 @@ def project_profile():
                                      coverage_data=None,
                                      introspector_data=None,
                                      project_repository=None,
-                                     light_analysis={})
+                                     light_analysis={},
+                                     recent_results=None)
 
             # Get statistics of the project
             project_statistics = data_storage.PROJECT_TIMESTAMPS

--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -264,7 +264,7 @@ max_fuzzer_count = 0;
 
 {% for project_timestamp in project_statistics %}
   {% if project_timestamp.coverage_data != None %}
-    code_coverage_lines_x.push("{{project_timestamp.date}}");
+    code_coverage_lines_x.push('{{project_timestamp.date}}');
     code_coverage_lines_y.push({{project_timestamp.coverage_data.line_coverage.percent}});
     fuzzer_count_y.push({{project_timestamp.fuzzer_count}});
     max_fuzzer_count = Math.max(max_fuzzer_count, {{project_timestamp.fuzzer_count}});
@@ -277,11 +277,11 @@ max_fuzzer_count = 0;
 
     {% if project_timestamp.per_fuzzer_coverage_data != None %}
       {% for (fuzzer, cov_data) in project_timestamp.per_fuzzer_coverage_data.items() %}
-        if (fuzzers.get("{{fuzzer}}") === undefined) {
-          fuzzers.set("{{fuzzer}}", {x: [], y: []});
+        if (fuzzers.get('{{fuzzer}}') === undefined) {
+          fuzzers.set('{{fuzzer}}', {x: [], y: []});
         }
-        var vv = fuzzers.get("{{fuzzer}}");
-        vv.x.push("{{project_timestamp.date}}");
+        var vv = fuzzers.get('{{fuzzer}}');
+        vv.x.push('{{project_timestamp.date}}');
         vv.y.push({{cov_data.percent}});
       {%endfor%}
     {% endif %}
@@ -292,17 +292,17 @@ max_fuzzer_count = 0;
 const code_coverage_lines_data = [{
   x: code_coverage_lines_x,
   y: code_coverage_lines_y,
-  mode:"lines"
+  mode:'lines'
 }];
 const code_coverage_lines_layout = {
-  xaxis: {title: "Date"},
-  yaxis: {title: "Coverage", range: [0.0, 100.0]},  
-  title: "Code Coverage (lines) %",
-  type: "scatter"
+  xaxis: {title: 'Date'},
+  yaxis: {title: 'Coverage', range: [0.0, 100.0]},  
+  title: 'Code Coverage (lines) %',
+  type: 'scatter'
 };
-Plotly.newPlot("codeCoverageLinesOverTimePlot", code_coverage_lines_data, code_coverage_lines_layout);
+Plotly.newPlot('codeCoverageLinesOverTimePlot', code_coverage_lines_data, code_coverage_lines_layout);
 
-const progress_graph_div = document.getElementById("progress_graphs")
+const progress_graph_div = document.getElementById('progress_graphs')
 
 for (const [fuzzer_name, coverage_percentage] of fuzzers) {
   const per_fuzzer_id = 'perFuzzerCoverageLinesOverTimePlot' + fuzzer_name;
@@ -317,20 +317,20 @@ for (const [fuzzer_name, coverage_percentage] of fuzzers) {
 
   const the_div = document.createElement('div')
   the_div.id = per_fuzzer_id
-  the_div.style = "width:100%;max-width:500px"
+  the_div.style = 'width:100%;max-width:500px'
   gc_div.appendChild(the_div);
 
   // Plot for fuzzer counter over time
   const per_fuzzer_code_coverage_lines_data = [{
     x: coverage_percentage.x,
     y: coverage_percentage.y,
-    mode:"lines"
+    mode:'lines'
   }];
   const per_fuzzer_code_coverage_lines_layout = {
-    xaxis: {title: "Date"},
-    yaxis: {title: "Coverage", range: [0.0, 100.0]},
-    title: "Code Coverage (lines) %<br>" + fuzzer_name,
-    type: "scatter"
+    xaxis: {title: 'Date'},
+    yaxis: {title: 'Coverage', range: [0.0, 100.0]},
+    title: 'Code Coverage (lines) %<br>' + fuzzer_name,
+    type: 'scatter'
   };
   Plotly.newPlot(per_fuzzer_id, per_fuzzer_code_coverage_lines_data, per_fuzzer_code_coverage_lines_layout);
 }
@@ -339,15 +339,15 @@ for (const [fuzzer_name, coverage_percentage] of fuzzers) {
 const fuzzer_count_data = [{
   x: code_coverage_lines_x,
   y: fuzzer_count_y,
-  mode:"lines"
+  mode:'lines'
 }];
 const fuzzer_count_layout = {
-  xaxis: {title: "Date"},
-  yaxis: {title: "Fuzzers", range: [0.0, max_fuzzer_count + 5]},
-  title: "Fuzzer count",
-  type: "scatter"
+  xaxis: {title: 'Date'},
+  yaxis: {title: 'Fuzzers', range: [0.0, max_fuzzer_count + 5]},
+  title: 'Fuzzer count',
+  type: 'scatter'
 };
-Plotly.newPlot("fuzzerCountOverTimePlot", fuzzer_count_data, fuzzer_count_layout);
+Plotly.newPlot('fuzzerCountOverTimePlot', fuzzer_count_data, fuzzer_count_layout);
 
 {% endif %} // has_project_stats
 
@@ -357,30 +357,30 @@ Plotly.newPlot("fuzzerCountOverTimePlot", fuzzer_count_data, fuzzer_count_layout
 const code_coverage_functions_data = [{
   x: code_coverage_lines_x,
   y: code_coverage_functions_y,
-  mode:"lines"
+  mode:'lines'
 }];
 const code_coverage_functions_layout = {
-  xaxis: {title: "Date"},
-  yaxis: {title: "Coverage", range: [0.0, 100.0]},  
-  title: "Code Coverage (functions) %",
-  type: "scatter"
+  xaxis: {title: 'Date'},
+  yaxis: {title: 'Coverage', range: [0.0, 100.0]},  
+  title: 'Code Coverage (functions) %',
+  type: 'scatter'
 };
-Plotly.newPlot("codeCoverageFunctionsOverTimePlot", code_coverage_functions_data, code_coverage_functions_layout);
+Plotly.newPlot('codeCoverageFunctionsOverTimePlot', code_coverage_functions_data, code_coverage_functions_layout);
 
 
 // Plot for static rachability over time
 const code_reachability_data = [{
   x: code_coverage_lines_x,
   y: code_reachability_y,
-  mode:"lines"
+  mode:'lines'
 }];
 const code_reachability_layout = {
-  xaxis: {title: "Date"},
-  yaxis: {title: "Reachability", range: [0.0, 100.0]},  
-  title: "Static reachability %",
-  type: "scatter"
+  xaxis: {title: 'Date'},
+  yaxis: {title: 'Reachability', range: [0.0, 100.0]},  
+  title: 'Static reachability %',
+  type: 'scatter'
 };
-Plotly.newPlot("staticReachabilityOverTimePlot", code_reachability_data, code_reachability_layout);
+Plotly.newPlot('staticReachabilityOverTimePlot', code_reachability_data, code_reachability_layout);
 {% endif %}
 
 

--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -10,8 +10,7 @@
             <div class="pr__profile-header">
               <h2>Project: <a href="{{project_url}}"> {{ project.name }}</a></h2>
             </div>
-            <div class="profile__table" style="max-width: 450px">
-              <table>
+              <table class="profile__table" style="max-width: 450px">
                 <tbody>
                   <tr>
                     <td>Language</td>
@@ -131,11 +130,57 @@
                   </tr> 
                 </tbody>
               </table>
+
+              {% if project.has_recent_results() %}
+              <div style="max-height: 30rem; overflow: auto; margin-top: 1.5rem">
+                <table class="profile__table" style="max-width: 80%;">
+                  <thead>
+                    <th>Fuzzer</th>
+                    <th>Code coverage (lines)</th>
+                    <th>Latest Report</th>
+                    <th>Comments</th>
+                  </thead>
+                  <tbody>
+                    {% for fuzzer, fuzzer_data in project.recent_results.items()
+                      |sort(attribute='0')
+                      |sort(reverse=true, attribute='1.got_lost,1.has_degraded')
+                    %}
+                      <tr
+                        {% if fuzzer_data['got_lost'] or fuzzer_data['has_degraded'] %}
+                          class="alert alert-danger" role="alert"
+                        {% endif %}
+                      >
+                        <td>
+                          {{ fuzzer }}
+                        </td>
+                        <td>
+                          <code style="color: unset; white-space: nowrap;">
+                            {{ fuzzer_data['current'] }}% (avg: {{ fuzzer_data['avg'] }}%, max: {{ fuzzer_data['max'] }}%)
+                          </code>
+                        </td>
+                        <td>
+                          <a href="{{fuzzer_data['report_url']}}">{{ fuzzer_data['report_date'] }}</a>
+                        </td>
+                        <td>
+                          {% if fuzzer_data['got_lost'] %}
+                            Fuzzer no longer available!
+                          {% endif %}
+                          {% if fuzzer_data['has_degraded'] %}
+                            Coverage has degraded!
+                          {% endif %}
+                        </td>
+                      </tr>
+                    {%endfor%}
+                  </tbody>
+                </table>
+              </div>
+              {% endif %}
+
             </div>
           </div>
           <!-- project profile table -->
           <div class="project__progress">
-            <h2>Historical progression</h2>
+            <h2>Historical Progression</h2>
             <div class="progress__graph">
               <!-- single graph -->
               <div class="single__graph">
@@ -163,9 +208,6 @@
                 </div>
               </div>
             </div>
-            <h2>Per fuzzer progression</h2>
-            <div id="progress_graphs" class="progress__graph">
-            </div>
               {% else %}
             </div>
             <p>
@@ -176,6 +218,14 @@
           {% endif %}
           </div> <!-- project historical progress -->
         </div>
+
+        {% if project.has_recent_results() %}
+        <div class="project__progress">
+          <h2>Per Fuzzer Progression</h2>
+          <div id="progress_graphs" class="progress__graph">
+          </div>
+        </div>
+        {% endif %}
       </section>
 
       <!-- Functions of interest forthe given project -->
@@ -258,7 +308,6 @@ const code_coverage_lines_y = [];
 const code_coverage_functions_y = [];
 const code_reachability_y = [];
 const fuzzer_count_y = [];
-const fuzzers = new Map();
 max_fuzzer_count = 0;
 
 
@@ -273,17 +322,6 @@ max_fuzzer_count = 0;
     {% if project.has_introspector() %}
       code_coverage_functions_y.push({{project_timestamp.introspector_data.functions_covered_estimate}});
       code_reachability_y.push({{project_timestamp.introspector_data.static_reachability}});
-    {% endif %}
-
-    {% if project_timestamp.per_fuzzer_coverage_data != None %}
-      {% for (fuzzer, cov_data) in project_timestamp.per_fuzzer_coverage_data.items() %}
-        if (fuzzers.get('{{fuzzer}}') === undefined) {
-          fuzzers.set('{{fuzzer}}', {x: [], y: []});
-        }
-        var vv = fuzzers.get('{{fuzzer}}');
-        vv.x.push('{{project_timestamp.date}}');
-        vv.y.push({{cov_data.percent}});
-      {%endfor%}
     {% endif %}
   {% endif %}
 {%endfor%}
@@ -302,8 +340,29 @@ const code_coverage_lines_layout = {
 };
 Plotly.newPlot('codeCoverageLinesOverTimePlot', code_coverage_lines_data, code_coverage_lines_layout);
 
-const progress_graph_div = document.getElementById('progress_graphs')
+// Plot for fuzzer counter over time
+const fuzzer_count_data = [{
+  x: code_coverage_lines_x,
+  y: fuzzer_count_y,
+  mode:'lines'
+}];
+const fuzzer_count_layout = {
+  xaxis: {title: 'Date'},
+  yaxis: {title: 'Fuzzers', range: [0.0, max_fuzzer_count + 5]},
+  title: 'Fuzzer count',
+  type: 'scatter'
+};
+Plotly.newPlot('fuzzerCountOverTimePlot', fuzzer_count_data, fuzzer_count_layout);
 
+{% endif %} // has_project_stats
+
+{% if project.has_recent_results() %}
+const fuzzers = new Map();
+  {% for fuzzer, fuzzer_data in project.recent_results.items() %}
+    fuzzers.set('{{fuzzer}}', {x: {{fuzzer_data['coverages_dates']|tojson}}, y: {{fuzzer_data['coverages_values']|tojson}}});
+  {% endfor %}
+
+const progress_graph_div = document.getElementById('progress_graphs')
 for (const [fuzzer_name, coverage_percentage] of fuzzers) {
   const per_fuzzer_id = 'perFuzzerCoverageLinesOverTimePlot' + fuzzer_name;
 
@@ -334,22 +393,7 @@ for (const [fuzzer_name, coverage_percentage] of fuzzers) {
   };
   Plotly.newPlot(per_fuzzer_id, per_fuzzer_code_coverage_lines_data, per_fuzzer_code_coverage_lines_layout);
 }
-
-// Plot for fuzzer counter over time
-const fuzzer_count_data = [{
-  x: code_coverage_lines_x,
-  y: fuzzer_count_y,
-  mode:'lines'
-}];
-const fuzzer_count_layout = {
-  xaxis: {title: 'Date'},
-  yaxis: {title: 'Fuzzers', range: [0.0, max_fuzzer_count + 5]},
-  title: 'Fuzzer count',
-  type: 'scatter'
-};
-Plotly.newPlot('fuzzerCountOverTimePlot', fuzzer_count_data, fuzzer_count_layout);
-
-{% endif %} // has_project_stats
+{% endif %} // has_recent_results
 
 {% if project.has_introspector() %}
 // Plots dependend on Fuzz Introspector

--- a/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
+++ b/tools/web-fuzzing-introspection/app/webapp/templates/project-profile.html
@@ -163,6 +163,9 @@
                 </div>
               </div>
             </div>
+            <h2>Per fuzzer progression</h2>
+            <div id="progress_graphs" class="progress__graph">
+            </div>
               {% else %}
             </div>
             <p>
@@ -255,6 +258,7 @@ const code_coverage_lines_y = [];
 const code_coverage_functions_y = [];
 const code_reachability_y = [];
 const fuzzer_count_y = [];
+const fuzzers = new Map();
 max_fuzzer_count = 0;
 
 
@@ -269,6 +273,17 @@ max_fuzzer_count = 0;
     {% if project.has_introspector() %}
       code_coverage_functions_y.push({{project_timestamp.introspector_data.functions_covered_estimate}});
       code_reachability_y.push({{project_timestamp.introspector_data.static_reachability}});
+    {% endif %}
+
+    {% if project_timestamp.per_fuzzer_coverage_data != None %}
+      {% for (fuzzer, cov_data) in project_timestamp.per_fuzzer_coverage_data.items() %}
+        if (fuzzers.get("{{fuzzer}}") === undefined) {
+          fuzzers.set("{{fuzzer}}", {x: [], y: []});
+        }
+        var vv = fuzzers.get("{{fuzzer}}");
+        vv.x.push("{{project_timestamp.date}}");
+        vv.y.push({{cov_data.percent}});
+      {%endfor%}
     {% endif %}
   {% endif %}
 {%endfor%}
@@ -286,6 +301,39 @@ const code_coverage_lines_layout = {
   type: "scatter"
 };
 Plotly.newPlot("codeCoverageLinesOverTimePlot", code_coverage_lines_data, code_coverage_lines_layout);
+
+const progress_graph_div = document.getElementById("progress_graphs")
+
+for (const [fuzzer_name, coverage_percentage] of fuzzers) {
+  const per_fuzzer_id = 'perFuzzerCoverageLinesOverTimePlot' + fuzzer_name;
+
+  const sg_div = document.createElement('div');
+  sg_div.classList.add('single__graph');
+  progress_graph_div.appendChild(sg_div);
+
+  const gc_div = document.createElement('div');
+  gc_div.classList.add('graph__chart')
+  sg_div.appendChild(gc_div);
+
+  const the_div = document.createElement('div')
+  the_div.id = per_fuzzer_id
+  the_div.style = "width:100%;max-width:500px"
+  gc_div.appendChild(the_div);
+
+  // Plot for fuzzer counter over time
+  const per_fuzzer_code_coverage_lines_data = [{
+    x: coverage_percentage.x,
+    y: coverage_percentage.y,
+    mode:"lines"
+  }];
+  const per_fuzzer_code_coverage_lines_layout = {
+    xaxis: {title: "Date"},
+    yaxis: {title: "Coverage", range: [0.0, 100.0]},
+    title: "Code Coverage (lines) %<br>" + fuzzer_name,
+    type: "scatter"
+  };
+  Plotly.newPlot(per_fuzzer_id, per_fuzzer_code_coverage_lines_data, per_fuzzer_code_coverage_lines_layout);
+}
 
 // Plot for fuzzer counter over time
 const fuzzer_count_data = [{


### PR DESCRIPTION
Adds per fuzzer summary.json (based on `https://storage.googleapis.com/oss-fuzz-coverage/{0}/reports-by-target/{1}/{2}/linux/summary.json`) to the project timestamp data and generates per fuzzer coverage plots for the project overview, example below.

This PR is mainly to understand if an approach like this would be acceptable, though to implement some metrics in https://github.com/ossf/fuzz-introspector/issues/2054 it is probably needed to have a separate stage that takes a look at project data over time and not only in report generation. 

Still this PR [addresses an issue](https://github.com/ossf/fuzz-introspector/issues/1338) but it might take too much screen space (especially for large numbers of fuzzers), it might also require too much storage space, data ingress and runtime for data generation, and could have noticeable effects on webpage load time as well.

![Screenshot_20250217_162814](https://github.com/user-attachments/assets/f94e5fe1-94a4-4b3d-8119-45e147fb6092)
