### PR TITLE
webapp: Fix xref func name search

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -2499,8 +2499,8 @@ def extract_project_tests_xref(project_name: str,
 
     for file, reach_list in test_files.items():
         for target in reach_list:
-            func_name = target['function_name']
-            if not funcs or func_name in funcs:
+            func_name = target['function_name'].split('::')[-1]
+            if not funcs or any(func.endswith(func_name) for func in funcs):
                 result.setdefault(func_name, []).append(file)
 
     return result


### PR DESCRIPTION
This PR enables the tests xref API to search for partially matching function name instead of exact match to allow generic information in the function name, like namespace in C++.