### PR TITLE
Adapt Fuzz Introspector to LLVM 22 API changes

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -18,46 +18,40 @@ set -ex
 BASE=$PWD
 BUILD_BASE=$BASE/build
 
-if [ -d $BUILD_BASE ]; then
+if [ -d "$BUILD_BASE/llvm-project" ] && [ -d "$BUILD_BASE/llvm-build" ]; then
   echo "Reusing set up (LLVM Source). Updating the LLVM plugin"
   rm -rf $BUILD_BASE/llvm-project/llvm/include/llvm/Transforms/FuzzIntrospector
   rm -rf $BUILD_BASE/llvm-project/llvm/lib/Transforms/FuzzIntrospector
   cp -rf ${BASE}/frontends/llvm/include/llvm/Transforms/FuzzIntrospector/ $BUILD_BASE/llvm-project/llvm/include/llvm/Transforms/FuzzIntrospector
   cp -rf ${BASE}/frontends/llvm/lib/Transforms/FuzzIntrospector $BUILD_BASE/llvm-project/llvm/lib/Transforms/FuzzIntrospector
 
+  # Recreate build dir if it was generated with a different CMake generator.
+  if [ -f "$BUILD_BASE/llvm-build/CMakeCache.txt" ] && \
+     grep -q 'CMAKE_GENERATOR:INTERNAL=Unix Makefiles' "$BUILD_BASE/llvm-build/CMakeCache.txt"; then
+    echo "Existing llvm-build uses Unix Makefiles; recreating for Ninja"
+    rm -rf "$BUILD_BASE/llvm-build"
+    mkdir "$BUILD_BASE/llvm-build"
+  fi
+
   cd $BUILD_BASE/llvm-build
-  cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS="clang;compiler-rt"  \
-        -DLLVM_BINUTILS_INCDIR=../binutils/include \
+  cmake -G Ninja \
+        -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DLLVM_TARGETS_TO_BUILD="X86" ../llvm-project/llvm/
-  make -j5 llvm-headers
-  make -j10
-  make
+        -DLLVM_TARGETS_TO_BUILD="X86" \
+        -DLLVM_ENABLE_RTTI=ON \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        ../llvm-project/llvm/
+  ninja clang lld compiler-rt
 else
-  echo "Cloning and building binutild-gdb and LLVM from scratch."
-  mkdir $BUILD_BASE
-
-  # Build  binutils
-  cd $BUILD_BASE
-  git clone --depth 1 https://github.com/bminor/binutils-gdb binutils
-
-  # Remove some directories we don't need
-  cd binutils
-  rm -rf ./gcc
-  rm -rf ./gdb
-  cd ../
-
-  # Build gold
-  mkdir build
-  cd ./build
-  ../binutils/configure --enable-gold --enable-plugins --disable-werror
-  make all-gold
+  echo "Cloning and building LLVM from scratch."
+  mkdir -p $BUILD_BASE
 
   # Now build LLVM
   cd ${BUILD_BASE}
   git clone https://github.com/llvm/llvm-project/
   cd llvm-project/
-  git checkout llvmorg-21.1.0-rc3
+  git checkout llvmorg-22.1.0
 
   echo "Applying diffs to insert Fuzz Introspector plugin in the LLVM pipeline"
   $BASE/frontends/llvm/patch-llvm.sh
@@ -71,11 +65,13 @@ else
   cd ${BUILD_BASE}
   mkdir llvm-build
   cd llvm-build
-  cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS="clang;compiler-rt"  \
-        -DLLVM_BINUTILS_INCDIR=../binutils/include \
+  cmake -G Ninja \
+        -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DLLVM_TARGETS_TO_BUILD="X86" ../llvm-project/llvm/
-  make llvm-headers
-  make -j5
-  make
+        -DLLVM_TARGETS_TO_BUILD="X86" \
+        -DLLVM_ENABLE_RTTI=ON \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        ../llvm-project/llvm/
+  ninja clang lld compiler-rt
 fi

--- a/doc/LocalBuild.md
+++ b/doc/LocalBuild.md
@@ -65,7 +65,7 @@ cd ../
 # Build LLVM and Clang
 git clone https://github.com/llvm/llvm-project/
 cd llvm-project/
