### PR TITLE
Upgrade pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cxxfilt==0.3.0
 lxml==4.9.1
 matplotlib==3.10.0
 numpy==2.1.0
-PyYAML==6.0
+PyYAML==6.0.2
 soupsieve==2.2.1
 yapf==0.32.0
 pylint==3.0.0


### PR DESCRIPTION
On Python 3.12, where there are no prebuilts available for version 6.0, I'm seeing a compilation error:

```
      File "<string>", line 204, in get_source_files
      File "/tmp/pip-build-env-em_api7q/overlay/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 131, in __getattr__
        raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
```

Part of (but not sufficient to fix) #2125 