### PR TITLE
support python 3.12

### DIFF
--- a/tools/web-fuzzing-introspection/requirements.txt
+++ b/tools/web-fuzzing-introspection/requirements.txt
@@ -5,7 +5,7 @@ Jinja2==3.1.6
 MarkupSafe==2.1.2
 Werkzeug==3.0.6
 requests==2.32.3
-pyyaml==6.0
+pyyaml==6.0.2
 orjson==3.10.0
 flask_smorest==0.44.0
 marshmallow==3.21.0


### PR DESCRIPTION
Fix pip install error

```log
python3 -m pip install -r ./tools/web-fuzzing-introspection/requirements.txt
Collecting click==8.1.3 (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 1))
  Using cached click-8.1.3-py3-none-any.whl.metadata (3.2 kB)
Collecting Flask==3.0.2 (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 2))
  Using cached flask-3.0.2-py3-none-any.whl.metadata (3.6 kB)
Collecting itsdangerous==2.1.2 (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 3))
  Using cached itsdangerous-2.1.2-py3-none-any.whl.metadata (2.9 kB)
Requirement already satisfied: Jinja2==3.1.6 in ./scripts/oss-fuzz-gen-e2e/workdir/.venv/lib/python3.12/site-packages (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 4)) (3.1.6)
Collecting MarkupSafe==2.1.2 (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 5))
  Using cached MarkupSafe-2.1.2.tar.gz (19 kB)
  Preparing metadata (setup.py) ... done
Collecting Werkzeug==3.0.6 (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 6))
  Using cached werkzeug-3.0.6-py3-none-any.whl.metadata (3.7 kB)
Requirement already satisfied: requests==2.32.3 in ./scripts/oss-fuzz-gen-e2e/workdir/.venv/lib/python3.12/site-packages (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 7)) (2.32.3)
Collecting pyyaml==6.0 (from -r ./tools/web-fuzzing-introspection/requirements.txt (line 8))
  Using cached PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [67 lines of output]
      /tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: MIT License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/home/yuwei/afgen/fuzz-introspector/scripts/oss-fuzz-gen-e2e/workdir/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/home/yuwei/afgen/fuzz-introspector/scripts/oss-fuzz-gen-e2e/workdir/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/yuwei/afgen/fuzz-introspector/scripts/oss-fuzz-gen-e2e/workdir/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 312, in run
          self.find_sources()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 320, in find_sources
          mm.run()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 543, in run
          self.add_defaults()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 581, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/command/sdist.py", line 109, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/sdist.py", line 245, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/sdist.py", line 330, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 204, in get_source_files
        File "/tmp/pip-build-env-0_fn5bc7/overlay/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 131, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```