-git checkout release/15.x
+git checkout llvmorg-22.1.0
 
 # Patch Clang to run fuzz introspector
 ../../frontends/llvm/patch-llvm.sh
@@ -98,7 +98,7 @@ cd tests/simple-example-0
 # Run compiler pass to generate *.data and *.data.yaml files
 mkdir work
 cd work
-FUZZ_INTROSPECTOR=1 ../../../build/llvm-build/bin/clang -fsanitize=fuzzer -fuse-ld=gold -flto -g ../fuzzer.c -o fuzzer
+FUZZ_INTROSPECTOR=1 ../../../build/llvm-build/bin/clang -fsanitize=fuzzer -fuse-ld=lld -flto -g ../fuzzer.c -o fuzzer
 
 # Run post-processing to analyse data files and generate HTML report
 python3 ../../../src/main.py correlate --binaries-dir=.
@@ -125,7 +125,7 @@ cd work
 ../build_cov.sh
 
 # Build fuzz-introspector normally
-FUZZ_INTROSPECTOR=1 ../../../build/llvm-build/bin/clang -fsanitize=fuzzer -fuse-ld=gold -flto -g ../fuzzer.c -o fuzzer
+FUZZ_INTROSPECTOR=1 ../../../build/llvm-build/bin/clang -fsanitize=fuzzer -fuse-ld=lld -flto -g ../fuzzer.c -o fuzzer
 
 # Run post-processing to analyse data files and generate HTML report
 python3 ../../../src/main.py correlate --binaries-dir=.

--- a/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
+++ b/frontends/llvm/lib/Transforms/FuzzIntrospector/FuzzIntrospector.cpp
@@ -15,10 +15,14 @@
 
 #include "llvm/Transforms/FuzzIntrospector/FuzzIntrospector.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DebugInfoMetadata.h"
+#if LLVM_VERSION_MAJOR >= 19
+#include "llvm/IR/DebugProgramInstruction.h"
+#endif
 #include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
