### PR TITLE
Add CI scripts and update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ A more detailed description is available in [doc/Architecture](/doc/Architecture
 ### Code of Conduct
 Before contributing, please follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
+### Preparing the PR for CI
+
+You can run the `ci_checks.sh` script to run the linting and api tests that are
+run during CI. Make sure to activate the Python virtual environment as it is
+not done by the script to allow more flexibility for the local dev setup.
+
+The commit message **needs** to contain a signoff line with your data, this is
+supported by Git see [here](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff).
+
 ### Connect with the Fuzzing Community
 If you want to get involved in the Fuzzing community or have ideas to chat about, we discuss
 this project in the

--- a/api_test.sh
+++ b/api_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+set -Eeuo pipefail
+
+set -x
+
+echo "api test"
+python3 .github/helper/api_test.py

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2022 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+set -Eeuo pipefail
+
+set -x
+
+./code_checks.sh
+
+./api_test.sh
+


### PR DESCRIPTION
This adds/updates CI scripts for linting and api tests.

I worry that having separate scripts will cause a mismatch with the github actions in the future. I think a cleaner solution would be to call the scripts instead. For example call `./code_checks.sh` instead of the actions/commands starting at this point (after setting up the environment completely): https://github.com/ossf/fuzz-introspector/blob/main/.github/workflows/main.yml#L16
