### PR TITLE
fix(analyser): update path handling in `TestFileAnalyser`

### DIFF
--- a/src/fuzz_introspector/analyses/test_file_analyser.py
+++ b/src/fuzz_introspector/analyses/test_file_analyser.py
@@ -121,7 +121,7 @@ class TestFileAnalyser(analysis.AnalysisInterface):
 
         # Auto determine base information if not provided
         if not self.directory:
-            paths = [func.function_source_file for func in functions.values()]
+            paths = [os.path.abspath(func.function_source_file) for func in functions.values()]
             common_path = os.path.commonpath(paths)
             if os.path.isfile(common_path):
                 common_path = os.path.dirname(common_path)


### PR DESCRIPTION
When following the example of "using fuzz-introspector w/o oss-fuzz", at the final step
```sh
# in tests/simple-example-0/work
python3 ../../../src/main.py report --target-dir=. --correlation-file=./exe_to_fuzz_introspector_logs.yaml
```
I got the following error:
```sh
debug info file: %s /home/cc/fuzz-introspector/tests/simple-example-0/work/../work/fuzzerLogFile-0-xvPezDK7xM.data.debug_info
debug info file: %s /home/cc/fuzz-introspector/tests/simple-example-0/work/../work/fuzzerLogFile-0-xvPezDK7xM.data.debug_all_types
debug info file: %s /home/cc/fuzz-introspector/tests/simple-example-0/work/../work/fuzzerLogFile-0-xvPezDK7xM.data.debug_all_functions
Traceback (most recent call last):
  File "/home/cc/fuzz-introspector/tests/simple-example-0/work/../../../src/main.py", line 25, in <module>
    main()
  File "/home/cc/fuzz-introspector/tests/simple-example-0/work/../../../src/main.py", line 20, in main
    cli.main()
  File "/home/cc/fuzz-introspector/src/fuzz_introspector/cli.py", line 311, in main
    return_code, _ = commands.run_analysis_on_dir(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/fuzz-introspector/src/fuzz_introspector/commands.py", line 167, in run_analysis_on_dir
    html_report.create_html_report(introspection_proj,
  File "/home/cc/fuzz-introspector/src/fuzz_introspector/html_report.py", line 786, in create_html_report
    html_report_core += create_section_optional_analyses(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/fuzz-introspector/src/fuzz_introspector/html_report.py", line 676, in create_section_optional_analyses
    html_string = analysis_instance.analysis_func(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cc/fuzz-introspector/src/fuzz_introspector/analyses/test_file_analyser.py", line 105, in analysis_func
    self.standalone_analysis(introspection_proj.proj_profile,
  File "/home/cc/fuzz-introspector/src/fuzz_introspector/analyses/test_file_analyser.py", line 125, in standalone_analysis
    common_path = os.path.commonpath(paths)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 547, in commonpath
ValueError: Can't mix absolute and relative paths
```
I changed the path handling logic to use the absolute path, and it works. Hope this PR can help.