@@ -464,11 +468,16 @@ void FuzzIntrospector::dumpDebugCompileUnits(std::ofstream &O,
                                              DebugInfoFinder &Finder) {
   for (DICompileUnit *CU : Finder.compile_units()) {
     O << "Compile unit: ";
-    auto Lang = dwarf::LanguageString(CU->getSourceLanguage());
+#if LLVM_VERSION_MAJOR >= 22
+    auto SourceLang = CU->getSourceLanguage().getName();
+#else
+    auto SourceLang = CU->getSourceLanguage();
+#endif
+    auto Lang = dwarf::LanguageString(SourceLang);
     if (!Lang.empty())
       O << Lang.str();
     else
-      O << "unknown-language(" << CU->getSourceLanguage() << ")";
+      O << "unknown-language(" << SourceLang << ")";
     printFile(O, CU->getFilename(), CU->getDirectory());
     O << '\n';
   }
@@ -935,13 +944,27 @@ bool FuzzIntrospector::runOnModule(Module &M) {
   }
 
   logPrintf(L1, "Running introspector on %s\n", M.getName());
+
   if (!getenv("FUZZ_INTROSPECTOR_FORCE_RUN")) {
     if (shouldRunIntrospector(M) == false) {
-      // Run the analysis on a non-fuzzer binary.
+#if LLVM_VERSION_MAJOR >= 19
+      if (getenv("FUZZ_INTROSPECTOR_AUTO_FUZZ")) {
+        // AUTO_FUZZ calls wrapFunction() via extractAllFunctionDetailsToYaml,
+        // so debug info must be normalized before entering that path.
+        M.convertToNewDbgValues();
+        runIntrospectorOnNonFuzzerBinary(M);
+        return true;
+      }
+#endif
+      // Not a fuzzer binary and AUTO_FUZZ not set — nothing to do.
       runIntrospectorOnNonFuzzerBinary(M);
       return false;
     }
   }
+
+#if LLVM_VERSION_MAJOR >= 19
+  M.convertToNewDbgValues();
+#endif
 
   // init randomness
   srand((unsigned)time(NULL) * getpid());
@@ -1677,14 +1700,82 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
   // Find the depth of the function.
   FuncWrap.ReturnType = resolveTypeName(F->getReturnType());
 
-  // Arguments
-  // errs() << "Function:\n";
-  // errs() << FuncWrap.FunctionName << "\n";
+#if LLVM_VERSION_MAJOR >= 19 && LLVM_VERSION_MAJOR <= 20
+  // LLVM 21+ removed IsNewDbgInfoFormat (field always true); assert only valid on 19-20.
+  assert(F->getParent()->IsNewDbgInfoFormat &&
+         "Module must be normalized to DbgRecord format");
+#endif
+
+#if LLVM_VERSION_MAJOR >= 19
+  // New path: use DbgVariableRecord API for LLVM 19+
+  SmallVector<bool, 8> NeedNameByIndex(F->arg_size(), false);
+  unsigned MissingArgCount = 0;
+  for (auto &A : F->args()) {
+    if (!A.hasName()) {
+      NeedNameByIndex[A.getArgNo()] = true;
+      ++MissingArgCount;
+    }
+  }
+
+  SmallVector<std::string, 8> ArgNameByIndex;
+
+  if (MissingArgCount > 0) {
+    ArgNameByIndex.resize(F->arg_size());
+
+    DISubprogram *FSP = F->getSubprogram();
+    if (FSP != nullptr) {
+      unsigned Remaining = MissingArgCount;
+
+      auto recordArg = [&](const DILocalVariable *DLV) -> bool {
+        if (!DLV || DLV->getName().empty())
+          return false;
+        if (!DLV->getScope() ||
+            DLV->getScope()->getSubprogram() != FSP)
+          return false;
+        unsigned ArgNo = DLV->getArg();
+        if (ArgNo == 0)
+          return false;
+        unsigned Idx = ArgNo - 1;
+        if (Idx >= ArgNameByIndex.size())
+          return false;
+        if (!NeedNameByIndex[Idx])
+          return false;
+        ArgNameByIndex[Idx] = DLV->getName().str();
+        NeedNameByIndex[Idx] = false;
+        return true;
+      };
+
+      for (auto &BB : *F) {
+        for (auto &I : BB) {
+          for (DbgVariableRecord &DVR :
+               filterDbgVars(I.getDbgRecordRange())) {
+            if (recordArg(DVR.getVariable()) && --Remaining == 0)
+              goto done_scan;
+          }
+        }
+      }
+    done_scan:;
+    }
+  }
+
+  // Build argument lists
   for (auto &A : F->args()) {
     FuncWrap.ArgTypes.push_back(resolveTypeName(A.getType()));
-    // FuncWrap.ArgNames.push_back(A.getName().str());
+    if (A.hasName()) {
+      FuncWrap.ArgNames.push_back(A.getName().str());
+    } else {
+      unsigned ArgNo = A.getArgNo();
+      if (ArgNo < ArgNameByIndex.size() && !ArgNameByIndex[ArgNo].empty())
+        FuncWrap.ArgNames.push_back(ArgNameByIndex[ArgNo]);
+      else
+        FuncWrap.ArgNames.push_back("");
+    }
+  }
+#else
+  // Legacy path: original logic for LLVM < 19
+  for (auto &A : F->args()) {
+    FuncWrap.ArgTypes.push_back(resolveTypeName(A.getType()));
     if (A.getName().str().empty()) {
-      const DILocalVariable *Var = NULL;
       bool FoundArg = false;
       for (auto &BB : *F) {
         for (auto &I : BB) {
@@ -1697,10 +1788,12 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
                 // errs() << "--" << DLV->getName().str() << "\n";
                 FuncWrap.ArgNames.push_back(DLV->getName().str());
                 FoundArg = true;
+                break;
               }
             }
           }
         }
+        if (FoundArg) break;
       }
       if (FoundArg == false) {
         FuncWrap.ArgNames.push_back("");
@@ -1710,6 +1803,7 @@ FuzzerFunctionWrapper FuzzIntrospector::wrapFunction(Function *F) {
       FuncWrap.ArgNames.push_back(A.getName().str());
     }
   }
+#endif
 
   // Log the amount of basic blocks, instruction count and cyclomatic
   // complexity of the function.
