### PR TITLE
webapp: use __slots__ to save memory

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/data_storage.py
+++ b/tools/web-fuzzing-introspection/app/webapp/data_storage.py
@@ -112,7 +112,6 @@ def get_project_branch_blockers(project: str) -> List[BranchBlocker]:
 
 def retrieve_functions(proj: str, is_constructor: bool) -> List[Function]:
     """Retrieve functions or constructors"""
-    print('Retrieving functions for project:', proj)
     if is_constructor:
         json_path = all_constructors_file.replace('{PROJ}', proj)
     else:


### PR DESCRIPTION
Saves around 1/3 of memory when loading functions measured by pympler/asizeof. We should apply this on the rest of the data structures as well, but we should make sure the fields in those are not assigned at any point.