### PR TITLE
test_extraction: Fix bug and combine loop

### DIFF
--- a/src/fuzz_introspector/analysis.py
+++ b/src/fuzz_introspector/analysis.py
@@ -1143,7 +1143,10 @@ def _extract_test_information_cpp(report_dict, out_dir):
     return extract_tests_from_directories(directories, 'c-cpp', out_dir)
 
 
-def extract_tests_from_directories(directories, language, out_dir, need_copy=True) -> Set[str]:
+def extract_tests_from_directories(directories,
+                                   language,
+                                   out_dir,
+                                   need_copy=True) -> Set[str]:
     """Extracts test files from a given collection of directory paths and also
     copies them to the `constants.SAVED_SOURCE_FOLDER` folder with the same
     absolute path appended."""
@@ -1166,7 +1169,8 @@ def extract_tests_from_directories(directories, language, out_dir, need_copy=Tru
                         break
 
                     assembled_dir += dd2
-                    if os.path.isdir(assembled_dir) and assembled_dir.startswith(directory):
+                    if os.path.isdir(assembled_dir
+                                     ) and assembled_dir.startswith(directory):
                         all_directories.add(assembled_dir)
                     assembled_dir += '/'
 


### PR DESCRIPTION
This PR fixes the logic below in test file extraction to fix bug and to enhance performance.

1) Merged directory and file discovery into a single loop for improved performance.
2) Avoided adding the root directory by skipping empty path components during directory splitting. (i.e. directory start with `/` will always return an empty string at the beginning of the splited list and cause root directory `/` been added wrongly to the `all_directories` variable)
3) Enhanced performance by skipping hidden directories (those starting with a dot).
4) Ensured only directories within the specified base directory are included.
5) Introduced a flag to enable or disable the copying of test files.