### PR TITLE
frontend: Fix type alias extraction

### DIFF
--- a/src/fuzz_introspector/frontends/frontend_c_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_c_cpp.py
@@ -344,7 +344,7 @@ class CppSourceCodeFile(SourceCodeFile):
         }
 
         typedef_type = typedef.child_by_field_name('type')
-        if not typedef_type or not typedef_type.text:
+        if not typedef_type:
             # Skip invalid type definition
             return
 
@@ -355,7 +355,11 @@ class CppSourceCodeFile(SourceCodeFile):
 
             typedef_name = typedef_type.child_by_field_name('name')
             if typedef_name and typedef_name.text:
-              typedef_type = typedef_name
+                typedef_type = typedef_name
+
+        if not typedef_type or not typedef_type.text:
+            # Skip invalid type text
+            return
 
         typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8',
                                                           errors='ignore')

--- a/src/fuzz_introspector/frontends/frontend_c_cpp.py
+++ b/src/fuzz_introspector/frontends/frontend_c_cpp.py
@@ -348,15 +348,17 @@ class CppSourceCodeFile(SourceCodeFile):
             # Skip invalid type definition
             return
 
-        if typedef_type.type in ['struct_specifier', 'union_specifier']:
-            # Already handled in the struct/union section
-            return
-        elif typedef_type.type == 'primitive_type':
-            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8',
-                                                              errors='ignore')
-        elif typedef_type.type == 'sized_type_specifier':
-            typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8',
-                                                              errors='ignore')
+        if typedef_type.child_count > 0:
+            if typedef_type.child_by_field_name('body'):
+                # Already handled by other process statements
+                return
+
+            typedef_name = typedef_type.child_by_field_name('name')
+            if typedef_name and typedef_name.text:
+              typedef_type = typedef_name
+
+        typedef_struct['type'] = typedef_type.text.decode(encoding='utf-8',
+                                                          errors='ignore')
 
         self.typedefs.append(typedef_struct)
 


### PR DESCRIPTION
Currently, type aliases in the C/C++ frontend are being incorrectly ignored. As a result, some `typedef` declarations for structs or unions that are redefined under a different alias are missing from the final output. This PR corrects the typedef extraction logic in the C/C++ frontend to ensure that such type aliases are included.

For example, in the following case, the struct `abc` is correctly extracted, but the alias `ddd` for `struct abc` is missing from the result:

```c
struct abc {
   int aaa;
};

typedef struct abc ddd;
```
