### PR TITLE
analyser: Fix bug in base directory setting

### DIFF
--- a/src/fuzz_introspector/analyses/test_file_analyser.py
+++ b/src/fuzz_introspector/analyses/test_file_analyser.py
@@ -85,8 +85,7 @@ class TestFileAnalyser(analysis.AnalysisInterface):
                       conclusions: List[html_helpers.HTMLConclusion],
                       out_dir: str) -> str:
         """Analysis function."""
-        if not basefolder:
-            basefolder = os.environ.get('SRC', '/src')
+        basefolder = os.environ.get('SRC', '/src')
 
         language = utils.detect_language(basefolder)
 


### PR DESCRIPTION
This PR fixes a bug in test_file_analyser where the wrong base folder is used during the second run of the Tree-sitter frontend for discovering test files, causing empty fuzzing profiles during the analysis stage of a general project run.