### PR TITLE
frontend: Add fail safe configuration for tree-sitter node text decode

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_c_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_c_cpp.py
@@ -140,14 +140,14 @@ class CppSourceCodeFile(SourceCodeFile):
                 for child in new_namespace.children:
                     if not child.is_named or not child.text:
                         continue
-                    namespace += '::' + child.text.decode()
+                    namespace += '::' + child.text.decode(encoding='utf-8', errors='ignore')
                     if namespace.startswith('::'):
                         namespace = namespace[2:]
 
             # General namespace
             elif new_namespace.type == 'namespace_identifier':
                 if new_namespace.text:
-                    namespace += '::' + new_namespace.text.decode()
+                    namespace += '::' + new_namespace.text.decode(encoding='utf-8', errors='ignore')
                     if namespace.startswith('::'):
                         namespace = namespace[2:]
 
@@ -173,15 +173,15 @@ class CppSourceCodeFile(SourceCodeFile):
                 if not enum_item_name or not enum_item_name.text:
                     # Skip anonymous enum items
                     continue
-                item_dict['name'] = enum_item_name.text.decode()
+                item_dict['name'] = enum_item_name.text.decode(encoding='utf-8', errors='ignore')
 
                 if enum_item_value and enum_item_value.text:
-                    item_dict['value'] = enum_item_value.text.decode()
+                    item_dict['value'] = enum_item_value.text.decode(encoding='utf-8', errors='ignore')
 
                 enumerator_list.append(item_dict)
 
         self.enum_defs.append({
-            'name': enum_name_field.text.decode(),
+            'name': enum_name_field.text.decode(encoding='utf-8', errors='ignore'),
             'enumerators': enumerator_list,
             'item_type': 'enum',
             'pos': {
@@ -202,9 +202,9 @@ class CppSourceCodeFile(SourceCodeFile):
 
         self.preproc_defs.append({
             'name':
-            preproc_name_field.text.decode(),
+            preproc_name_field.text.decode(encoding='utf-8', errors='ignore'),
             'type_or_value':
-            preproc_body_field.text.decode(),
+            preproc_body_field.text.decode(encoding='utf-8', errors='ignore'),
             'item_type':
             'preproc_def',
             'pos': {
@@ -224,14 +224,14 @@ class CppSourceCodeFile(SourceCodeFile):
         # Extract name for struct or anonymous struct
         struct_name_field = struct.child_by_field_name('name')
         if struct_name_field and struct_name_field.text:
-            struct_name = struct_name_field.text.decode()
+            struct_name = struct_name_field.text.decode(encoding='utf-8', errors='ignore')
         else:
             parent = struct.parent
             declarator = None
             if parent and parent.type in ['declaration', 'type_definition']:
                 declarator = parent.child_by_field_name('declarator')
             if declarator and declarator.text:
-                struct_name = declarator.text.decode()
+                struct_name = declarator.text.decode(encoding='utf-8', errors='ignore')
             else:
                 # Skip anonymous struct with no name
                 return
@@ -247,8 +247,8 @@ class CppSourceCodeFile(SourceCodeFile):
 
             if child.type == 'field_declaration':
                 fields.append({
-                    'type': child_name.text.decode(),
-                    'name': child_type.text.decode()
+                    'type': child_name.text.decode(encoding='utf-8', errors='ignore'),
+                    'name': child_type.text.decode(encoding='utf-8', errors='ignore')
                 })
         self.struct_defs.append({
             'name': struct_name,
@@ -271,14 +271,14 @@ class CppSourceCodeFile(SourceCodeFile):
         # Extract name for union or anonymous union
         union_name_field = union.child_by_field_name('name')
         if union_name_field and union_name_field.text:
-            union_name = union_name_field.text.decode()
+            union_name = union_name_field.text.decode(encoding='utf-8', errors='ignore')
         else:
             parent = union.parent
             declarator = None
             if parent and parent.type in ['declaration', 'type_definition']:
                 declarator = parent.child_by_field_name('declarator')
             if declarator and declarator.text:
-                union_name = declarator.text.decode()
+                union_name = declarator.text.decode(encoding='utf-8', errors='ignore')
             else:
                 # Skip anonymous union with no name
                 return
@@ -293,8 +293,8 @@ class CppSourceCodeFile(SourceCodeFile):
                 continue
             if child.type == 'field_declaration':
                 fields.append({
-                    'type': child_name.text.decode(),
-                    'name': child_type.text.decode(),
+                    'type': child_name.text.decode(encoding='utf-8', errors='ignore'),
+                    'name': child_type.text.decode(encoding='utf-8', errors='ignore'),
                 })
         self.union_defs.append({
             'name': union_name,
@@ -315,7 +315,7 @@ class CppSourceCodeFile(SourceCodeFile):
             return
 
         typedef_struct: dict[str, Any] = {
-            'name': typedef_declarator_node.text.decode(),
+            'name': typedef_declarator_node.text.decode(encoding='utf-8', errors='ignore'),
             'item_type': 'typedef',
         }
 
@@ -334,9 +334,9 @@ class CppSourceCodeFile(SourceCodeFile):
             # Already handled in the struct/union section
             return
         elif typedef_type.type == 'primitive_type':
-            typedef_struct['type'] = typedef_type.text.decode()
+            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8', errors='ignore')
         elif typedef_type.type == 'sized_type_specifier':
-            typedef_struct['type'] = typedef_type.text.decode()
+            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8', errors='ignore')
 
         self.typedefs.append(typedef_struct)
 
@@ -347,7 +347,7 @@ class CppSourceCodeFile(SourceCodeFile):
             # Skip invalid include statement
             return
 
-        include_path = include_path_node.text.decode().replace(
+        include_path = include_path_node.text.decode(encoding='utf-8', errors='ignore').replace(
             '"', '').replace('>', '').replace('<', '')
         self.includes.add(include_path)
 
@@ -371,14 +371,14 @@ class CppSourceCodeFile(SourceCodeFile):
             if not var_name or not var_name.text:
                 return
 
-            if macro and macro.text and macro.text.decode().startswith(
+            if macro and macro.text and macro.text.decode(encoding='utf-8', errors='ignore').startswith(
                     '#ifdef'):
                 type = 'ifdef'
             else:
                 type = 'ifndef'
             conditions.append({
                 'type': type,
-                'condition': var_name.text.decode(),
+                'condition': var_name.text.decode(encoding='utf-8', errors='ignore'),
             })
         elif macro.type in ['preproc_if', 'preproc_elif']:
             condition = macro.child_by_field_name('condition')
@@ -389,7 +389,7 @@ class CppSourceCodeFile(SourceCodeFile):
 
             conditions.append({
                 'type': 'if',
-                'condition': condition.text.decode(),
+                'condition': condition.text.decode(encoding='utf-8', errors='ignore'),
             })
 
         # Extract #else #elif branches
@@ -460,7 +460,7 @@ class FunctionDefinition():
     def function_source_code_as_text(self) -> str:
         """Returns the source code the function."""
         if self.root and self.root.text:
-            return self.root.text.decode()
+            return self.root.text.decode(encoding='utf-8', errors='ignore')
 
         return ''
 
@@ -520,16 +520,16 @@ class FunctionDefinition():
                 self.valid = False
                 return
 
-            self.name = name_node.text.decode()
+            self.name = name_node.text.decode(encoding='utf-8', errors='ignore')
             for idx, param in enumerate(param_node.children):
                 if param.text:
-                    param_name = param.text.decode()
+                    param_name = param.text.decode(encoding='utf-8', errors='ignore')
                 else:
                     param_name = f'arg{idx}'
                 self.arg_names.append(param_name)
                 self.arg_types.append('auto')
             self.return_type = 'auto'
-            self.sig = self.name + param_node.text.decode()
+            self.sig = self.name + param_node.text.decode(encoding='utf-8', errors='ignore')
             self.complexity = 1
             self.icount = 1
             self.bbcount = 1
@@ -538,17 +538,17 @@ class FunctionDefinition():
 
         # Extract function name and return type
         name_node = self.root.child_by_field_name('declarator')
-        self.sig = name_node.text.decode()
+        self.sig = name_node.text.decode(encoding='utf-8', errors='ignore')
         logger.debug('Extracting information for %s', self.sig)
         param_list_node = None
         for child in name_node.children:
             if 'identifier' in child.type:
-                self.name = child.text.decode()
+                self.name = child.text.decode(encoding='utf-8', errors='ignore')
 
             elif child.type == 'function_declarator':
                 for decl in child.children:
                     if 'identifier' in decl.type:
-                        self.name = decl.text.decode()
+                        self.name = decl.text.decode(encoding='utf-8', errors='ignore')
 
                     elif decl.type == 'parameter_list':
                         param_list_node = decl
@@ -570,12 +570,12 @@ class FunctionDefinition():
             if (new_parent.type == 'class_specifier'
                     and new_parent.child_by_field_name('name') is not None):
                 full_name = new_parent.child_by_field_name(
-                    'name').text.decode() + '::' + full_name
+                    'name').text.decode(encoding='utf-8', errors='ignore') + '::' + full_name
             if new_parent.type == 'namespace_definition':
                 # Ignore anonymous namespaces
                 if new_parent.child_by_field_name('name') is not None:
                     full_name = new_parent.child_by_field_name(
-                        'name').text.decode() + '::' + full_name
+                        'name').text.decode(encoding='utf-8', errors='ignore') + '::' + full_name
             tmp_root = new_parent
         logger.debug('Full function scope not from name: %s', full_name)
 
@@ -592,21 +592,21 @@ class FunctionDefinition():
                         if child.child_by_field_name(
                                 'declarator').type == 'identifier':
                             tmp_name = child.child_by_field_name(
-                                'declarator').text.decode()
+                                'declarator').text.decode(encoding='utf-8', errors='ignore')
             if tmp_node.child_by_field_name('scope') is not None:
                 scope_to_add = tmp_node.child_by_field_name(
-                    'scope').text.decode() + '::'
+                    'scope').text.decode(encoding='utf-8', errors='ignore') + '::'
 
             if tmp_node.type == 'identifier':
-                tmp_name = tmp_node.text.decode()
+                tmp_name = tmp_node.text.decode(encoding='utf-8', errors='ignore')
                 break
             if tmp_node.type == 'field_identifier':
-                tmp_name = tmp_node.text.decode()
+                tmp_name = tmp_node.text.decode(encoding='utf-8', errors='ignore')
                 break
             if tmp_node.child_by_field_name(
                     'name') is not None and tmp_node.child_by_field_name(
                         'name').type == 'identifier':
-                tmp_name = tmp_node.child_by_field_name('name').text.decode()
+                tmp_name = tmp_node.child_by_field_name('name').text.decode(encoding='utf-8', errors='ignore')
             tmp_node = tmp_node.child_by_field_name('declarator')
         if tmp_name:
             logger.debug('Assigning name')
@@ -620,11 +620,11 @@ class FunctionDefinition():
         #    full_name = full_name + self.root.child_by_field_name(
         #    'declarator').child_by_field_name(
         #    'declarator').child_by_field_name(
-        #    'declarator').text.decode()
+        #    'declarator').text.decode(encoding='utf-8', errors='ignore')
         # except:
         #    try:
         #        full_name = full_name + self.root.child_by_field_name(
-        #        'declarator').child_by_field_name('declarator').text.decode()
+        #        'declarator').child_by_field_name('declarator').text.decode(encoding='utf-8', errors='ignore')
         #    except:
 
         # This can happen for e.g. operators
@@ -641,7 +641,7 @@ class FunctionDefinition():
         # Handles return type
         type_node = self.root.child_by_field_name('type')
         if type_node:
-            self.return_type = type_node.text.decode()
+            self.return_type = type_node.text.decode(encoding='utf-8', errors='ignore')
         else:
             self.return_type = 'void'
 
@@ -676,9 +676,9 @@ class FunctionDefinition():
                     pcount, acount, param_name = result
 
                     self.arg_types.append(
-                        f'{param_type.text.decode()}{"*" * pcount}'
+                        f'{param_type.text.decode(encoding="utf-8", errors="ignore")}{"*" * pcount}'
                         f'{"[]" * acount}')
-                    self.arg_names.append(param_name.text.decode().replace(
+                    self.arg_names.append(param_name.text.decode(encoding='utf-8', errors='ignore').replace(
                         '&', ''))
                     self.var_map[self.arg_names[-1]] = self.arg_types[-1]
 
@@ -771,9 +771,9 @@ class FunctionDefinition():
             for call_expr in call_exprs:
                 func_call = call_expr.child_by_field_name('function')
                 args = call_expr.child_by_field_name('arguments')
-                if func_call and func_call.text.decode() == 'assert':
+                if func_call and func_call.text.decode(encoding='utf-8', errors='ignore') == 'assert':
                     self.assert_stmts.append({
-                        'condition': args.text.decode(),
+                        'condition': args.text.decode(encoding='utf-8', errors='ignore'),
                         'pos': {
                             'source_file': self.parent_source.source_file,
                             'line_start': call_expr.start_point.row,
@@ -786,7 +786,7 @@ class FunctionDefinition():
         """Internal helper for processing the function invocation statement."""
         # logger.debug('Current namespace: %s', self.namespace_or_class)
         logger.debug('Processing invoke: %s',
-                     expr.text.decode() if expr.text else '')
+                     expr.text.decode(encoding='utf-8', errors='ignore') if expr.text else '')
         callsites = []
         target_name: str = ''
 
@@ -801,7 +801,7 @@ class FunctionDefinition():
             if func.type in [
                     'identifier', 'qualified_identifier', 'template_function'
             ] and func.text:
-                target_name = func.text.decode()
+                target_name = func.text.decode(encoding='utf-8', errors='ignore')
 
                 # Find the matching function in our project
                 matched_func = get_function_node(
@@ -814,7 +814,7 @@ class FunctionDefinition():
                 else:
                     name_node = func.child_by_field_name('name')
                     if name_node and name_node.text:
-                        target_name2 = name_node.text.decode()
+                        target_name2 = name_node.text.decode(encoding='utf-8', errors='ignore')
                         matched_func2 = get_function_node(
                             target_name2,
                             project.all_functions,
@@ -850,7 +850,7 @@ class FunctionDefinition():
                                         project) -> tuple[Optional[str], str]:
         """Helper for determining the return type of a field expression
         in a chained call and its full qualified name."""
-        # logger.debug('Handling field expression: %s',field_expr.text.decode())
+        # logger.debug('Handling field expression: %s',field_expr.text.decode(encoding='utf-8', errors='ignore'))
         ret_type = None
         object_type = None
 
@@ -862,10 +862,10 @@ class FunctionDefinition():
 
         if field.type == 'template_method':
             name_node = field.child_by_field_name('name')
-            full_name = (name_node.text.decode()
+            full_name = (name_node.text.decode(encoding='utf-8', errors='ignore')
                          if name_node and name_node.text else '')
         else:
-            full_name = field.text.decode() if field.text else ''
+            full_name = field.text.decode(encoding='utf-8', errors='ignore') if field.text else ''
 
         # Chained field access
         if arg.type == 'field_expression':
@@ -878,7 +878,7 @@ class FunctionDefinition():
         # Named object
         elif arg.type in ['identifier', 'qualified_identifier']:
             if arg.text:
-                object_type = self.var_map.get(arg.text.decode())
+                object_type = self.var_map.get(arg.text.decode(encoding='utf-8', errors='ignore'))
         elif arg.type == 'call_expression':
             # Bail, we do not support this yet. Examples of code:
             # "static_cast<impl::xpath_query_impl*>(_impl)->root->eval_string
@@ -901,26 +901,26 @@ class FunctionDefinition():
                            project) -> list[tuple[str, int, int]]:
         """Process and store the callsites of the function."""
         logger.debug('Processing callsite: %s',
-                     stmt.text.decode() if stmt.text else '')
+                     stmt.text.decode(encoding='utf-8', errors='ignore') if stmt.text else '')
         callsites = []
 
         # Call statement
         if stmt.type == 'call_expression':
-            # logger.debug('Handling call expression: %s', stmt.text.decode())
+            # logger.debug('Handling call expression: %s', stmt.text.decode(encoding='utf-8', errors='ignore'))
             callsites.extend(self._process_invoke(stmt, project))
 
         # Constructor call statement
         elif stmt.type == 'new_expression':
-            # logger.debug('Handling new_expression: %s', stmt.text.decode())
+            # logger.debug('Handling new_expression: %s', stmt.text.decode(encoding='utf-8', errors='ignore'))
             ctr_type = stmt.child_by_field_name('type')
             if ctr_type and ctr_type.text:
-                cls = ctr_type.text.decode()
+                cls = ctr_type.text.decode(encoding='utf-8', errors='ignore')
                 cls = f'{cls}::{cls.rsplit("::")[-1]}'
                 callsites.append(
                     (cls, stmt.byte_range[1], stmt.start_point.row + 1))
 
         elif stmt.type == 'declaration':
-            # logger.debug('Handling declaration: %s', stmt.text.decode())
+            # logger.debug('Handling declaration: %s', stmt.text.decode(encoding='utf-8', errors='ignore'))
             var_type = ''
             var_type_obj = stmt.child_by_field_name('type')
 
@@ -938,16 +938,16 @@ class FunctionDefinition():
                     if var_type_obj.child_by_field_name('scope') is not None:
                         scope = var_type_obj.child_by_field_name('scope')
                         if scope and scope.text:
-                            var_type += scope.text.decode()
+                            var_type += scope.text.decode(encoding='utf-8', errors='ignore')
                     var_type += '::'
                     var_type_obj = var_type_obj.child_by_field_name('name')
 
                 if var_type_obj and var_type_obj.type == 'template_type':
                     template_name = var_type_obj.child_by_field_name('name')
                     if template_name and template_name.text:
-                        var_type += template_name.text.decode()
+                        var_type += template_name.text.decode(encoding='utf-8', errors='ignore')
                 else:
-                    var_type += (var_type_obj.text.decode()
+                    var_type += (var_type_obj.text.decode(encoding='utf-8', errors='ignore')
                                  if var_type_obj and var_type_obj.text else '')
 
                 break
@@ -962,7 +962,7 @@ class FunctionDefinition():
                 return []
 
             logger.debug('Extracted declaration: Type `%s` : Name `%s`',
-                         var_type, var_name.text.decode())
+                         var_type, var_name.text.decode(encoding='utf-8', errors='ignore'))
             # Handles implicit default constructor call
             if var_name.type == 'identifier':
                 # We're looking for a constructor, so add the name as it
@@ -1000,7 +1000,7 @@ class FunctionDefinition():
             var_type = f'{var_type}{"*" * pcount}{"[]" * acount}'
             name_text = var_name.text
             if name_text:
-                self.var_map[name_text.decode().replace('&', '')] = var_type
+                self.var_map[name_text.decode(encoding='utf-8', errors='ignore').replace('&', '')] = var_type
 
         return callsites
 

--- a/src/fuzz_introspector/frontends/frontend_c_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_c_cpp.py
@@ -140,14 +140,16 @@ class CppSourceCodeFile(SourceCodeFile):
                 for child in new_namespace.children:
                     if not child.is_named or not child.text:
                         continue
-                    namespace += '::' + child.text.decode(encoding='utf-8', errors='ignore')
+                    namespace += '::' + child.text.decode(encoding='utf-8',
+                                                          errors='ignore')
                     if namespace.startswith('::'):
                         namespace = namespace[2:]
 
             # General namespace
             elif new_namespace.type == 'namespace_identifier':
                 if new_namespace.text:
-                    namespace += '::' + new_namespace.text.decode(encoding='utf-8', errors='ignore')
+                    namespace += '::' + new_namespace.text.decode(
+                        encoding='utf-8', errors='ignore')
                     if namespace.startswith('::'):
                         namespace = namespace[2:]
 
@@ -173,17 +175,22 @@ class CppSourceCodeFile(SourceCodeFile):
                 if not enum_item_name or not enum_item_name.text:
                     # Skip anonymous enum items
                     continue
-                item_dict['name'] = enum_item_name.text.decode(encoding='utf-8', errors='ignore')
+                item_dict['name'] = enum_item_name.text.decode(
+                    encoding='utf-8', errors='ignore')
 
                 if enum_item_value and enum_item_value.text:
-                    item_dict['value'] = enum_item_value.text.decode(encoding='utf-8', errors='ignore')
+                    item_dict['value'] = enum_item_value.text.decode(
+                        encoding='utf-8', errors='ignore')
 
                 enumerator_list.append(item_dict)
 
         self.enum_defs.append({
-            'name': enum_name_field.text.decode(encoding='utf-8', errors='ignore'),
-            'enumerators': enumerator_list,
-            'item_type': 'enum',
+            'name':
+            enum_name_field.text.decode(encoding='utf-8', errors='ignore'),
+            'enumerators':
+            enumerator_list,
+            'item_type':
+            'enum',
             'pos': {
                 'source_file': self.source_file,
                 'line_start': enum.start_point.row,
@@ -224,14 +231,16 @@ class CppSourceCodeFile(SourceCodeFile):
         # Extract name for struct or anonymous struct
         struct_name_field = struct.child_by_field_name('name')
         if struct_name_field and struct_name_field.text:
-            struct_name = struct_name_field.text.decode(encoding='utf-8', errors='ignore')
+            struct_name = struct_name_field.text.decode(encoding='utf-8',
+                                                        errors='ignore')
         else:
             parent = struct.parent
             declarator = None
             if parent and parent.type in ['declaration', 'type_definition']:
                 declarator = parent.child_by_field_name('declarator')
             if declarator and declarator.text:
-                struct_name = declarator.text.decode(encoding='utf-8', errors='ignore')
+                struct_name = declarator.text.decode(encoding='utf-8',
+                                                     errors='ignore')
             else:
                 # Skip anonymous struct with no name
                 return
@@ -247,8 +256,10 @@ class CppSourceCodeFile(SourceCodeFile):
 
             if child.type == 'field_declaration':
                 fields.append({
-                    'type': child_name.text.decode(encoding='utf-8', errors='ignore'),
-                    'name': child_type.text.decode(encoding='utf-8', errors='ignore')
+                    'type':
+                    child_name.text.decode(encoding='utf-8', errors='ignore'),
+                    'name':
+                    child_type.text.decode(encoding='utf-8', errors='ignore')
                 })
         self.struct_defs.append({
             'name': struct_name,
@@ -271,14 +282,16 @@ class CppSourceCodeFile(SourceCodeFile):
         # Extract name for union or anonymous union
         union_name_field = union.child_by_field_name('name')
         if union_name_field and union_name_field.text:
-            union_name = union_name_field.text.decode(encoding='utf-8', errors='ignore')
+            union_name = union_name_field.text.decode(encoding='utf-8',
+                                                      errors='ignore')
         else:
             parent = union.parent
             declarator = None
             if parent and parent.type in ['declaration', 'type_definition']:
                 declarator = parent.child_by_field_name('declarator')
             if declarator and declarator.text:
-                union_name = declarator.text.decode(encoding='utf-8', errors='ignore')
+                union_name = declarator.text.decode(encoding='utf-8',
+                                                    errors='ignore')
             else:
                 # Skip anonymous union with no name
                 return
@@ -293,8 +306,10 @@ class CppSourceCodeFile(SourceCodeFile):
                 continue
             if child.type == 'field_declaration':
                 fields.append({
-                    'type': child_name.text.decode(encoding='utf-8', errors='ignore'),
-                    'name': child_type.text.decode(encoding='utf-8', errors='ignore'),
+                    'type':
+                    child_name.text.decode(encoding='utf-8', errors='ignore'),
+                    'name':
+                    child_type.text.decode(encoding='utf-8', errors='ignore'),
                 })
         self.union_defs.append({
             'name': union_name,
@@ -315,8 +330,11 @@ class CppSourceCodeFile(SourceCodeFile):
             return
 
         typedef_struct: dict[str, Any] = {
-            'name': typedef_declarator_node.text.decode(encoding='utf-8', errors='ignore'),
-            'item_type': 'typedef',
+            'name':
+            typedef_declarator_node.text.decode(encoding='utf-8',
+                                                errors='ignore'),
+            'item_type':
+            'typedef',
         }
 
         typedef_struct['pos'] = {
@@ -334,9 +352,11 @@ class CppSourceCodeFile(SourceCodeFile):
             # Already handled in the struct/union section
             return
         elif typedef_type.type == 'primitive_type':
-            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8', errors='ignore')
+            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8',
+                                                              errors='ignore')
         elif typedef_type.type == 'sized_type_specifier':
-            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8', errors='ignore')
+            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8',
+                                                              errors='ignore')
 
         self.typedefs.append(typedef_struct)
 
@@ -347,8 +367,10 @@ class CppSourceCodeFile(SourceCodeFile):
             # Skip invalid include statement
             return
 
-        include_path = include_path_node.text.decode(encoding='utf-8', errors='ignore').replace(
-            '"', '').replace('>', '').replace('<', '')
+        include_path = include_path_node.text.decode(
+            encoding='utf-8',
+            errors='ignore').replace('"', '').replace('>',
+                                                      '').replace('<', '')
         self.includes.add(include_path)
 
     def _process_macro_block(self, macro: Node, namespace: str,
@@ -371,14 +393,16 @@ class CppSourceCodeFile(SourceCodeFile):
             if not var_name or not var_name.text:
                 return
 
-            if macro and macro.text and macro.text.decode(encoding='utf-8', errors='ignore').startswith(
-                    '#ifdef'):
+            if macro and macro.text and macro.text.decode(
+                    encoding='utf-8', errors='ignore').startswith('#ifdef'):
                 type = 'ifdef'
             else:
                 type = 'ifndef'
             conditions.append({
-                'type': type,
-                'condition': var_name.text.decode(encoding='utf-8', errors='ignore'),
+                'type':
+                type,
+                'condition':
+                var_name.text.decode(encoding='utf-8', errors='ignore'),
             })
         elif macro.type in ['preproc_if', 'preproc_elif']:
             condition = macro.child_by_field_name('condition')
@@ -388,8 +412,10 @@ class CppSourceCodeFile(SourceCodeFile):
                 return
 
             conditions.append({
-                'type': 'if',
-                'condition': condition.text.decode(encoding='utf-8', errors='ignore'),
+                'type':
+                'if',
+                'condition':
+                condition.text.decode(encoding='utf-8', errors='ignore'),
             })
 
         # Extract #else #elif branches
@@ -520,16 +546,19 @@ class FunctionDefinition():
                 self.valid = False
                 return
 
-            self.name = name_node.text.decode(encoding='utf-8', errors='ignore')
+            self.name = name_node.text.decode(encoding='utf-8',
+                                              errors='ignore')
             for idx, param in enumerate(param_node.children):
                 if param.text:
-                    param_name = param.text.decode(encoding='utf-8', errors='ignore')
+                    param_name = param.text.decode(encoding='utf-8',
+                                                   errors='ignore')
                 else:
                     param_name = f'arg{idx}'
                 self.arg_names.append(param_name)
                 self.arg_types.append('auto')
             self.return_type = 'auto'
-            self.sig = self.name + param_node.text.decode(encoding='utf-8', errors='ignore')
+            self.sig = self.name + param_node.text.decode(encoding='utf-8',
+                                                          errors='ignore')
             self.complexity = 1
             self.icount = 1
             self.bbcount = 1
@@ -543,12 +572,14 @@ class FunctionDefinition():
         param_list_node = None
         for child in name_node.children:
             if 'identifier' in child.type:
-                self.name = child.text.decode(encoding='utf-8', errors='ignore')
+                self.name = child.text.decode(encoding='utf-8',
+                                              errors='ignore')
 
             elif child.type == 'function_declarator':
                 for decl in child.children:
                     if 'identifier' in decl.type:
-                        self.name = decl.text.decode(encoding='utf-8', errors='ignore')
+                        self.name = decl.text.decode(encoding='utf-8',
+                                                     errors='ignore')
 
                     elif decl.type == 'parameter_list':
                         param_list_node = decl
@@ -569,13 +600,14 @@ class FunctionDefinition():
                 break
             if (new_parent.type == 'class_specifier'
                     and new_parent.child_by_field_name('name') is not None):
-                full_name = new_parent.child_by_field_name(
-                    'name').text.decode(encoding='utf-8', errors='ignore') + '::' + full_name
+                full_name = new_parent.child_by_field_name('name').text.decode(
+                    encoding='utf-8', errors='ignore') + '::' + full_name
             if new_parent.type == 'namespace_definition':
                 # Ignore anonymous namespaces
                 if new_parent.child_by_field_name('name') is not None:
                     full_name = new_parent.child_by_field_name(
-                        'name').text.decode(encoding='utf-8', errors='ignore') + '::' + full_name
+                        'name').text.decode(encoding='utf-8',
+                                            errors='ignore') + '::' + full_name
             tmp_root = new_parent
         logger.debug('Full function scope not from name: %s', full_name)
 
@@ -592,21 +624,26 @@ class FunctionDefinition():
                         if child.child_by_field_name(
                                 'declarator').type == 'identifier':
                             tmp_name = child.child_by_field_name(
-                                'declarator').text.decode(encoding='utf-8', errors='ignore')
+                                'declarator').text.decode(encoding='utf-8',
+                                                          errors='ignore')
             if tmp_node.child_by_field_name('scope') is not None:
                 scope_to_add = tmp_node.child_by_field_name(
-                    'scope').text.decode(encoding='utf-8', errors='ignore') + '::'
+                    'scope').text.decode(encoding='utf-8',
+                                         errors='ignore') + '::'
 
             if tmp_node.type == 'identifier':
-                tmp_name = tmp_node.text.decode(encoding='utf-8', errors='ignore')
+                tmp_name = tmp_node.text.decode(encoding='utf-8',
+                                                errors='ignore')
                 break
             if tmp_node.type == 'field_identifier':
-                tmp_name = tmp_node.text.decode(encoding='utf-8', errors='ignore')
+                tmp_name = tmp_node.text.decode(encoding='utf-8',
+                                                errors='ignore')
                 break
             if tmp_node.child_by_field_name(
                     'name') is not None and tmp_node.child_by_field_name(
                         'name').type == 'identifier':
-                tmp_name = tmp_node.child_by_field_name('name').text.decode(encoding='utf-8', errors='ignore')
+                tmp_name = tmp_node.child_by_field_name('name').text.decode(
+                    encoding='utf-8', errors='ignore')
             tmp_node = tmp_node.child_by_field_name('declarator')
         if tmp_name:
             logger.debug('Assigning name')
@@ -624,7 +661,8 @@ class FunctionDefinition():
         # except:
         #    try:
         #        full_name = full_name + self.root.child_by_field_name(
-        #        'declarator').child_by_field_name('declarator').text.decode(encoding='utf-8', errors='ignore')
+        #        'declarator').child_by_field_name(
+        #        'declarator').text.decode(encoding='utf-8', errors='ignore')
         #    except:
 
         # This can happen for e.g. operators
@@ -641,7 +679,8 @@ class FunctionDefinition():
         # Handles return type
         type_node = self.root.child_by_field_name('type')
         if type_node:
-            self.return_type = type_node.text.decode(encoding='utf-8', errors='ignore')
+            self.return_type = type_node.text.decode(encoding='utf-8',
+                                                     errors='ignore')
         else:
             self.return_type = 'void'
 
@@ -678,8 +717,10 @@ class FunctionDefinition():
                     self.arg_types.append(
                         f'{param_type.text.decode(encoding="utf-8", errors="ignore")}{"*" * pcount}'
                         f'{"[]" * acount}')
-                    self.arg_names.append(param_name.text.decode(encoding='utf-8', errors='ignore').replace(
-                        '&', ''))
+                    self.arg_names.append(
+                        param_name.text.decode(encoding='utf-8',
+                                               errors='ignore').replace(
+                                                   '&', ''))
                     self.var_map[self.arg_names[-1]] = self.arg_types[-1]
 
         # Handles other fields
@@ -771,9 +812,11 @@ class FunctionDefinition():
             for call_expr in call_exprs:
                 func_call = call_expr.child_by_field_name('function')
                 args = call_expr.child_by_field_name('arguments')
-                if func_call and func_call.text.decode(encoding='utf-8', errors='ignore') == 'assert':
+                if func_call and func_call.text.decode(
+                        encoding='utf-8', errors='ignore') == 'assert':
                     self.assert_stmts.append({
-                        'condition': args.text.decode(encoding='utf-8', errors='ignore'),
+                        'condition':
+                        args.text.decode(encoding='utf-8', errors='ignore'),
                         'pos': {
                             'source_file': self.parent_source.source_file,
                             'line_start': call_expr.start_point.row,
@@ -785,8 +828,10 @@ class FunctionDefinition():
                         project) -> list[tuple[str, int, int]]:
         """Internal helper for processing the function invocation statement."""
         # logger.debug('Current namespace: %s', self.namespace_or_class)
-        logger.debug('Processing invoke: %s',
-                     expr.text.decode(encoding='utf-8', errors='ignore') if expr.text else '')
+        logger.debug(
+            'Processing invoke: %s',
+            expr.text.decode(encoding='utf-8', errors='ignore')
+            if expr.text else '')
         callsites = []
         target_name: str = ''
 
@@ -801,7 +846,8 @@ class FunctionDefinition():
             if func.type in [
                     'identifier', 'qualified_identifier', 'template_function'
             ] and func.text:
-                target_name = func.text.decode(encoding='utf-8', errors='ignore')
+                target_name = func.text.decode(encoding='utf-8',
+                                               errors='ignore')
 
                 # Find the matching function in our project
                 matched_func = get_function_node(
@@ -814,7 +860,8 @@ class FunctionDefinition():
                 else:
                     name_node = func.child_by_field_name('name')
                     if name_node and name_node.text:
-                        target_name2 = name_node.text.decode(encoding='utf-8', errors='ignore')
+                        target_name2 = name_node.text.decode(encoding='utf-8',
+                                                             errors='ignore')
                         matched_func2 = get_function_node(
                             target_name2,
                             project.all_functions,
@@ -850,7 +897,6 @@ class FunctionDefinition():
                                         project) -> tuple[Optional[str], str]:
         """Helper for determining the return type of a field expression
         in a chained call and its full qualified name."""
-        # logger.debug('Handling field expression: %s',field_expr.text.decode(encoding='utf-8', errors='ignore'))
         ret_type = None
         object_type = None
 
@@ -862,10 +908,12 @@ class FunctionDefinition():
 
         if field.type == 'template_method':
             name_node = field.child_by_field_name('name')
-            full_name = (name_node.text.decode(encoding='utf-8', errors='ignore')
+            full_name = (name_node.text.decode(encoding='utf-8',
+                                               errors='ignore')
                          if name_node and name_node.text else '')
         else:
-            full_name = field.text.decode(encoding='utf-8', errors='ignore') if field.text else ''
+            full_name = field.text.decode(
+                encoding='utf-8', errors='ignore') if field.text else ''
 
         # Chained field access
         if arg.type == 'field_expression':
@@ -878,7 +926,8 @@ class FunctionDefinition():
         # Named object
         elif arg.type in ['identifier', 'qualified_identifier']:
             if arg.text:
-                object_type = self.var_map.get(arg.text.decode(encoding='utf-8', errors='ignore'))
+                object_type = self.var_map.get(
+                    arg.text.decode(encoding='utf-8', errors='ignore'))
         elif arg.type == 'call_expression':
             # Bail, we do not support this yet. Examples of code:
             # "static_cast<impl::xpath_query_impl*>(_impl)->root->eval_string
@@ -900,18 +949,18 @@ class FunctionDefinition():
     def _process_callsites(self, stmt: Node,
                            project) -> list[tuple[str, int, int]]:
         """Process and store the callsites of the function."""
-        logger.debug('Processing callsite: %s',
-                     stmt.text.decode(encoding='utf-8', errors='ignore') if stmt.text else '')
+        logger.debug(
+            'Processing callsite: %s',
+            stmt.text.decode(encoding='utf-8', errors='ignore')
+            if stmt.text else '')
         callsites = []
 
         # Call statement
         if stmt.type == 'call_expression':
-            # logger.debug('Handling call expression: %s', stmt.text.decode(encoding='utf-8', errors='ignore'))
             callsites.extend(self._process_invoke(stmt, project))
 
         # Constructor call statement
         elif stmt.type == 'new_expression':
-            # logger.debug('Handling new_expression: %s', stmt.text.decode(encoding='utf-8', errors='ignore'))
             ctr_type = stmt.child_by_field_name('type')
             if ctr_type and ctr_type.text:
                 cls = ctr_type.text.decode(encoding='utf-8', errors='ignore')
@@ -920,7 +969,6 @@ class FunctionDefinition():
                     (cls, stmt.byte_range[1], stmt.start_point.row + 1))
 
         elif stmt.type == 'declaration':
-            # logger.debug('Handling declaration: %s', stmt.text.decode(encoding='utf-8', errors='ignore'))
             var_type = ''
             var_type_obj = stmt.child_by_field_name('type')
 
@@ -938,16 +986,19 @@ class FunctionDefinition():
                     if var_type_obj.child_by_field_name('scope') is not None:
                         scope = var_type_obj.child_by_field_name('scope')
                         if scope and scope.text:
-                            var_type += scope.text.decode(encoding='utf-8', errors='ignore')
+                            var_type += scope.text.decode(encoding='utf-8',
+                                                          errors='ignore')
                     var_type += '::'
                     var_type_obj = var_type_obj.child_by_field_name('name')
 
                 if var_type_obj and var_type_obj.type == 'template_type':
                     template_name = var_type_obj.child_by_field_name('name')
                     if template_name and template_name.text:
-                        var_type += template_name.text.decode(encoding='utf-8', errors='ignore')
+                        var_type += template_name.text.decode(encoding='utf-8',
+                                                              errors='ignore')
                 else:
-                    var_type += (var_type_obj.text.decode(encoding='utf-8', errors='ignore')
+                    var_type += (var_type_obj.text.decode(encoding='utf-8',
+                                                          errors='ignore')
                                  if var_type_obj and var_type_obj.text else '')
 
                 break
@@ -961,8 +1012,9 @@ class FunctionDefinition():
                 logger.debug('Could not extract necessary attributes')
                 return []
 
-            logger.debug('Extracted declaration: Type `%s` : Name `%s`',
-                         var_type, var_name.text.decode(encoding='utf-8', errors='ignore'))
+            logger.debug(
+                'Extracted declaration: Type `%s` : Name `%s`', var_type,
+                var_name.text.decode(encoding='utf-8', errors='ignore'))
             # Handles implicit default constructor call
             if var_name.type == 'identifier':
                 # We're looking for a constructor, so add the name as it
@@ -1000,7 +1052,9 @@ class FunctionDefinition():
             var_type = f'{var_type}{"*" * pcount}{"[]" * acount}'
             name_text = var_name.text
             if name_text:
-                self.var_map[name_text.decode(encoding='utf-8', errors='ignore').replace('&', '')] = var_type
+                self.var_map[name_text.decode(encoding='utf-8',
+                                              errors='ignore').replace(
+                                                  '&', '')] = var_type
 
         return callsites
 

--- a/src/fuzz_introspector/frontends/frontend_go.py
+++ b/src/fuzz_introspector/frontends/frontend_go.py
@@ -92,7 +92,9 @@ class GoSourceCodeFile(SourceCodeFile):
 
                     for path in import_spec.children:
                         if path.type == 'import_spec':
-                            path = path.text.decode(encoding='utf-8', errors='ignore').replace('"', '')
+                            path = path.text.decode(encoding='utf-8',
+                                                    errors='ignore').replace(
+                                                        '"', '')
                             # Only store the package name, not full path
                             import_set.add(path.rsplit('/', 1)[-1])
 
@@ -450,15 +452,18 @@ class FunctionMethod():
                     receiver_type = child.child_by_field_name('type')
 
                     if receiver_name and receiver_type:
-                        self.receiver = receiver_type.text.decode(encoding='utf-8', errors='ignore')
-                        self.receiver_name = receiver_name.text.decode(encoding='utf-8', errors='ignore')
+                        self.receiver = receiver_type.text.decode(
+                            encoding='utf-8', errors='ignore')
+                        self.receiver_name = receiver_name.text.decode(
+                            encoding='utf-8', errors='ignore')
                         self.var_map[self.receiver_name] = self.receiver
 
         # Process name
         name_node = self.root
         while name_node.child_by_field_name('name') is not None:
             name_node = name_node.child_by_field_name('name')
-            self.name = name_node.text.decode(encoding='utf-8', errors='ignore')
+            self.name = name_node.text.decode(encoding='utf-8',
+                                              errors='ignore')
         if self.receiver:
             self.name = f'{self.receiver}.{self.name}'
 
@@ -479,12 +484,14 @@ class FunctionMethod():
                     param_tmp = param
                     while param_tmp.child_by_field_name('name') is not None:
                         param_tmp = param_tmp.child_by_field_name('name')
-                    param_name = param_tmp.text.decode(encoding='utf-8', errors='ignore')
+                    param_name = param_tmp.text.decode(encoding='utf-8',
+                                                       errors='ignore')
 
                     # Param type
                     if not param.child_by_field_name('type'):
                         continue
-                    type_str = param.child_by_field_name('type').text.decode(encoding='utf-8', errors='ignore')
+                    type_str = param.child_by_field_name('type').text.decode(
+                        encoding='utf-8', errors='ignore')
                     param_tmp = param
                     while param_tmp.child_by_field_name(
                             'declarator') is not None:
@@ -505,7 +512,8 @@ class FunctionMethod():
         # Process return value
         result = self.root.child_by_field_name('result')
         if result:
-            self.return_type = result.text.decode(encoding='utf-8', errors='ignore')
+            self.return_type = result.text.decode(encoding='utf-8',
+                                                  errors='ignore')
         else:
             self.return_type = 'void'
 
@@ -582,12 +590,14 @@ class FunctionMethod():
         # Simple call
         if call_child.type == 'identifier':
             if call_child.text:
-                target_name = call_child.text.decode(encoding='utf-8', errors='ignore')
+                target_name = call_child.text.decode(encoding='utf-8',
+                                                     errors='ignore')
 
         # Package/method call
         if call_child.type == 'selector_expression':
             if call_child.text:
-                target_name = call_child.text.decode(encoding='utf-8', errors='ignore')
+                target_name = call_child.text.decode(encoding='utf-8',
+                                                     errors='ignore')
 
             # Variable call
             split_call = target_name.split('.') if target_name else []
@@ -629,14 +639,17 @@ class FunctionMethod():
 
             # Identifier
             if child.type == 'identifier':
-                if child.text and child.text.decode(encoding='utf-8', errors='ignore') in self.var_map:
-                    return self.var_map[child.text.decode(encoding='utf-8', errors='ignore')]
+                if child.text and child.text.decode(
+                        encoding='utf-8', errors='ignore') in self.var_map:
+                    return self.var_map[child.text.decode(encoding='utf-8',
+                                                          errors='ignore')]
 
             # Composite Literal
             elif child.type == 'composite_literal':
                 composite_type = child.child_by_field_name('type')
                 if composite_type and composite_type.text:
-                    return composite_type.text.decode(encoding='utf-8', errors='ignore')
+                    return composite_type.text.decode(encoding='utf-8',
+                                                      errors='ignore')
 
             # Call expression
             elif child.type == 'call_expression':
@@ -655,17 +668,20 @@ class FunctionMethod():
                 if target_name == 'new':
                     for arg in args.children:
                         if arg.type.endswith('identifier') and arg.text:
-                            return arg.text.decode(encoding='utf-8', errors='ignore')
+                            return arg.text.decode(encoding='utf-8',
+                                                   errors='ignore')
 
                 elif target_name == 'make':
                     for arg in args.children:
                         type_node = arg.child_by_field_name('value')
                         if type_node and type_node.text:
-                            return type_node.text.decode(encoding='utf-8', errors='ignore')
+                            return type_node.text.decode(encoding='utf-8',
+                                                         errors='ignore')
 
                         type_node = arg.child_by_field_name('element')
                         if type_node and type_node.text:
-                            return type_node.text.decode(encoding='utf-8', errors='ignore')
+                            return type_node.text.decode(encoding='utf-8',
+                                                         errors='ignore')
 
             # Selector expression
             elif child.type == 'selector_expression':
@@ -680,7 +696,8 @@ class FunctionMethod():
                 if not op or not op.text:
                     continue
 
-                parent_type = self.var_map.get(op.text.decode(encoding='utf-8', errors='ignore'))
+                parent_type = self.var_map.get(
+                    op.text.decode(encoding='utf-8', errors='ignore'))
                 if parent_type:
                     if '[' in parent_type and ']' in parent_type:
                         return parent_type.rsplit(']', 1)[-1]
@@ -712,7 +729,8 @@ class FunctionMethod():
 
                 for child in left.children:
                     if child.type == 'identifier' and child.text:
-                        decl_name = child.text.decode(encoding='utf-8', errors='ignore')
+                        decl_name = child.text.decode(encoding='utf-8',
+                                                      errors='ignore')
 
                 decl_type = self._detect_variable_type(right, all_funcs_meths)
 
@@ -733,13 +751,16 @@ class FunctionMethod():
 
                     for left_child in left.children:
                         if left_child.type == 'identifier' and left_child.text:
-                            decl_name = left_child.text.decode(encoding='utf-8', errors='ignore')
+                            decl_name = left_child.text.decode(
+                                encoding='utf-8', errors='ignore')
 
                     if right.type == 'identifier':
                         if not right.text:
                             continue
 
-                        decl_type = self.var_map.get(right.text.decode(encoding='utf-8', errors='ignore'), '')
+                        decl_type = self.var_map.get(
+                            right.text.decode(encoding='utf-8',
+                                              errors='ignore'), '')
                         if decl_type and '[' in decl_type and ']' in decl_type:
                             decl_type = decl_type.split(']', 1)[-1]
                         elif decl_type == 'string':

--- a/src/fuzz_introspector/frontends/frontend_go.py
+++ b/src/fuzz_introspector/frontends/frontend_go.py
@@ -92,7 +92,7 @@ class GoSourceCodeFile(SourceCodeFile):
 
                     for path in import_spec.children:
                         if path.type == 'import_spec':
-                            path = path.text.decode().replace('"', '')
+                            path = path.text.decode(encoding='utf-8', errors='ignore').replace('"', '')
                             # Only store the package name, not full path
                             import_set.add(path.rsplit('/', 1)[-1])
 
@@ -388,7 +388,7 @@ class FunctionMethod():
     def function_source_code_as_text(self) -> str:
         """Returns the source code the function."""
         if self.root and self.root.text:
-            return self.root.text.decode()
+            return self.root.text.decode(encoding='utf-8', errors='ignore')
 
         return ''
 
@@ -450,15 +450,15 @@ class FunctionMethod():
                     receiver_type = child.child_by_field_name('type')
 
                     if receiver_name and receiver_type:
-                        self.receiver = receiver_type.text.decode()
-                        self.receiver_name = receiver_name.text.decode()
+                        self.receiver = receiver_type.text.decode(encoding='utf-8', errors='ignore')
+                        self.receiver_name = receiver_name.text.decode(encoding='utf-8', errors='ignore')
                         self.var_map[self.receiver_name] = self.receiver
 
         # Process name
         name_node = self.root
         while name_node.child_by_field_name('name') is not None:
             name_node = name_node.child_by_field_name('name')
-            self.name = name_node.text.decode()
+            self.name = name_node.text.decode(encoding='utf-8', errors='ignore')
         if self.receiver:
             self.name = f'{self.receiver}.{self.name}'
 
@@ -479,12 +479,12 @@ class FunctionMethod():
                     param_tmp = param
                     while param_tmp.child_by_field_name('name') is not None:
                         param_tmp = param_tmp.child_by_field_name('name')
-                    param_name = param_tmp.text.decode()
+                    param_name = param_tmp.text.decode(encoding='utf-8', errors='ignore')
 
                     # Param type
                     if not param.child_by_field_name('type'):
                         continue
-                    type_str = param.child_by_field_name('type').text.decode()
+                    type_str = param.child_by_field_name('type').text.decode(encoding='utf-8', errors='ignore')
                     param_tmp = param
                     while param_tmp.child_by_field_name(
                             'declarator') is not None:
@@ -505,7 +505,7 @@ class FunctionMethod():
         # Process return value
         result = self.root.child_by_field_name('result')
         if result:
-            self.return_type = result.text.decode()
+            self.return_type = result.text.decode(encoding='utf-8', errors='ignore')
         else:
             self.return_type = 'void'
 
@@ -582,12 +582,12 @@ class FunctionMethod():
         # Simple call
         if call_child.type == 'identifier':
             if call_child.text:
-                target_name = call_child.text.decode()
+                target_name = call_child.text.decode(encoding='utf-8', errors='ignore')
 
         # Package/method call
         if call_child.type == 'selector_expression':
             if call_child.text:
-                target_name = call_child.text.decode()
+                target_name = call_child.text.decode(encoding='utf-8', errors='ignore')
 
             # Variable call
             split_call = target_name.split('.') if target_name else []
@@ -629,14 +629,14 @@ class FunctionMethod():
 
             # Identifier
             if child.type == 'identifier':
-                if child.text and child.text.decode() in self.var_map:
-                    return self.var_map[child.text.decode()]
+                if child.text and child.text.decode(encoding='utf-8', errors='ignore') in self.var_map:
+                    return self.var_map[child.text.decode(encoding='utf-8', errors='ignore')]
 
             # Composite Literal
             elif child.type == 'composite_literal':
                 composite_type = child.child_by_field_name('type')
                 if composite_type and composite_type.text:
-                    return composite_type.text.decode()
+                    return composite_type.text.decode(encoding='utf-8', errors='ignore')
 
             # Call expression
             elif child.type == 'call_expression':
@@ -655,17 +655,17 @@ class FunctionMethod():
                 if target_name == 'new':
                     for arg in args.children:
                         if arg.type.endswith('identifier') and arg.text:
-                            return arg.text.decode()
+                            return arg.text.decode(encoding='utf-8', errors='ignore')
 
                 elif target_name == 'make':
                     for arg in args.children:
                         type_node = arg.child_by_field_name('value')
                         if type_node and type_node.text:
-                            return type_node.text.decode()
+                            return type_node.text.decode(encoding='utf-8', errors='ignore')
 
                         type_node = arg.child_by_field_name('element')
                         if type_node and type_node.text:
-                            return type_node.text.decode()
+                            return type_node.text.decode(encoding='utf-8', errors='ignore')
 
             # Selector expression
             elif child.type == 'selector_expression':
@@ -680,7 +680,7 @@ class FunctionMethod():
                 if not op or not op.text:
                     continue
 
-                parent_type = self.var_map.get(op.text.decode())
+                parent_type = self.var_map.get(op.text.decode(encoding='utf-8', errors='ignore'))
                 if parent_type:
                     if '[' in parent_type and ']' in parent_type:
                         return parent_type.rsplit(']', 1)[-1]
@@ -712,7 +712,7 @@ class FunctionMethod():
 
                 for child in left.children:
                     if child.type == 'identifier' and child.text:
-                        decl_name = child.text.decode()
+                        decl_name = child.text.decode(encoding='utf-8', errors='ignore')
 
                 decl_type = self._detect_variable_type(right, all_funcs_meths)
 
@@ -733,13 +733,13 @@ class FunctionMethod():
 
                     for left_child in left.children:
                         if left_child.type == 'identifier' and left_child.text:
-                            decl_name = left_child.text.decode()
+                            decl_name = left_child.text.decode(encoding='utf-8', errors='ignore')
 
                     if right.type == 'identifier':
                         if not right.text:
                             continue
 
-                        decl_type = self.var_map.get(right.text.decode(), '')
+                        decl_type = self.var_map.get(right.text.decode(encoding='utf-8', errors='ignore'), '')
                         if decl_type and '[' in decl_type and ']' in decl_type:
                             decl_type = decl_type.split(']', 1)[-1]
                         elif decl_type == 'string':

--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -104,7 +104,8 @@ class JvmSourceCodeFile(SourceCodeFile):
             for node in nodes:
                 for package in node.children:
                     if package.type in ['scoped_identifier', 'identifier']:
-                        self.package = package.text.decode(encoding='utf-8', errors='ignore')
+                        self.package = package.text.decode(encoding='utf-8',
+                                                           errors='ignore')
 
     def _set_class_interface_declaration(self):
         """Internal helper for retrieving all classes."""
@@ -124,7 +125,8 @@ class JvmSourceCodeFile(SourceCodeFile):
                 wildcard = False
                 for imp in node.children:
                     if imp.type == 'scoped_identifier':
-                        package = imp.text.decode(encoding='utf-8', errors='ignore')
+                        package = imp.text.decode(encoding='utf-8',
+                                                  errors='ignore')
                     if imp.type == 'asterisk':
                         wildcard = True
                 if not wildcard and not package.startswith('java.lang'):
@@ -317,20 +319,25 @@ class JavaMethod():
                 if self.is_constructor:
                     self.name = '<init>'
                 else:
-                    self.name = child.text.decode(encoding='utf-8', errors='ignore')
+                    self.name = child.text.decode(encoding='utf-8',
+                                                  errors='ignore')
                     if self.name == self.parent_source.entrypoint:
                         self.is_entry_method = True
 
             # Process modifiers and annotations
             elif child.type == 'modifiers':
                 for modifier in child.children:
-                    if modifier.text.decode(encoding='utf-8', errors='ignore') == 'public':
+                    if modifier.text.decode(encoding='utf-8',
+                                            errors='ignore') == 'public':
                         self.public = True
-                    if modifier.text.decode(encoding='utf-8', errors='ignore') == 'abstract':
+                    if modifier.text.decode(encoding='utf-8',
+                                            errors='ignore') == 'abstract':
                         self.concrete = False
-                    if modifier.text.decode(encoding='utf-8', errors='ignore') == 'static':
+                    if modifier.text.decode(encoding='utf-8',
+                                            errors='ignore') == 'static':
                         self.static = True
-                    if modifier.text.decode(encoding='utf-8', errors='ignore') == '@FuzzTest':
+                    if modifier.text.decode(encoding='utf-8',
+                                            errors='ignore') == '@FuzzTest':
                         self.is_entry_method = True
 
             # Process arguments
@@ -338,9 +345,11 @@ class JavaMethod():
                 for argument in child.children:
                     if argument.type == 'formal_parameter':
                         arg_name = argument.child_by_field_name(
-                            'name').text.decode(encoding='utf-8', errors='ignore')
+                            'name').text.decode(encoding='utf-8',
+                                                errors='ignore')
                         arg_type = argument.child_by_field_name(
-                            'type').text.decode(encoding='utf-8', errors='ignore')
+                            'type').text.decode(encoding='utf-8',
+                                                errors='ignore')
 
                         self.arg_names.append(arg_name)
                         self.arg_types.append(arg_type)
@@ -349,7 +358,8 @@ class JavaMethod():
             # Process return type
             elif child.type.endswith('type_identifier') or child.type.endswith(
                     '_type'):
-                self.return_type = child.text.decode(encoding='utf-8', errors='ignore')
+                self.return_type = child.text.decode(encoding='utf-8',
+                                                     errors='ignore')
 
             # Process body and store statment nodes
             elif child.type in ['block', 'constructor_body']:
@@ -362,7 +372,9 @@ class JavaMethod():
             elif child.type == 'throws':
                 for exception in child.children:
                     if exception.type.endswith('type_identifier'):
-                        self.exceptions.append(exception.text.decode(encoding='utf-8', errors='ignore'))
+                        self.exceptions.append(
+                            exception.text.decode(encoding='utf-8',
+                                                  errors='ignore'))
 
     def _process_statements(self):
         """Loop through all statements and process them."""
@@ -460,7 +472,8 @@ class JavaMethod():
 
             # Variable call or static call
             else:
-                var_name = stmt.text.decode(encoding='utf-8', errors='ignore') if stmt.text else ''
+                var_name = stmt.text.decode(
+                    encoding='utf-8', errors='ignore') if stmt.text else ''
                 return_value = self.var_map.get(var_name, '')
                 if not return_value:
                     return_value = self.class_interface.class_fields.get(
@@ -479,7 +492,9 @@ class JavaMethod():
                     cls = classes.get(object_class)
                     if cls and field.text:
                         return_value = cls.class_fields.get(
-                            field.text.decode(encoding='utf-8', errors='ignore'), self.class_interface.name)
+                            field.text.decode(encoding='utf-8',
+                                              errors='ignore'),
+                            self.class_interface.name)
 
             # Chained call
             elif stmt.type == 'method_invocation':
@@ -507,7 +522,8 @@ class JavaMethod():
                             continue
                         return_value = (
                             self.parent_source.get_full_qualified_name(
-                                cast_type.text.decode(encoding='utf-8', errors='ignore')))
+                                cast_type.text.decode(encoding='utf-8',
+                                                      errors='ignore')))
 
                         if value.type == 'method_invocation':
                             _, invoke_callsites = self._process_invoke(
@@ -562,7 +578,8 @@ class JavaMethod():
 
             # Variables
             elif argument.type == 'identifier':
-                arg_name = argument.text.decode(encoding='utf-8', errors='ignore') if argument.text else ''
+                arg_name = argument.text.decode(
+                    encoding='utf-8', errors='ignore') if argument.text else ''
                 return_value = self.var_map.get(arg_name, '')
                 if not return_value:
                     return_value = self.class_interface.class_fields.get(
@@ -599,7 +616,9 @@ class JavaMethod():
                     cls = classes.get(object_class)
                     if cls and field.text:
                         return_value = cls.class_fields.get(
-                            field.text.decode(encoding='utf-8', errors='ignore'), self.class_interface.name)
+                            field.text.decode(encoding='utf-8',
+                                              errors='ignore'),
+                            self.class_interface.name)
                 return_values.append(return_value)
 
             # Type casting expression
@@ -664,7 +683,9 @@ class JavaMethod():
 
                 elif cls_type.type.endswith(
                         'type_identifier') or cls_type.type.endswith('_type'):
-                    cls_name = cls_type.text.decode(encoding='utf-8', errors='ignore') if cls_type.text else ''
+                    cls_name = cls_type.text.decode(
+                        encoding='utf-8',
+                        errors='ignore') if cls_type.text else ''
                     object_type = cls_name.split('<')[0]
 
             object_type = self.parent_source.get_full_qualified_name(
@@ -699,8 +720,9 @@ class JavaMethod():
                     object_type = packaged_type
                     break
 
-            target_name = (f'[{object_type}].{name.text.decode(encoding="utf-8", errors="ignore")}'
-                           f'({",".join(argument_types)})')
+            target_name = (
+                f'[{object_type}].{name.text.decode(encoding="utf-8", errors="ignore")}'
+                f'({",".join(argument_types)})')
             callsites.append(
                 (target_name, expr.byte_range[1], expr.start_point.row + 1))
 
@@ -708,11 +730,14 @@ class JavaMethod():
         # Preserve the full method call
         elif name and name.text:
             if objects and objects.text:
-                target_name = (f'{objects.text.decode(encoding="utf-8", errors="ignore")}.{name.text.decode(encoding="utf-8", errors="ignore")}'
-                               f'({",".join(argument_types)})')
+                target_name = (
+                    f'{objects.text.decode(encoding="utf-8", errors="ignore")}.'
+                    f'{name.text.decode(encoding="utf-8", errors="ignore")}'
+                    f'({",".join(argument_types)})')
             else:
-                target_name = (f'{name.text.decode(encoding="utf-8", errors="ignore")}'
-                               f'({",".join(argument_types)})')
+                target_name = (
+                    f'{name.text.decode(encoding="utf-8", errors="ignore")}'
+                    f'({",".join(argument_types)})')
 
             callsites.append(
                 (target_name, expr.byte_range[1], expr.start_point.row + 1))
@@ -764,7 +789,8 @@ class JavaMethod():
             if not left or not left.text or not right:
                 return type_str, callsites
 
-            var_name = left.text.decode(encoding='utf-8', errors='ignore').split(' ')[-1]
+            var_name = left.text.decode(encoding='utf-8',
+                                        errors='ignore').split(' ')[-1]
             type_str, invoke_callsites = self._process_callsites(
                 right, classes)
             self.var_map[var_name] = type_str
@@ -777,7 +803,8 @@ class JavaMethod():
                     if not name_node or not name_node.text or not value_node:
                         continue
 
-                    var_name = name_node.text.decode(encoding='utf-8', errors='ignore')
+                    var_name = name_node.text.decode(encoding='utf-8',
+                                                     errors='ignore')
                     type_str, invoke_callsites = self._process_callsites(
                         value_node, classes)
                     self.var_map[var_name] = type_str
@@ -900,7 +927,8 @@ class JavaClassInterface():
             if child.type == 'superclass':
                 for cls in child.children:
                     if cls.type.endswith('type_identifier') and cls.text:
-                        self.super_class = cls.text.decode(encoding='utf-8', errors='ignore')
+                        self.super_class = cls.text.decode(encoding='utf-8',
+                                                           errors='ignore')
 
             # Process super interfaces
             elif child.type == 'super_interfaces':
@@ -912,13 +940,17 @@ class JavaClassInterface():
                     for interface in interfaces.children:
                         if (interface.type.endswith('type_identifier')
                                 and interface.text):
-                            type_set.add(interface.text.decode(encoding='utf-8', errors='ignore'))
+                            type_set.add(
+                                interface.text.decode(encoding='utf-8',
+                                                      errors='ignore'))
                     self.super_interfaces = list(type_set)
 
             # Process modifiers
             elif child.type == 'modifiers':
                 for modifier in child.children:
-                    modi_txt = modifier.text.decode(encoding='utf-8', errors='ignore') if modifier.text else ''
+                    modi_txt = modifier.text.decode(
+                        encoding='utf-8',
+                        errors='ignore') if modifier.text else ''
                     if modi_txt == 'public':
                         self.class_public = True
                     if modi_txt == 'abstract':
@@ -931,7 +963,8 @@ class JavaClassInterface():
 
             # Process name
             elif child.type == 'identifier':
-                self.name = child.text.decode(encoding='utf-8', errors='ignore') if child.text else ''
+                self.name = child.text.decode(
+                    encoding='utf-8', errors='ignore') if child.text else ''
                 if self.package:
                     self.name = f'{self.package}.{self.name}'
 
@@ -953,7 +986,8 @@ class JavaClassInterface():
                         if not type_node or not type_node.text:
                             continue
 
-                        field_type = type_node.text.decode(encoding='utf-8', errors='ignore')
+                        field_type = type_node.text.decode(encoding='utf-8',
+                                                           errors='ignore')
                         fields = [
                             field for field in body.children
                             if field.type == 'variable_declarator'
@@ -964,7 +998,8 @@ class JavaClassInterface():
                             name_node = field.child_by_field_name('name')
 
                         if name_node and name_node.text and field_type:
-                            field_name = name_node.text.decode(encoding='utf-8', errors='ignore')
+                            field_name = name_node.text.decode(
+                                encoding='utf-8', errors='ignore')
                             self.class_fields[field_name] = field_type
 
                     # Process inner classes or interfaces

--- a/src/fuzz_introspector/frontends/frontend_jvm.py
+++ b/src/fuzz_introspector/frontends/frontend_jvm.py
@@ -104,7 +104,7 @@ class JvmSourceCodeFile(SourceCodeFile):
             for node in nodes:
                 for package in node.children:
                     if package.type in ['scoped_identifier', 'identifier']:
-                        self.package = package.text.decode()
+                        self.package = package.text.decode(encoding='utf-8', errors='ignore')
 
     def _set_class_interface_declaration(self):
         """Internal helper for retrieving all classes."""
@@ -124,7 +124,7 @@ class JvmSourceCodeFile(SourceCodeFile):
                 wildcard = False
                 for imp in node.children:
                     if imp.type == 'scoped_identifier':
-                        package = imp.text.decode()
+                        package = imp.text.decode(encoding='utf-8', errors='ignore')
                     if imp.type == 'asterisk':
                         wildcard = True
                 if not wildcard and not package.startswith('java.lang'):
@@ -271,7 +271,7 @@ class JavaMethod():
     def function_source_code_as_text(self) -> str:
         """Returns the source code the function."""
         if self.root and self.root.text:
-            return self.root.text.decode()
+            return self.root.text.decode(encoding='utf-8', errors='ignore')
 
         return ''
 
@@ -317,20 +317,20 @@ class JavaMethod():
                 if self.is_constructor:
                     self.name = '<init>'
                 else:
-                    self.name = child.text.decode()
+                    self.name = child.text.decode(encoding='utf-8', errors='ignore')
                     if self.name == self.parent_source.entrypoint:
                         self.is_entry_method = True
 
             # Process modifiers and annotations
             elif child.type == 'modifiers':
                 for modifier in child.children:
-                    if modifier.text.decode() == 'public':
+                    if modifier.text.decode(encoding='utf-8', errors='ignore') == 'public':
                         self.public = True
-                    if modifier.text.decode() == 'abstract':
+                    if modifier.text.decode(encoding='utf-8', errors='ignore') == 'abstract':
                         self.concrete = False
-                    if modifier.text.decode() == 'static':
+                    if modifier.text.decode(encoding='utf-8', errors='ignore') == 'static':
                         self.static = True
-                    if modifier.text.decode() == '@FuzzTest':
+                    if modifier.text.decode(encoding='utf-8', errors='ignore') == '@FuzzTest':
                         self.is_entry_method = True
 
             # Process arguments
@@ -338,9 +338,9 @@ class JavaMethod():
                 for argument in child.children:
                     if argument.type == 'formal_parameter':
                         arg_name = argument.child_by_field_name(
-                            'name').text.decode()
+                            'name').text.decode(encoding='utf-8', errors='ignore')
                         arg_type = argument.child_by_field_name(
-                            'type').text.decode()
+                            'type').text.decode(encoding='utf-8', errors='ignore')
 
                         self.arg_names.append(arg_name)
                         self.arg_types.append(arg_type)
@@ -349,7 +349,7 @@ class JavaMethod():
             # Process return type
             elif child.type.endswith('type_identifier') or child.type.endswith(
                     '_type'):
-                self.return_type = child.text.decode()
+                self.return_type = child.text.decode(encoding='utf-8', errors='ignore')
 
             # Process body and store statment nodes
             elif child.type in ['block', 'constructor_body']:
@@ -362,7 +362,7 @@ class JavaMethod():
             elif child.type == 'throws':
                 for exception in child.children:
                     if exception.type.endswith('type_identifier'):
-                        self.exceptions.append(exception.text.decode())
+                        self.exceptions.append(exception.text.decode(encoding='utf-8', errors='ignore'))
 
     def _process_statements(self):
         """Loop through all statements and process them."""
@@ -460,7 +460,7 @@ class JavaMethod():
 
             # Variable call or static call
             else:
-                var_name = stmt.text.decode() if stmt.text else ''
+                var_name = stmt.text.decode(encoding='utf-8', errors='ignore') if stmt.text else ''
                 return_value = self.var_map.get(var_name, '')
                 if not return_value:
                     return_value = self.class_interface.class_fields.get(
@@ -479,7 +479,7 @@ class JavaMethod():
                     cls = classes.get(object_class)
                     if cls and field.text:
                         return_value = cls.class_fields.get(
-                            field.text.decode(), self.class_interface.name)
+                            field.text.decode(encoding='utf-8', errors='ignore'), self.class_interface.name)
 
             # Chained call
             elif stmt.type == 'method_invocation':
@@ -507,7 +507,7 @@ class JavaMethod():
                             continue
                         return_value = (
                             self.parent_source.get_full_qualified_name(
-                                cast_type.text.decode()))
+                                cast_type.text.decode(encoding='utf-8', errors='ignore')))
 
                         if value.type == 'method_invocation':
                             _, invoke_callsites = self._process_invoke(
@@ -562,7 +562,7 @@ class JavaMethod():
 
             # Variables
             elif argument.type == 'identifier':
-                arg_name = argument.text.decode() if argument.text else ''
+                arg_name = argument.text.decode(encoding='utf-8', errors='ignore') if argument.text else ''
                 return_value = self.var_map.get(arg_name, '')
                 if not return_value:
                     return_value = self.class_interface.class_fields.get(
@@ -599,7 +599,7 @@ class JavaMethod():
                     cls = classes.get(object_class)
                     if cls and field.text:
                         return_value = cls.class_fields.get(
-                            field.text.decode(), self.class_interface.name)
+                            field.text.decode(encoding='utf-8', errors='ignore'), self.class_interface.name)
                 return_values.append(return_value)
 
             # Type casting expression
@@ -610,7 +610,7 @@ class JavaMethod():
                     continue
 
                 return_value = self.parent_source.get_full_qualified_name(
-                    cast_type.text.decode())
+                    cast_type.text.decode(encoding='utf-8', errors='ignore'))
 
                 if value.type == 'method_invocation':
                     _, invoke_callsites = self._process_invoke(value, classes)
@@ -664,7 +664,7 @@ class JavaMethod():
 
                 elif cls_type.type.endswith(
                         'type_identifier') or cls_type.type.endswith('_type'):
-                    cls_name = cls_type.text.decode() if cls_type.text else ''
+                    cls_name = cls_type.text.decode(encoding='utf-8', errors='ignore') if cls_type.text else ''
                     object_type = cls_name.split('<')[0]
 
             object_type = self.parent_source.get_full_qualified_name(
@@ -699,7 +699,7 @@ class JavaMethod():
                     object_type = packaged_type
                     break
 
-            target_name = (f'[{object_type}].{name.text.decode()}'
+            target_name = (f'[{object_type}].{name.text.decode(encoding="utf-8", errors="ignore")}'
                            f'({",".join(argument_types)})')
             callsites.append(
                 (target_name, expr.byte_range[1], expr.start_point.row + 1))
@@ -708,10 +708,10 @@ class JavaMethod():
         # Preserve the full method call
         elif name and name.text:
             if objects and objects.text:
-                target_name = (f'{objects.text.decode()}.{name.text.decode()}'
+                target_name = (f'{objects.text.decode(encoding="utf-8", errors="ignore")}.{name.text.decode(encoding="utf-8", errors="ignore")}'
                                f'({",".join(argument_types)})')
             else:
-                target_name = (f'{name.text.decode()}'
+                target_name = (f'{name.text.decode(encoding="utf-8", errors="ignore")}'
                                f'({",".join(argument_types)})')
 
             callsites.append(
@@ -721,7 +721,7 @@ class JavaMethod():
         if object_type == 'com.code_intelligence.jazzer.api.FuzzedDataProvider':
             if name and name.text:
                 return_type = FUZZING_METHOD_RETURN_TYPE_MAP.get(
-                    name.text.decode(), '')
+                    name.text.decode(encoding='utf-8', errors='ignore'), '')
         else:
             return_type = self.class_interface.name
             if object_type in classes and target_name:
@@ -764,7 +764,7 @@ class JavaMethod():
             if not left or not left.text or not right:
                 return type_str, callsites
 
-            var_name = left.text.decode().split(' ')[-1]
+            var_name = left.text.decode(encoding='utf-8', errors='ignore').split(' ')[-1]
             type_str, invoke_callsites = self._process_callsites(
                 right, classes)
             self.var_map[var_name] = type_str
@@ -777,7 +777,7 @@ class JavaMethod():
                     if not name_node or not name_node.text or not value_node:
                         continue
 
-                    var_name = name_node.text.decode()
+                    var_name = name_node.text.decode(encoding='utf-8', errors='ignore')
                     type_str, invoke_callsites = self._process_callsites(
                         value_node, classes)
                     self.var_map[var_name] = type_str
@@ -788,7 +788,7 @@ class JavaMethod():
             if not name_node or not name_node.text or not value_node:
                 return type_str, callsites
 
-            var_name = name_node.text.decode()
+            var_name = name_node.text.decode(encoding='utf-8', errors='ignore')
             type_str, invoke_callsites = self._process_callsites(
                 value_node, classes)
             self.var_map[var_name] = type_str
@@ -900,7 +900,7 @@ class JavaClassInterface():
             if child.type == 'superclass':
                 for cls in child.children:
                     if cls.type.endswith('type_identifier') and cls.text:
-                        self.super_class = cls.text.decode()
+                        self.super_class = cls.text.decode(encoding='utf-8', errors='ignore')
 
             # Process super interfaces
             elif child.type == 'super_interfaces':
@@ -912,13 +912,13 @@ class JavaClassInterface():
                     for interface in interfaces.children:
                         if (interface.type.endswith('type_identifier')
                                 and interface.text):
-                            type_set.add(interface.text.decode())
+                            type_set.add(interface.text.decode(encoding='utf-8', errors='ignore'))
                     self.super_interfaces = list(type_set)
 
             # Process modifiers
             elif child.type == 'modifiers':
                 for modifier in child.children:
-                    modi_txt = modifier.text.decode() if modifier.text else ''
+                    modi_txt = modifier.text.decode(encoding='utf-8', errors='ignore') if modifier.text else ''
                     if modi_txt == 'public':
                         self.class_public = True
                     if modi_txt == 'abstract':
@@ -931,7 +931,7 @@ class JavaClassInterface():
 
             # Process name
             elif child.type == 'identifier':
-                self.name = child.text.decode() if child.text else ''
+                self.name = child.text.decode(encoding='utf-8', errors='ignore') if child.text else ''
                 if self.package:
                     self.name = f'{self.package}.{self.name}'
 
@@ -953,7 +953,7 @@ class JavaClassInterface():
                         if not type_node or not type_node.text:
                             continue
 
-                        field_type = type_node.text.decode()
+                        field_type = type_node.text.decode(encoding='utf-8', errors='ignore')
                         fields = [
                             field for field in body.children
                             if field.type == 'variable_declarator'
@@ -964,7 +964,7 @@ class JavaClassInterface():
                             name_node = field.child_by_field_name('name')
 
                         if name_node and name_node.text and field_type:
-                            field_name = name_node.text.decode()
+                            field_name = name_node.text.decode(encoding='utf-8', errors='ignore')
                             self.class_fields[field_name] = field_type
 
                     # Process inner classes or interfaces

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -63,7 +63,9 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 impl_type = node.child_by_field_name('type')
                 impl_body = node.child_by_field_name('body')
                 if impl_type and impl_type.text:
-                    prefix.append(impl_type.text.decode(encoding='utf-8', errors='ignore').split('<')[0])
+                    prefix.append(
+                        impl_type.text.decode(encoding='utf-8',
+                                              errors='ignore').split('<')[0])
 
                 # Check impl_bdoy
                 if not impl_body:
@@ -90,7 +92,9 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 # Basic info of this mod
                 mod_name = node.child_by_field_name('name')
                 if mod_name and mod_name.text:
-                    prefix.append(mod_name.text.decode(encoding='utf-8', errors='ignore'))
+                    prefix.append(
+                        mod_name.text.decode(encoding='utf-8',
+                                             errors='ignore'))
 
                 # Loop through the body of this mod
                 for mod in mod_body.children:
@@ -116,7 +120,9 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 trait_name = node.child_by_field_name('name')
                 trait_body = node.child_by_field_name('body')
                 if trait_name and trait_name.text:
-                    prefix.append(trait_name.text.decode(encoding='utf-8', errors='ignore').split('<')[0])
+                    prefix.append(
+                        trait_name.text.decode(encoding='utf-8',
+                                               errors='ignore').split('<')[0])
 
                 # Check trait_body
                 if not trait_body:
@@ -150,7 +156,8 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 use_stmt = node.child_by_field_name('argument')
                 if use_stmt and use_stmt.text:
                     use_map = self._process_recursive_use(
-                        use_stmt.text.decode(encoding='utf-8', errors='ignore'))
+                        use_stmt.text.decode(encoding='utf-8',
+                                             errors='ignore'))
                     self.uses.update(use_map)
 
             # Handling macro definition
@@ -283,14 +290,16 @@ class RustFunction():
     def _process_declaration(self):
         """Internal helper to process the function/method declaration."""
         # Process name
-        self.name = self.root.child_by_field_name('name').text.decode(encoding='utf-8', errors='ignore')
+        self.name = self.root.child_by_field_name('name').text.decode(
+            encoding='utf-8', errors='ignore')
         if self.prefix:
             self.name = f'{"::".join(self.prefix)}::{self.name}'
 
         # Process return type
         return_type = self.root.child_by_field_name('return_type')
         if return_type:
-            self.return_type = return_type.text.decode(encoding='utf-8', errors='ignore').split('<')[0]
+            self.return_type = return_type.text.decode(
+                encoding='utf-8', errors='ignore').split('<')[0]
         else:
             self.return_type = 'void'
 
@@ -300,12 +309,17 @@ class RustFunction():
             if param.type == 'parameter':
                 for item in param.children:
                     if item.type == 'identifier':
-                        self.arg_names.append(item.text.decode(encoding='utf-8', errors='ignore'))
+                        self.arg_names.append(
+                            item.text.decode(encoding='utf-8',
+                                             errors='ignore'))
                     elif 'type' in item.type:
-                        self.arg_types.append(item.text.decode(encoding='utf-8', errors='ignore'))
+                        self.arg_types.append(
+                            item.text.decode(encoding='utf-8',
+                                             errors='ignore'))
 
         # Process signature
-        signature = self.root.text.decode(encoding='utf-8', errors='ignore').split('{')[0]
+        signature = self.root.text.decode(encoding='utf-8',
+                                          errors='ignore').split('{')[0]
         self.sig = ''.join(line.strip() for line in signature.splitlines()
                            if line.strip())
 
@@ -327,7 +341,8 @@ class RustFunction():
         for child in self.root.children:
             # Process name
             if child.type == 'identifier':
-                self.name = child.text.decode(encoding='utf-8', errors='ignore')
+                self.name = child.text.decode(encoding='utf-8',
+                                              errors='ignore')
                 if self.name == 'fuzz_target':
                     self.is_entry_method = True
 
@@ -335,7 +350,8 @@ class RustFunction():
             elif child.type == 'token_tree':
                 for token_tree in child.children:
                     if token_tree.type == 'token_tree':
-                        content = token_tree.text.decode(encoding='utf-8', errors='ignore')
+                        content = token_tree.text.decode(encoding='utf-8',
+                                                         errors='ignore')
                         if content.startswith('{'):
                             cbytes = content.encode('utf-8')
                             root = self.parent_source.parser.parse(cbytes)
@@ -344,7 +360,8 @@ class RustFunction():
             elif child.type == 'macro_rule':
                 token_tree = child.child_by_field_name('right')
                 if token_tree:
-                    content = token_tree.text.decode(encoding='utf-8', errors='ignore')
+                    content = token_tree.text.decode(encoding='utf-8',
+                                                     errors='ignore')
                     if content.startswith('{'):
                         cbytes = content.encode('utf-8')
                         root = self.parent_source.parser.parse(cbytes)
@@ -424,7 +441,8 @@ class RustFunction():
                 # Simple function call
                 if func.type in ['identifier', 'scoped_identifier']:
                     if func.text:
-                        target_name = func.text.decode(encoding='utf-8', errors='ignore')
+                        target_name = func.text.decode(encoding='utf-8',
+                                                       errors='ignore')
 
                     # Ignore lambda function calls
                     if target_name in self.var_map:
@@ -437,7 +455,9 @@ class RustFunction():
                     _, target_name = _process_field_expr_return_type(func)
 
                 elif func.type == 'generic_function' and func.text:
-                    target_name = func.text.decode(encoding='utf-8', errors='ignore').split('.', 1)[-1]
+                    target_name = func.text.decode(encoding='utf-8',
+                                                   errors='ignore').split(
+                                                       '.', 1)[-1]
 
                 if target_name and func.byte_range and func.start_point:
                     callsites.append((target_name, func.byte_range[1],
@@ -463,7 +483,9 @@ class RustFunction():
 
             name = field_expr.child_by_field_name('field')
             obj = field_expr.child_by_field_name('value')
-            full_name = name.text.decode(encoding='utf-8', errors='ignore') if name and name.text else ''
+            full_name = name.text.decode(
+                encoding='utf-8',
+                errors='ignore') if name and name.text else ''
 
             if not obj:
                 return (return_type, full_name)
@@ -472,7 +494,8 @@ class RustFunction():
             if obj.type == 'call_expression':
                 object_type = _retrieve_return_type(obj)
             elif obj.type in ['identifier', 'scoped_identifier']:
-                object_text = obj.text.decode(encoding='utf-8', errors='ignore') if obj.text else ''
+                object_text = obj.text.decode(
+                    encoding='utf-8', errors='ignore') if obj.text else ''
                 node = get_function_node(object_text, functions)
                 if node:
                     object_type = node.return_type
@@ -501,7 +524,8 @@ class RustFunction():
             func = call_expr.child_by_field_name('function')
             if func:
                 if func.type in ['identifier', 'scoped_identifier']:
-                    func_name = func.text.decode(encoding='utf-8', errors='ignore') if func.text else ''
+                    func_name = func.text.decode(
+                        encoding='utf-8', errors='ignore') if func.text else ''
                     node = get_function_node(func_name, functions)
                     if node:
                         return_type = node.return_type
@@ -520,10 +544,13 @@ class RustFunction():
                 param_name = stmt.child_by_field_name('pattern')
                 param_type = stmt.child_by_field_name('value')
                 if param_name and param_type:
-                    name = param_name.text.decode(encoding='utf-8', errors='ignore') if param_name.text else ''
+                    name = param_name.text.decode(
+                        encoding='utf-8',
+                        errors='ignore') if param_name.text else ''
                     return_type = None
                     if param_type.type == 'identifier':
-                        target = (param_type.text.decode(encoding='utf-8', errors='ignore')
+                        target = (param_type.text.decode(encoding='utf-8',
+                                                         errors='ignore')
                                   if param_type.text else '')
                         return_type = self.var_map.get(target)
                         if not return_type:
@@ -536,14 +563,17 @@ class RustFunction():
                         # for pointers and primitive types are needed.
                         return_node = param_type.child_by_field_name('type')
                         if return_node and return_node.text:
-                            return_type = return_node.text.decode(encoding='utf-8', errors='ignore')
+                            return_type = return_node.text.decode(
+                                encoding='utf-8', errors='ignore')
                     elif param_type.type == 'call_expression':
                         return_type = _retrieve_return_type(param_type)
                     elif param_type.type == 'reference_expression':
                         for ref_type in param_type.children:
                             if ref_type.type == 'identifier':
                                 key_bytes = ref_type.text
-                                key = key_bytes.decode(encoding='utf-8', errors='ignore') if key_bytes else ''
+                                key = key_bytes.decode(
+                                    encoding='utf-8',
+                                    errors='ignore') if key_bytes else ''
                                 return_type = self.var_map.get(key)
                             elif ref_type.type == 'call_expression':
                                 return_type = _retrieve_return_type(ref_type)
@@ -554,7 +584,8 @@ class RustFunction():
             elif stmt.type == 'macro_invocation':
                 for child in stmt.children:
                     if child.type == 'identifier' and child.text:
-                        macro_name = child.text.decode(encoding='utf-8', errors='ignore')
+                        macro_name = child.text.decode(encoding='utf-8',
+                                                       errors='ignore')
                         target_func = get_function_node(macro_name, functions)
                         if target_func and target_func.is_macro:
                             callsites.append(

--- a/src/fuzz_introspector/frontends/frontend_rust.py
+++ b/src/fuzz_introspector/frontends/frontend_rust.py
@@ -63,7 +63,7 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 impl_type = node.child_by_field_name('type')
                 impl_body = node.child_by_field_name('body')
                 if impl_type and impl_type.text:
-                    prefix.append(impl_type.text.decode().split('<')[0])
+                    prefix.append(impl_type.text.decode(encoding='utf-8', errors='ignore').split('<')[0])
 
                 # Check impl_bdoy
                 if not impl_body:
@@ -90,7 +90,7 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 # Basic info of this mod
                 mod_name = node.child_by_field_name('name')
                 if mod_name and mod_name.text:
-                    prefix.append(mod_name.text.decode())
+                    prefix.append(mod_name.text.decode(encoding='utf-8', errors='ignore'))
 
                 # Loop through the body of this mod
                 for mod in mod_body.children:
@@ -116,7 +116,7 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 trait_name = node.child_by_field_name('name')
                 trait_body = node.child_by_field_name('body')
                 if trait_name and trait_name.text:
-                    prefix.append(trait_name.text.decode().split('<')[0])
+                    prefix.append(trait_name.text.decode(encoding='utf-8', errors='ignore').split('<')[0])
 
                 # Check trait_body
                 if not trait_body:
@@ -150,7 +150,7 @@ class RustSourceCodeFile(datatypes.SourceCodeFile):
                 use_stmt = node.child_by_field_name('argument')
                 if use_stmt and use_stmt.text:
                     use_map = self._process_recursive_use(
-                        use_stmt.text.decode())
+                        use_stmt.text.decode(encoding='utf-8', errors='ignore'))
                     self.uses.update(use_map)
 
             # Handling macro definition
@@ -276,21 +276,21 @@ class RustFunction():
     def function_source_code_as_text(self) -> str:
         """Returns the source code the function."""
         if self.root and self.root.text:
-            return self.root.text.decode()
+            return self.root.text.decode(encoding='utf-8', errors='ignore')
 
         return ''
 
     def _process_declaration(self):
         """Internal helper to process the function/method declaration."""
         # Process name
-        self.name = self.root.child_by_field_name('name').text.decode()
+        self.name = self.root.child_by_field_name('name').text.decode(encoding='utf-8', errors='ignore')
         if self.prefix:
             self.name = f'{"::".join(self.prefix)}::{self.name}'
 
         # Process return type
         return_type = self.root.child_by_field_name('return_type')
         if return_type:
-            self.return_type = return_type.text.decode().split('<')[0]
+            self.return_type = return_type.text.decode(encoding='utf-8', errors='ignore').split('<')[0]
         else:
             self.return_type = 'void'
 
@@ -300,12 +300,12 @@ class RustFunction():
             if param.type == 'parameter':
                 for item in param.children:
                     if item.type == 'identifier':
-                        self.arg_names.append(item.text.decode())
+                        self.arg_names.append(item.text.decode(encoding='utf-8', errors='ignore'))
                     elif 'type' in item.type:
-                        self.arg_types.append(item.text.decode())
+                        self.arg_types.append(item.text.decode(encoding='utf-8', errors='ignore'))
 
         # Process signature
-        signature = self.root.text.decode().split('{')[0]
+        signature = self.root.text.decode(encoding='utf-8', errors='ignore').split('{')[0]
         self.sig = ''.join(line.strip() for line in signature.splitlines()
                            if line.strip())
 
@@ -327,7 +327,7 @@ class RustFunction():
         for child in self.root.children:
             # Process name
             if child.type == 'identifier':
-                self.name = child.text.decode()
+                self.name = child.text.decode(encoding='utf-8', errors='ignore')
                 if self.name == 'fuzz_target':
                     self.is_entry_method = True
 
@@ -335,7 +335,7 @@ class RustFunction():
             elif child.type == 'token_tree':
                 for token_tree in child.children:
                     if token_tree.type == 'token_tree':
-                        content = token_tree.text.decode()
+                        content = token_tree.text.decode(encoding='utf-8', errors='ignore')
                         if content.startswith('{'):
                             cbytes = content.encode('utf-8')
                             root = self.parent_source.parser.parse(cbytes)
@@ -344,7 +344,7 @@ class RustFunction():
             elif child.type == 'macro_rule':
                 token_tree = child.child_by_field_name('right')
                 if token_tree:
-                    content = token_tree.text.decode()
+                    content = token_tree.text.decode(encoding='utf-8', errors='ignore')
                     if content.startswith('{'):
                         cbytes = content.encode('utf-8')
                         root = self.parent_source.parser.parse(cbytes)
@@ -424,7 +424,7 @@ class RustFunction():
                 # Simple function call
                 if func.type in ['identifier', 'scoped_identifier']:
                     if func.text:
-                        target_name = func.text.decode()
+                        target_name = func.text.decode(encoding='utf-8', errors='ignore')
 
                     # Ignore lambda function calls
                     if target_name in self.var_map:
@@ -437,7 +437,7 @@ class RustFunction():
                     _, target_name = _process_field_expr_return_type(func)
 
                 elif func.type == 'generic_function' and func.text:
-                    target_name = func.text.decode().split('.', 1)[-1]
+                    target_name = func.text.decode(encoding='utf-8', errors='ignore').split('.', 1)[-1]
 
                 if target_name and func.byte_range and func.start_point:
                     callsites.append((target_name, func.byte_range[1],
@@ -463,7 +463,7 @@ class RustFunction():
 
             name = field_expr.child_by_field_name('field')
             obj = field_expr.child_by_field_name('value')
-            full_name = name.text.decode() if name and name.text else ''
+            full_name = name.text.decode(encoding='utf-8', errors='ignore') if name and name.text else ''
 
             if not obj:
                 return (return_type, full_name)
@@ -472,7 +472,7 @@ class RustFunction():
             if obj.type == 'call_expression':
                 object_type = _retrieve_return_type(obj)
             elif obj.type in ['identifier', 'scoped_identifier']:
-                object_text = obj.text.decode() if obj.text else ''
+                object_text = obj.text.decode(encoding='utf-8', errors='ignore') if obj.text else ''
                 node = get_function_node(object_text, functions)
                 if node:
                     object_type = node.return_type
@@ -501,7 +501,7 @@ class RustFunction():
             func = call_expr.child_by_field_name('function')
             if func:
                 if func.type in ['identifier', 'scoped_identifier']:
-                    func_name = func.text.decode() if func.text else ''
+                    func_name = func.text.decode(encoding='utf-8', errors='ignore') if func.text else ''
                     node = get_function_node(func_name, functions)
                     if node:
                         return_type = node.return_type
@@ -520,10 +520,10 @@ class RustFunction():
                 param_name = stmt.child_by_field_name('pattern')
                 param_type = stmt.child_by_field_name('value')
                 if param_name and param_type:
-                    name = param_name.text.decode() if param_name.text else ''
+                    name = param_name.text.decode(encoding='utf-8', errors='ignore') if param_name.text else ''
                     return_type = None
                     if param_type.type == 'identifier':
-                        target = (param_type.text.decode()
+                        target = (param_type.text.decode(encoding='utf-8', errors='ignore')
                                   if param_type.text else '')
                         return_type = self.var_map.get(target)
                         if not return_type:
@@ -536,14 +536,14 @@ class RustFunction():
                         # for pointers and primitive types are needed.
                         return_node = param_type.child_by_field_name('type')
                         if return_node and return_node.text:
-                            return_type = return_node.text.decode()
+                            return_type = return_node.text.decode(encoding='utf-8', errors='ignore')
                     elif param_type.type == 'call_expression':
                         return_type = _retrieve_return_type(param_type)
                     elif param_type.type == 'reference_expression':
                         for ref_type in param_type.children:
                             if ref_type.type == 'identifier':
                                 key_bytes = ref_type.text
-                                key = key_bytes.decode() if key_bytes else ''
+                                key = key_bytes.decode(encoding='utf-8', errors='ignore') if key_bytes else ''
                                 return_type = self.var_map.get(key)
                             elif ref_type.type == 'call_expression':
                                 return_type = _retrieve_return_type(ref_type)
@@ -554,7 +554,7 @@ class RustFunction():
             elif stmt.type == 'macro_invocation':
                 for child in stmt.children:
                     if child.type == 'identifier' and child.text:
-                        macro_name = child.text.decode()
+                        macro_name = child.text.decode(encoding='utf-8', errors='ignore')
                         target_func = get_function_node(macro_name, functions)
                         if target_func and target_func.is_macro:
                             callsites.append(

--- a/src/test/data/source-code/c/unicode-error/simple.c
+++ b/src/test/data/source-code/c/unicode-error/simple.c
@@ -1,0 +1,2 @@
+#define BAD_MACRO "bad byte: ÿ"
+int LLVMFuzzerTestOneInput() { return 0; }

--- a/src/test/data/source-code/cpp/unicode-error/simple.cpp
+++ b/src/test/data/source-code/cpp/unicode-error/simple.cpp
@@ -1,0 +1,2 @@
+#define BAD_MACRO "bad byte: ÿ"
+int LLVMFuzzerTestOneInput() { return 0; }

--- a/src/test/data/source-code/go/unicode-error/simple.go
+++ b/src/test/data/source-code/go/unicode-error/simple.go
@@ -1,0 +1,5 @@
+package main
+
+func fuzzÿInput(data []byte) {
+    println("this is a fuzz target")
+}

--- a/src/test/data/source-code/jvm/unicode-error/simple.java
+++ b/src/test/data/source-code/jvm/unicode-error/simple.java
@@ -1,0 +1,5 @@
+public clÿass BadClass {
+    public static void fuzzerTestOneInput(String[] args) {
+        System.out.println("Fuzzing entry point");
+    }
+}

--- a/src/test/data/source-code/rust/unicode-error/simple.rs
+++ b/src/test/data/source-code/rust/unicode-error/simple.rs
@@ -1,0 +1,6 @@
+fn fuzz_Àinput(data: &[u8]) {
+    println!("this is a fuzz target");
+}
+
+fn main() {
+}

--- a/src/test/test_frontends_unicode.py
+++ b/src/test/test_frontends_unicode.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Fuzz Introspector Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing script for the C frontend"""
+
+from fuzz_introspector.frontends import oss_fuzz  # noqa: E402
+
+
+def test_unicode_error_c():
+    try:
+        project, _ = oss_fuzz.analyse_folder(
+            language='c',
+            directory='src/test/data/source-code/c/unicode-error/',
+            entrypoint='LLVMFuzzerTestOneInput',
+        )
+    except UnicodeDecodeError:
+        assert False
+
+
+def test_unicode_error_cpp():
+    try:
+        project, _ = oss_fuzz.analyse_folder(
+            language='c++',
+            directory='src/test/data/source-code/cpp/unicode-error/',
+            entrypoint='LLVMFuzzerTestOneInput',
+        )
+    except UnicodeDecodeError:
+        assert False
+
+
+def test_unicode_error_jvm():
+    try:
+        project, _ = oss_fuzz.analyse_folder(
+            language='jvm',
+            directory='src/test/data/source-code/jvm/unicode-error/',
+            entrypoint='fuzzerTestOneInput',
+        )
+    except UnicodeDecodeError:
+        assert False
+
+
+def test_unicode_error_rust():
+    try:
+        project, _ = oss_fuzz.analyse_folder(
+            language='rust',
+            directory='src/test/data/source-code/rust/unicode-error/',
+        )
+    except UnicodeDecodeError:
+        assert False
+
+
+def test_unicode_error_go():
+    try:
+        project, _ = oss_fuzz.analyse_folder(
+            language='go',
+            directory='src/test/data/source-code/go/unicode-error/'
+        )
+    except UnicodeDecodeError:
+        assert False


### PR DESCRIPTION
This PR adds fail safe configuration for the tree-sitter node text decoding and **ignore error character** that could cause UnicodeDecodeError. A new unit testing has been added to check for unexpected UnicodeDecodeError.