### PR TITLE
test_file_analyser: Initialise standalone test file analyser

### DIFF
--- a/src/fuzz_introspector/analyses/__init__.py
+++ b/src/fuzz_introspector/analyses/__init__.py
@@ -27,6 +27,7 @@ from fuzz_introspector.analyses import annotated_cfg
 from fuzz_introspector.analyses import source_code_line_analyser
 from fuzz_introspector.analyses import far_reach_low_coverage_analyser
 from fuzz_introspector.analyses import public_candidate_analyser
+from fuzz_introspector.analyses import test_file_analyser
 
 # All optional analyses.
 # Ordering here is important as top analysis will be shown first in the report
@@ -44,6 +45,7 @@ all_analyses: list[type[analysis.AnalysisInterface]] = [
     source_code_line_analyser.SourceCodeLineAnalyser,
     far_reach_low_coverage_analyser.FarReachLowCoverageAnalyser,
     public_candidate_analyser.PublicCandidateAnalyser,
+    test_file_analyser.TestFileAnalyser,
 ]
 
 # This is the list of analyses that are meant to run
@@ -52,4 +54,5 @@ standalone_analyses: list[type[analysis.AnalysisInterface]] = [
     source_code_line_analyser.SourceCodeLineAnalyser,
     far_reach_low_coverage_analyser.FarReachLowCoverageAnalyser,
     public_candidate_analyser.PublicCandidateAnalyser,
+    test_file_analyser.TestFileAnalyser,
 ]

--- a/src/fuzz_introspector/analyses/test_file_analyser.py
+++ b/src/fuzz_introspector/analyses/test_file_analyser.py
@@ -90,8 +90,8 @@ class TestFileAnalyser(analysis.AnalysisInterface):
         """Standalone analysis."""
         super().standalone_analysis(proj_profile, profiles, out_dir)
 
-        all_test_files = analysis.extract_tests_from_directories(
-            {self.directory}, self.language, out_dir, False)
+        all_test_files: set[str] = analysis.extract_tests_from_directories(
+            {self.directory}, self.language, out_dir)
 
         with open(os.path.join(out_dir, 'all_tests.json'), 'w') as f:
             f.write(json.dumps(list(all_test_files)))

--- a/src/fuzz_introspector/analyses/test_file_analyser.py
+++ b/src/fuzz_introspector/analyses/test_file_analyser.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis plugin for analysing test files."""
+import json
+import logging
+import os
+
+from typing import (Any, List, Dict)
+
+from fuzz_introspector import (analysis, html_helpers)
+
+from fuzz_introspector.datatypes import (project_profile, fuzzer_profile)
+
+logger = logging.getLogger(name=__name__)
+
+
+class TestFileAnalyser(analysis.AnalysisInterface):
+    """Analysis utility for testing analysis."""
+
+    name: str = 'TestFileAnalyser'
+
+    def __init__(self) -> None:
+        self.json_results: Dict[str, Any] = {}
+        self.json_string_result = ''
+        self.test_file_paths = set()
+
+    @classmethod
+    def get_name(cls):
+        """Return the analyser identifying name for processing.
+
+        :return: The identifying name of this analyser
+        :rtype: str
+        """
+        return cls.name
+
+    def get_json_string_result(self) -> str:
+        """Return the stored json string result.
+
+        :return: The json string result processed and stored
+            by this analyser
+        :rtype: str
+        """
+        if self.json_string_result:
+            return self.json_string_result
+
+        return json.dumps(self.json_results)
+
+    def set_json_string_result(self, json_string: str):
+        """Store the result of this analyser as json string result
+        for further processing in a later time.
+
+        :param json_string: A json string variable storing the
+            processing result of the analyser for future use
+        :type json_string: str
+        """
+        self.json_string_result = json_string
+
+    def set_base_information(self, directory: str, language: str):
+        """Setter for base information."""
+        self.directory = directory
+        self.language = language
+
+    def analysis_func(self,
+                      table_of_contents: html_helpers.HtmlTableOfContents,
+                      tables: List[str],
+                      proj_profile: project_profile.MergedProjectProfile,
+                      profiles: List[fuzzer_profile.FuzzerProfile],
+                      basefolder: str, coverage_url: str,
+                      conclusions: List[html_helpers.HTMLConclusion],
+                      out_dir: str) -> str:
+        """Analysis function."""
+        self.standalone_analysis(proj_profile, profiles, out_dir)
+        return ''
+
+    def standalone_analysis(self,
+                            proj_profile: project_profile.MergedProjectProfile,
+                            profiles: List[fuzzer_profile.FuzzerProfile],
+                            out_dir: str) -> None:
+        """Standalone analysis."""
+        super().standalone_analysis(proj_profile, profiles, out_dir)
+
+        all_test_files = analysis.extract_tests_from_directories(
+            {self.directory}, self.language, out_dir, False)
+
+        with open(os.path.join(out_dir, 'all_tests.json'), 'w') as f:
+            f.write(json.dumps(list(all_test_files)))
+
+        return None

--- a/src/fuzz_introspector/analyses/test_file_analyser.py
+++ b/src/fuzz_introspector/analyses/test_file_analyser.py
@@ -33,7 +33,6 @@ class TestFileAnalyser(analysis.AnalysisInterface):
     def __init__(self) -> None:
         self.json_results: Dict[str, Any] = {}
         self.json_string_result = ''
-        self.test_file_paths = set()
 
     @classmethod
     def get_name(cls):

--- a/src/fuzz_introspector/cli.py
+++ b/src/fuzz_introspector/cli.py
@@ -279,8 +279,6 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         type=str,
         help='Folder to store analysis results.')
 
-
-
     return parser
 
 

--- a/src/fuzz_introspector/cli.py
+++ b/src/fuzz_introspector/cli.py
@@ -259,6 +259,28 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         type=str,
         help='Folder to store analysis results.')
 
+    test_file_analyser_parser = analyser_parser.add_parser(
+        'TestFileAnalyser',
+        help=('Provide analysis of public test files found in the project.'))
+
+    test_file_analyser_parser.add_argument(
+        '--target-dir',
+        type=str,
+        help='Directory holding source to analyse.',
+        required=True)
+    test_file_analyser_parser.add_argument(
+        '--language',
+        type=str,
+        help='Programming of the source code to analyse.',
+        choices=constants.LANGUAGES_SUPPORTED)
+    test_file_analyser_parser.add_argument(
+        '--out-dir',
+        default='',
+        type=str,
+        help='Folder to store analysis results.')
+
+
+
     return parser
 
 

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -282,6 +282,8 @@ def analyse(args) -> int:
         target_analyser.set_max_functions(max_functions)
         target_analyser.set_min_complexity(min_complexity)
         target_analyser.set_introspection_project(introspection_proj)
+    elif target_analyser.get_name() == 'TestFileAnalyser':
+        target_analyser.set_base_information(args.target_dir, language)
 
     # Run the analyser
     target_analyser.standalone_analysis(introspection_proj.proj_profile,


### PR DESCRIPTION
This PR adds a new TestFileAnalyser to discover possible test and example files for the project in a standalone analysis run. The analyser will be extended to get cross reference and function matching in later PRs.