### PR TITLE
FI-datatype: Add handling of assert statements in FI

### DIFF
--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -91,6 +91,19 @@ class FunctionProfile:
         except Exception:
             self.callsite = dict()
 
+        # Set assert statement handling if exist
+        assert_stmts = elem.get('assertStmts', [])
+        self.assert_list = []
+        for stmt in assert_stmts:
+            condition = stmt.get('condition', '')
+            location = stmt.get('pos', {})
+            if location and condition:
+                self.assert_list.append({
+                    'condition': condition,
+                    'start_line': location.get('line_start', -1),
+                    'end_line': location.get('line_end', -1),
+                })
+
         # These are set later.
         self.hitcount: int = 0
         self.reached_by_fuzzers: List[str] = []
@@ -116,7 +129,8 @@ class FunctionProfile:
             'source_line_begin': self.function_linenumber,
             'source_line_end': self.function_line_number_end,
             'debug_summary': '',  # No debug summary from new frontend yet
-            'total_cyclomatic_complexity': self.total_cyclomatic_complexity
+            'total_cyclomatic_complexity': self.total_cyclomatic_complexity,
+            'assert_stmts': self.assert_list,
         }
 
     @property

--- a/src/fuzz_introspector/datatypes/function_profile.py
+++ b/src/fuzz_introspector/datatypes/function_profile.py
@@ -99,9 +99,12 @@ class FunctionProfile:
             location = stmt.get('pos', {})
             if location and condition:
                 self.assert_list.append({
-                    'condition': condition,
-                    'start_line': location.get('line_start', -1),
-                    'end_line': location.get('line_end', -1),
+                    'condition':
+                    condition,
+                    'start_line':
+                    location.get('line_start', -1),
+                    'end_line':
+                    location.get('line_end', -1),
                 })
 
         # These are set later.


### PR DESCRIPTION
This PR adds handling of the newly extracted assert statements in the FI backend function profiles. Currently only works for C projects, all other projects will result in empty list.