### PR TITLE
frontend-analyser: Fix frontend lto process

### DIFF
--- a/src/fuzz_introspector/analyses/__init__.py
+++ b/src/fuzz_introspector/analyses/__init__.py
@@ -27,7 +27,7 @@ from fuzz_introspector.analyses import annotated_cfg
 from fuzz_introspector.analyses import source_code_line_analyser
 from fuzz_introspector.analyses import far_reach_low_coverage_analyser
 from fuzz_introspector.analyses import public_candidate_analyser
-from fuzz_introspector.analyses import test_file_analyser
+from fuzz_introspector.analyses import frontend_analyser
 
 # All optional analyses.
 # Ordering here is important as top analysis will be shown first in the report
@@ -45,7 +45,7 @@ all_analyses: list[type[analysis.AnalysisInterface]] = [
     source_code_line_analyser.SourceCodeLineAnalyser,
     far_reach_low_coverage_analyser.FarReachLowCoverageAnalyser,
     public_candidate_analyser.PublicCandidateAnalyser,
-    test_file_analyser.TestFileAnalyser,
+    frontend_analyser.FrontendAnalyser,
 ]
 
 # This is the list of analyses that are meant to run
@@ -54,5 +54,5 @@ standalone_analyses: list[type[analysis.AnalysisInterface]] = [
     source_code_line_analyser.SourceCodeLineAnalyser,
     far_reach_low_coverage_analyser.FarReachLowCoverageAnalyser,
     public_candidate_analyser.PublicCandidateAnalyser,
-    test_file_analyser.TestFileAnalyser,
+    frontend_analyser.FrontendAnalyser,
 ]

--- a/src/fuzz_introspector/cli.py
+++ b/src/fuzz_introspector/cli.py
@@ -88,7 +88,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
                                    "OptimalTargets", "RuntimeCoverageAnalysis",
                                    "FuzzEngineInputAnalysis",
                                    "FilePathAnalyser", "MetadataAnalysis",
-                                   "AnnotatedCFG", "TestFileAnalyser"
+                                   "AnnotatedCFG", "FrontendAnalyser"
                                ],
                                help="""
             Analyses to run. Available options:
@@ -96,7 +96,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
             FuzzDriverSynthesizerAnalysis, FuzzEngineInputAnalysis,
             FilePathAnalyser, ThirdPartyAPICoverageAnalyser,
             MetadataAnalysis, OptimalTargets, RuntimeCoverageAnalysis,
-            SinkCoverageAnalyser, TestFileAnalyser
+            SinkCoverageAnalyser, FrontendAnalyser
         """)
     report_parser.add_argument("--enable-all-analyses",
                                action='store_true',
@@ -152,7 +152,7 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
                                                     help="""
         Available analyser:
         SourceCodeLineAnalyser FarReachLowCoverageAnalyser
-        PublicCandidateAnalyser TestFileAnalyser""")
+        PublicCandidateAnalyser FrontendAnalyser""")
 
     source_code_line_analyser_parser = analyser_parser.add_parser(
         'SourceCodeLineAnalyser',
@@ -259,21 +259,22 @@ def get_cmdline_parser() -> argparse.ArgumentParser:
         type=str,
         help='Folder to store analysis results.')
 
-    test_file_analyser_parser = analyser_parser.add_parser(
-        'TestFileAnalyser',
-        help=('Provide analysis of public test files found in the project.'))
+    frontend_analyser_parser = analyser_parser.add_parser(
+        'FrontendAnalyser',
+        help=('Do a second run of the frontend and provide analysis '
+              'of public test files found in the project.'))
 
-    test_file_analyser_parser.add_argument(
+    frontend_analyser_parser.add_argument(
         '--target-dir',
         type=str,
         help='Directory holding source to analyse.',
         required=True)
-    test_file_analyser_parser.add_argument(
+    frontend_analyser_parser.add_argument(
         '--language',
         type=str,
-        help='Programming of the source code to analyse.',
+        help='Programming language of the source code to analyse.',
         choices=constants.LANGUAGES_SUPPORTED)
-    test_file_analyser_parser.add_argument(
+    frontend_analyser_parser.add_argument(
         '--out-dir',
         default='',
         type=str,

--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -282,7 +282,7 @@ def analyse(args) -> int:
         target_analyser.set_max_functions(max_functions)
         target_analyser.set_min_complexity(min_complexity)
         target_analyser.set_introspection_project(introspection_proj)
-    elif target_analyser.get_name() == 'TestFileAnalyser':
+    elif target_analyser.get_name() == 'FrontendAnalyser':
         target_analyser.set_base_information(args.target_dir, language)
 
     # Run the analyser

--- a/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
+++ b/tools/web-fuzzing-introspection/app/static/assets/db/oss_fuzz.py
@@ -47,14 +47,18 @@ def get_introspector_report_url_report(project_name, datestr):
                                             datestr) + "fuzz_report.html"
 
 
-def get_introspector_report_url_typedef(project_name, datestr, second_run=False):
+def get_introspector_report_url_typedef(project_name,
+                                        datestr,
+                                        second_run=False):
     base = get_introspector_report_url_base(project_name, datestr)
     if second_run:
         base += "second-frontend-run/"
     return base + "full_type_defs.json"
 
 
-def get_introspector_report_url_macro_block(project_name, datestr, second_run=False):
+def get_introspector_report_url_macro_block(project_name,
+                                            datestr,
+                                            second_run=False):
     base = get_introspector_report_url_base(project_name, datestr)
     if second_run:
         base += "second-frontend-run/"


### PR DESCRIPTION
This PR renames test-file-analyser to frontend-analyser. The analyser performs a second run of the frontend to generate the necessary data from frontend extraction if any data were skipped due to the LTO approach. The output from the second run is stored in a separate subdirectory. This PR also updates the web app to search the subdirectory for the required JSON data, but only if it does not already exist in the base directory.