@@ -2254,36 +2348,28 @@ FuzzIntrospector::getInsnDebugInfo(Instruction *I) {
 
 std::pair<std::string, std::string>
 FuzzIntrospector::getBBDebugInfo(BasicBlock *BB, DILocation *PrevLoc) {
-  std::pair<std::string, std::string> Result = make_pair("", "");
+#if LLVM_VERSION_MAJOR >= 20
+  // LLVM 20+ returns end() for empty/all-PHI blocks; the loop below handles it.
+  BasicBlock::iterator It =
+      BB->getFirstNonPHIOrDbgOrLifetime(/*SkipPseudoOp=*/true);
+#else
+  // LLVM < 20 returns nullptr for empty/all-PHI blocks.
+  Instruction *FirstReal =
+      BB->getFirstNonPHIOrDbgOrLifetime(/*SkipPseudoOp=*/true);
+  if (FirstReal == nullptr)
+    return std::make_pair(std::string(), std::string());
+  BasicBlock::iterator It = FirstReal->getIterator();
+#endif
 
-  BasicBlock *CurrBB = BB;
-  BranchInst *CurrBI;
-  Instruction *CurrTI, *CurrI;
-  DILocation *CurrLoc;
-  /* TODO(David): Fix this for LLVM 21. Although I'm not 100% sure we still use this.*/
-/*
-  // Traverse all dummy BBs associated with the previous Loc.
-  do {
-    CurrTI = CurrBB->getTerminator();
-    CurrI = CurrBB->getFirstNonPHIOrDbgOrLifetime(true);
-    if (CurrI == nullptr)
-      break;
-    CurrLoc = CurrI->getDebugLoc();
-    CurrBI = dyn_cast<BranchInst>(CurrTI);
-    if (CurrBI && !CurrBI->isConditional()) {
-      CurrBB = CurrBI->getSuccessor(0);
-    } else
-      break;
-  } while (CurrLoc == PrevLoc);
-
-  // To skip the return BB in optimized CFG.
-  if (dyn_cast<ReturnInst>(CurrTI)) {
-    CurrI = BB->getFirstNonPHIOrDbgOrLifetime(true);
+  // Skip instructions whose location matches the branch/switch site (PrevLoc)
+  // to avoid attributing a branch side to the same source line as the branch
+  // itself in optimised CFGs.
+  for (; It != BB->end(); ++It) {
+    DILocation *Loc = It->getDebugLoc();
+    if (Loc && Loc != PrevLoc)
+      return getInsnDebugInfo(&*It);
   }
-  if (CurrI)
-    Result = getInsnDebugInfo(CurrI);
-*/
-  return Result;
+  return std::make_pair(std::string(), std::string());
 }
 
 void FuzzIntrospector::writeOutMap(std::vector<BranchProfileEntry> OutMap,

--- a/frontends/llvm/patch-llvm.sh
+++ b/frontends/llvm/patch-llvm.sh
@@ -29,16 +29,30 @@ if [ -f ./llvm/lib/Transforms/IPO/PassManagerBuilder.cpp ]; then
     sed -i 's/MPM.addPass(CrossDSOCFIPass());/MPM.addPass(CrossDSOCFIPass());\n  MPM.addPass(FuzzIntrospectorPass());/g' ./llvm/lib/Passes/PassBuilderPipelines.cpp
     sed -i 's/MODULE_PASS("annotation2metadata", Annotation2MetadataPass())/MODULE_PASS("annotation2metadata", Annotation2MetadataPass())\nMODULE_PASS("fuzz-introspector", FuzzIntrospectorPass())/g' ./llvm/lib/Passes/PassRegistry.def
 else
-    echo "Applying llvm 18 patches"
+    echo "Applying llvm 18+ patches (LLVM 18-22)"
     echo "add_subdirectory(FuzzIntrospector)" >> ./llvm/lib/Transforms/CMakeLists.txt
     sed -i 's/Instrumentation/Instrumentation\n  FuzzIntrospector/g' ./llvm/lib/Transforms/IPO/CMakeLists.txt
 
-    #  This is for LLVM 21. Monitor if this affects more.
+    # LLVM 21+: InitializePasses.h uses LLVM_ABI visibility macros.
+    # On LLVM 21+, initializeXRayInstrumentationPass was renamed to
+    # initializeXRayInstrumentationLegacyPass, so the sed below is a no-op.
     sed -i 's/LLVM_ABI void initializeMIRNamerPass/LLVM_ABI void initializeFuzzIntrospectorPass(PassRegistry \&);\nLLVM_ABI void initializeMIRNamerPass/g' llvm/include/llvm/InitializePasses.h
 
-    sed -i 's/void initializeXRayInstrumentationPass(PassRegistry\&);/void initializeXRayInstrumentationPass(PassRegistry\&);\nvoid initializeFuzzIntrospectorPass(PassRegistry\&);/g' ./llvm/include/llvm/InitializePasses.h
+    # LLVM 18-20: no LLVM_ABI macros; anchor on initializeXRayInstrumentationPass
+    # which was present through LLVM 20 but renamed in LLVM 21+.
+    # [ ]* handles spacing: LLVM 18-19 use "PassRegistry&", LLVM 20 uses "PassRegistry &".
+    sed -i 's/void initializeXRayInstrumentationPass(PassRegistry[ ]*\&);/void initializeXRayInstrumentationPass(PassRegistry \&);\nvoid initializeFuzzIntrospectorPass(PassRegistry \&);/g' ./llvm/include/llvm/InitializePasses.h
+
+    # Verify that exactly one of the two sed commands above injected the declaration.
+    _count=$(grep -c 'initializeFuzzIntrospectorPass' llvm/include/llvm/InitializePasses.h || true)
+    [ "$_count" -eq 1 ] || \
+        { echo "ERROR: expected exactly one initializeFuzzIntrospectorPass declaration, got $_count"; exit 1; }
+
     sed -i 's/#include "llvm\/Transforms\/Instrumentation\/ThreadSanitizer.h"/#include "llvm\/Transforms\/Instrumentation\/ThreadSanitizer.h"\n#include "llvm\/Transforms\/FuzzIntrospector\/FuzzIntrospector.h"/g' ./llvm/lib/Passes/PassBuilder.cpp
     sed -i 's/#include "llvm\/Transforms\/Instrumentation\/PGOInstrumentation.h"/#include "llvm\/Transforms\/Instrumentation\/PGOInstrumentation.h"\n#include "llvm\/Transforms\/FuzzIntrospector\/FuzzIntrospector.h"/g' ./llvm/lib/Passes/PassBuilderPipelines.cpp
     sed -i 's/MPM.addPass(CrossDSOCFIPass());/MPM.addPass(CrossDSOCFIPass());\n  MPM.addPass(FuzzIntrospectorPass());/g' ./llvm/lib/Passes/PassBuilderPipelines.cpp
+    grep -q 'FuzzIntrospectorPass' ./llvm/lib/Passes/PassBuilderPipelines.cpp || \
+        { echo "ERROR: Failed to inject FuzzIntrospectorPass into PassBuilderPipelines.cpp (CrossDSOCFIPass anchor not found)"; exit 1; }
+    echo "Verified: FuzzIntrospectorPass present in PassBuilderPipelines.cpp"
     sed -i 's/MODULE_PASS("annotation2metadata", Annotation2MetadataPass())/MODULE_PASS("annotation2metadata", Annotation2MetadataPass())\nMODULE_PASS("fuzz-introspector", FuzzIntrospectorPass())/g' ./llvm/lib/Passes/PassRegistry.def
 fi


### PR DESCRIPTION
Key changes:

1. Debug info migration (LLVM 19+ RemoveDIs):
   - Replaced DbgDeclareInst/DbgVariableIntrinsic with DbgVariableRecord
   - Added M.convertToNewDbgValues() to normalize debug info format
   - Recover argument names from debug info using new DbgVariableRecord API

2. getSourceLanguage() API change (LLVM 22):
   - Returns DISourceLanguageName instead of raw enum value
   - Extract numeric value via getName() before passing to dwarf::LanguageString()

3. getFirstNonPHIOrDbgOrLifetime() return type change (LLVM 20):
   - Now returns BasicBlock::iterator directly instead of Instruction*
   - Simplified getBBDebugInfo() implementation for LLVM 22

4. Pass registration updates (patch-llvm.sh):
   - Handle LLVM_ABI visibility macros in InitializePasses.h (LLVM 21+)
   - Account for initializeXRayInstrumentationPass rename (LLVM 21+)

5. Performance optimization:
   - Fast path skip DI scan when all arguments already have IR names
   - Early termination once all missing argument names are resolved

Updated build scripts and documentation to target LLVM 22.1.0.