### PR TITLE
webapp: Fix api mismatch

### DIFF
--- a/tools/web-fuzzing-introspection/app/webapp/routes.py
+++ b/tools/web-fuzzing-introspection/app/webapp/routes.py
@@ -1439,7 +1439,14 @@ def api_full_type_definition(args):
 
     typedef_list = extract_introspector_typedef(project_name,
                                                 latest_introspector_datestr)
-    return typedef_list
+
+    return {
+        'result': 'success',
+        'project': {
+            'name': project_name,
+            'typedef_list': typedef_list,
+        }
+    }
 
 
 @blueprint.route('/api/check_macro')


### PR DESCRIPTION
This PR fixes a API return mismatch for `full-type-definition` api.