### PR TITLE
analyser: introduce an option to control parallel mode

### DIFF
--- a/src/fuzz_introspector/commands.py
+++ b/src/fuzz_introspector/commands.py
@@ -113,6 +113,7 @@ def analyse_end_to_end(arg_language,
         correlation_file = ''
 
     try:
+        is_parallel = os.getenv('FUZZ_INTROSPECTOR_PARALLEL', "true").lower() == "true"
         exit_code, return_values2 = run_analysis_on_dir(
             target_folder=out_dir,
             coverage_url=coverage_url,
@@ -123,7 +124,8 @@ def analyse_end_to_end(arg_language,
             language=language,
             out_dir=out_dir,
             dump_files=dump_files,
-            harness_lists=harness_lists)
+            harness_lists=harness_lists,
+            parallelise=is_parallel)
         for k, v in return_values2.items():
             return_values[k] = v
     except DataLoaderError:


### PR DESCRIPTION
Fuzz Introspector is failed when building reports for Tarantool and other projects, see [1]:

During handling of the above exception, another exception occurred:

  File "/usr/local/lib/python3.10/multiprocessing/managers.py", line 817, in _callmethod
    conn.send((self._id, methodname, args, kwds))
  File "/fuzz-introspector/src/fuzz_introspector/datatypes/fuzzer_profile.py", line 359, in accummulate_profile
    return_dict[uniq_id] = self
AttributeError: 'ForkAwareLocal' object has no attribute 'connection'

The issue (theoretically) is related to processing data in parallel mode and cannot be reproduced locally. The patch introduce an option for controlling parallel mode - FUZZ_INTROSPECTOR_PARALLEL. When envronment variable is set to `false` Fuzz Introspector will process data in sequential mode.

1. https://github.com/google/oss-fuzz/issues/13226

Related to #2267
Related to google/oss-fuzz#13226