### PR TITLE
webapp: Make webapp extract new xref test

### DIFF
--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -58,6 +58,11 @@ def get_introspector_project_tests_url(project_name, datestr):
                                             datestr) + "light/all_tests.json"
 
 
+def get_introspector_project_tests_xref_url(project_name, datestr):
+    return get_introspector_report_url_base(project_name,
+                                            datestr) + "all_tests_with_xreference.json"
+
+
 def get_introspector_project_all_files(project_name, datestr):
     return get_introspector_report_url_base(project_name,
                                             datestr) + "light/all_files.json"
@@ -343,6 +348,24 @@ def extract_introspector_test_files(project_name, date_str):
     return test_files
 
 
+def extract_introspector_test_files_xref(project_name, date_str):
+    introspector_test_url = get_introspector_project_tests_xref_url(
+        project_name, date_str.replace("-", ""))
+
+    # Read the introspector atifact
+    try:
+        raw_introspector_json_request = requests.get(introspector_test_url,
+                                                     timeout=10)
+    except:
+        return None
+    try:
+        test_files = json.loads(raw_introspector_json_request.text)
+    except:
+        return None
+
+    return test_files
+
+
 def extract_introspector_report(project_name, date_str):
     introspector_summary_url = get_introspector_report_url_summary(
         project_name, date_str.replace("-", ""))
@@ -376,6 +399,16 @@ def extract_local_introspector_all_files(project_name, oss_fuzz_folder):
 def extract_local_introspector_test_files(project_name, oss_fuzz_folder):
     summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
                                 'inspector', 'test-files.json')
+    if not os.path.isfile(summary_json):
+        return {}
+    with open(summary_json, 'r') as f:
+        json_list = json.load(f)
+    return json_list
+
+
+def extract_local_introspector_test_files_xref(project_name, oss_fuzz_folder):
+    summary_json = os.path.join(oss_fuzz_folder, 'build', 'out', project_name,
+                                'inspector', 'all_tests_with_xreference.json')
     if not os.path.isfile(summary_json):
         return {}
     with open(summary_json, 'r') as f:

--- a/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/web_db_creator_from_summary.py
@@ -126,6 +126,15 @@ def save_test_files_report(test_files, project_name):
         json.dump(test_files, report_fd)
 
 
+def save_test_files_xref_report(test_files, project_name):
+    project_db_dir = os.path.join(constants.DB_PROJECT_DIR, project_name)
+    os.makedirs(project_db_dir, exist_ok=True)
+
+    report_dst = os.path.join(project_db_dir, 'test_files_xref.json')
+    with open(report_dst, 'w') as report_fd:
+        json.dump(test_files, report_fd)
+
+
 def save_all_files_report(all_files, project_name):
     project_db_dir = os.path.join(constants.DB_PROJECT_DIR, project_name)
     os.makedirs(project_db_dir, exist_ok=True)
@@ -360,6 +369,10 @@ def extract_local_project_data(project_name, oss_fuzz_path,
         project_name, oss_fuzz_path)
     if test_files:
         save_test_files_report(test_files, project_name)
+    test_files_xref = oss_fuzz.extract_local_introspector_test_files_xref(
+        project_name, oss_fuzz_path)
+    if test_files_xref:
+        save_test_files_xref_report(test_files_xref, project_name)
 
     light_test_files = oss_fuzz.extract_local_introspector_light_test_files(
         project_name, oss_fuzz_path)
@@ -547,6 +560,10 @@ def extract_project_data(project_name, date_str, should_include_details,
         project_name, date_str.replace("-", ""))
     if test_files:
         save_test_files_report(test_files, project_name)
+    test_files_xref = oss_fuzz.extract_introspector_test_files_xref(
+        project_name, date_str.replace("-", ""))
+    if test_files_xref:
+        save_test_files_xref_report(test_files_xref, project_name)
 
     all_files = oss_fuzz.extract_introspector_all_files(
         project_name, date_str.replace("-", ""))


### PR DESCRIPTION
This PR follows #2145 and adds new logic to the data preparation of the webapp to honour the newly created `all_tests_with_xreference.json`, which contains a mapping of test/example files to the functions they reach in the project.